### PR TITLE
Central unit/feature/sh 164 internal api

### DIFF
--- a/central_unit/configs/smart_home.yaml
+++ b/central_unit/configs/smart_home.yaml
@@ -1,7 +1,11 @@
 preset_values:
-  ipc_server_thread_count:
+  thread_count_values:
+    quarter_cpu_cores: &quarter_cpu_cores -3
+    third_cpu_cores: &third_cpu_cores -2
     half_cpu_cores: &half_cpu_cores -1
     all_cpu_cores: &all_cpu_cores 0
+    single_thread: &single_thread 1
+    two_threads: &two_threads 2
   log_levels:
     none: &none 0
     critical: &critical 1
@@ -10,9 +14,15 @@ preset_values:
     info: &info 4
     debug: &debug 5
 
+# Rule for thread count values:
+#   value < 0: ceil(all CPU cores / (|value| + 1))
+#   value == 0: all CPU cores
+#   value >= 1: exact thread count
 
 core:
   mode: "headless"  #TODO add kiosk gui
+  main_threads: *two_threads # Recommended setting value >= 2
+  worker_threads: *single_thread  # Recommended setting value >= 1
   logging:
     log_level: *warning
     enable_console_log_output: true
@@ -22,7 +32,7 @@ core:
       archive_old: true
       path: "/var/log/smarthome/core.log"
   ipc:
-    threads: *half_cpu_cores # Exact thread count if value > 0, possible preset values: *all_cpu_cores, *half_cpu_cores
+    threads: *two_threads # Recommended setting value >= 2
     tcp:
       enabled: true
       address: "127.0.0.1"

--- a/central_unit/docs/namespaces.h
+++ b/central_unit/docs/namespaces.h
@@ -30,6 +30,35 @@ namespace SmartHome::Service {
 }
 
 /**
+ * @namespace SmartHome::JsonRpcStrings
+ * @brief String constants for JSON-RPC protocol implementation.
+ *
+ * @details Contains compile-time string constants organized by purpose:
+ * - Protocol version and common values
+ * - JSON-RPC standard field names
+ * - Custom SmartHome-specific parameter keys
+ *
+ * @note All constants are defined as constexpr string_view for zero-overhead access.
+ */
+namespace SmartHome::JsonRpcStrings {
+}
+
+/**
+ * @namespace SmartHome::API
+ * @brief API layer for internal and external communication.
+ *
+ * @details Implements JSON-RPC 2.0 based API protocol for communication between
+ * SmartHome components and external interfaces:
+ * - JSON-RPC request/response structures
+ * - Internal API for component-to-component communication
+ * - Command routing and execution framework
+ * - Error handling with standard JSON-RPC error codes
+ * - Support for both structured (JSON) and raw command formats
+ */
+namespace SmartHome::API {
+}
+
+/**
  * @namespace SmartHome::IPC
  * @brief Inter-Process Communication layer.
  *

--- a/central_unit/src/common/CMakeLists.txt
+++ b/central_unit/src/common/CMakeLists.txt
@@ -23,6 +23,17 @@ target_link_libraries(smarthome_logger PRIVATE
         Boost::system
 )
 
+# SMARTHOME API
+add_library(smarthome_api STATIC
+        api/api.cpp
+)
+
+add_library(smarthome::api ALIAS smarthome_api)
+
+target_include_directories(smarthome_api PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api>
+)
+
 # SMARTHOME IPC
 add_library(smarthome_ipc STATIC
         ipc/socket_connection.cpp
@@ -40,6 +51,7 @@ target_link_libraries(smarthome_ipc PRIVATE
         Boost::system
         Boost::regex
         smarthome::logger
+        smarthome::api
 )
 
 # SMARTHOME UTILITY

--- a/central_unit/src/common/api/api.cpp
+++ b/central_unit/src/common/api/api.cpp
@@ -1,0 +1,370 @@
+#include "api.h"
+
+#include <iostream>
+
+#include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/classification.hpp>
+
+namespace SmartHome::API {
+    ApiId::ApiId(const apiId_t value): mState(State::HAS_VALUE), mValue(value) {
+    }
+
+    ApiId::ApiId(std::nullptr_t): mState(State::NULL_VALUE) {
+    }
+
+    bool ApiId::isUndefined() const { return mState == State::UNDEFINED; }
+
+    bool ApiId::isNull() const { return mState == State::NULL_VALUE; }
+
+    bool ApiId::hasValue() const { return mState == State::HAS_VALUE; }
+
+    apiId_t ApiId::value() const {
+        if (hasValue()) {
+            return mValue;
+        }
+        throw std::runtime_error("No value specified");
+    };
+
+    nlohmann::json ApiId::toJson() const {
+        if (mState == State::UNDEFINED)
+            throw std::runtime_error(
+                "Cannot cast ApiId to nlohmann::json - ID undefined");
+
+        nlohmann::json result;
+
+        if (hasValue()) result[JsonRpcStrings::Keys::ID] = mValue;
+        else result[JsonRpcStrings::Keys::ID] = JsonRpcStrings::Constants::NULL_VALUE;
+
+        return result;
+    }
+
+    ApiId ApiId::fromJson(const nlohmann::json &json) {
+        const auto iter = json.find(JsonRpcStrings::Keys::ID);
+        if (iter == json.end()) {
+            mState = State::UNDEFINED;
+        } else if (iter.value().is_number()) {
+            mValue = json[JsonRpcStrings::Keys::ID];
+            mState = State::HAS_VALUE;
+        } else if (iter.value().is_string() && iter.value() == JsonRpcStrings::Constants::NULL_VALUE) {
+            mState = State::NULL_VALUE;
+        } else {
+            throw std::runtime_error("Cannot cast json to ApiId - Invalid ID value");
+        }
+        return *this;
+    }
+
+    ApiId &ApiId::operator=(const apiId_t value) {
+        mState = State::HAS_VALUE;
+        mValue = value;
+        return *this;
+    }
+
+    ApiId &ApiId::operator=(std::nullptr_t) {
+        mState = State::NULL_VALUE;
+        mValue = {};
+        return *this;
+    }
+
+    ApiError::ApiError(const nlohmann::json &value) {
+        setValues(value);
+    }
+
+    ApiError::ApiError(const std::string_view value) {
+        setValues(nlohmann::json::parse(value));
+    }
+
+    ApiError::ApiError(const ErrorCodes newCode, const std::string_view newMessage, const std::string_view newData) {
+        code = newCode;
+        message = newMessage;
+        data = newData;
+    }
+
+    nlohmann::json ApiError::to_json() {
+        nlohmann::json json;
+
+        json[JsonRpcStrings::ErrorKeys::CODE] = code;
+        json[JsonRpcStrings::ErrorKeys::MESSAGE] = message;
+        if (!data.empty()) json[JsonRpcStrings::ErrorKeys::DATA] = data;
+
+        return json;
+    }
+
+    std::string ApiError::to_string() {
+        return nlohmann::to_string(to_json());
+    }
+
+    void ApiError::setValues(nlohmann::json json) {
+        char errorMessage[ERROR_MESSAGE_BUFFER_SIZE];
+        if (!json.contains(JsonRpcStrings::ErrorKeys::CODE)) {
+            sprintf(errorMessage, "Invalid JSON-RPC error: missing '%s' field",
+                    JsonRpcStrings::ErrorKeys::CODE.data());
+            throw std::invalid_argument(errorMessage);
+        }
+        if (!json[JsonRpcStrings::ErrorKeys::CODE].is_number_integer()) {
+            sprintf(errorMessage, "Invalid JSON-RPC error: '%s' must be integer",
+                    JsonRpcStrings::ErrorKeys::CODE.data());
+            throw std::invalid_argument(errorMessage);
+        }
+
+        if (!json.contains(JsonRpcStrings::ErrorKeys::MESSAGE)) {
+            sprintf(errorMessage, "Invalid JSON-RPC error: missing '%s' field",
+                    JsonRpcStrings::ErrorKeys::MESSAGE.data());
+            throw std::invalid_argument(errorMessage);
+        }
+        if (json[JsonRpcStrings::ErrorKeys::MESSAGE].get<std::string>().empty()) {
+            sprintf(errorMessage, "Invalid JSON-RPC error: '%s' cannot be empty",
+                    JsonRpcStrings::ErrorKeys::MESSAGE.data());
+            throw std::invalid_argument(errorMessage);
+        }
+
+        code = static_cast<ErrorCodes>(json[JsonRpcStrings::ErrorKeys::CODE].get<int>());
+        message = json[JsonRpcStrings::ErrorKeys::MESSAGE].get<std::string>();
+        if (json.contains(JsonRpcStrings::ErrorKeys::DATA) && json[JsonRpcStrings::ErrorKeys::DATA].is_string())
+            data = json[JsonRpcStrings::ErrorKeys::DATA].get<std::string>();
+    }
+
+    ApiRequest::ApiRequest(const nlohmann::json &value) {
+        setValues(value);
+    }
+
+    ApiRequest::ApiRequest(std::string_view value) {
+        if (nlohmann::json::accept(value)) {
+            setValues(nlohmann::json::parse(value));
+        } else {
+            setValues(value);
+        }
+    }
+
+    ApiRequest ApiRequest::operator()(const nlohmann::json &value) {
+        setValues(value);
+        return *this;
+    }
+
+    ApiRequest ApiRequest::operator()(std::string_view value) {
+        if (nlohmann::json::accept(value)) {
+            setValues(nlohmann::json::parse(value));
+        } else {
+            setValues(value);
+        }
+        return *this;
+    }
+
+    nlohmann::json ApiRequest::to_json() {
+        nlohmann::json json;
+
+        json[JsonRpcStrings::Keys::JSONRPC] = jsonrpc;
+        json[JsonRpcStrings::RequestKeys::METHOD] = method;
+        if (params.has_value()) json[JsonRpcStrings::RequestKeys::PARAMS] = *params;
+        if (!id.isUndefined()) json.update(id.toJson());
+
+        return json;
+    }
+
+    std::string ApiRequest::to_string() {
+        return nlohmann::to_string(to_json());
+    }
+
+    void ApiRequest::setValues(const nlohmann::json &json) {
+        char errorMessage[ERROR_MESSAGE_BUFFER_SIZE];
+        if (!json.contains(JsonRpcStrings::Keys::JSONRPC)) {
+            sprintf(errorMessage, "Invalid JSON-RPC request: missing '%s' field",
+                    JsonRpcStrings::Keys::JSONRPC.data());
+            throw std::invalid_argument(errorMessage);
+        }
+        if (json[JsonRpcStrings::Keys::JSONRPC].get<std::string>() != JsonRpcStrings::Constants::VERSION.data()) {
+            sprintf(errorMessage, "Invalid JSON-RPC request: %s must be equal '%s'",
+                    JsonRpcStrings::Keys::JSONRPC.data(),
+                    JsonRpcStrings::Constants::VERSION.data());
+            throw std::invalid_argument(errorMessage);
+        }
+
+        if (!json.contains(JsonRpcStrings::RequestKeys::METHOD)) {
+            sprintf(errorMessage, "Invalid JSON-RPC request: missing '%s' field",
+                    JsonRpcStrings::RequestKeys::METHOD.data());
+            throw std::invalid_argument(errorMessage);
+        }
+        if (json[JsonRpcStrings::RequestKeys::METHOD].get<std::string>().empty()) {
+            sprintf(errorMessage, "Invalid JSON-RPC request: '%s' cannot be empty",
+                    JsonRpcStrings::RequestKeys::METHOD.data());
+            throw std::invalid_argument(errorMessage);
+        }
+
+        jsonrpc = json[JsonRpcStrings::Keys::JSONRPC];
+        method = json[JsonRpcStrings::RequestKeys::METHOD];
+        if (json.contains(JsonRpcStrings::RequestKeys::PARAMS)) params = json[JsonRpcStrings::RequestKeys::PARAMS];
+        if (json.contains(JsonRpcStrings::Keys::ID)) id = json[JsonRpcStrings::Keys::ID];
+    }
+
+    void ApiRequest::setValues(const std::string_view string) {
+        std::vector<std::string> splitRequest = {};
+        boost::split(splitRequest, string, boost::is_any_of(" "));
+
+        if (splitRequest.size() < 2) {
+            throw std::invalid_argument("Invalid raw string request: request must have at least target and method");
+        }
+
+        jsonrpc = JsonRpcStrings::Constants::VERSION.data();
+        params.emplace(nlohmann::json());
+        auto &paramsJsonObject = params.value();
+        paramsJsonObject[JsonRpcStrings::ParamsKeys::TARGET] = splitRequest[0];
+        method = splitRequest[1];
+        id = static_cast<apiId_t>(0);
+
+        if (splitRequest.size() > 2) {
+            paramsJsonObject[JsonRpcStrings::ParamsKeys::METHOD_PARAMS] = nlohmann::json::array();
+            for (size_t i = 2; i < splitRequest.size(); i++) {
+                emplaceParameter(paramsJsonObject[JsonRpcStrings::ParamsKeys::METHOD_PARAMS], splitRequest[i]);
+            }
+        }
+    }
+
+    ApiResponse ApiResponse::operator()(const nlohmann::json &value) {
+        setValues(value);
+        return *this;
+    }
+
+    ApiResponse ApiResponse::operator()(std::string_view value) {
+        const nlohmann::json json = nlohmann::json::parse(value);
+        setValues(json);
+        return *this;
+    }
+
+    nlohmann::json ApiResponse::to_json() {
+        nlohmann::json json;
+
+        json[JsonRpcStrings::Keys::JSONRPC] = jsonrpc;
+        if (result.has_value()) {
+            if (nlohmann::json::accept(result.value()))
+                json[JsonRpcStrings::ResponseKeys::RESULT] = nlohmann::json::parse(result.value());
+            else json[JsonRpcStrings::ResponseKeys::RESULT] = result.value();
+        } else if (error.has_value()) {
+            json[JsonRpcStrings::ResponseKeys::ERROR] = error.value().to_json();
+        } else {
+            throw std::invalid_argument("Invalid JSON-RPC response");
+        }
+
+        if (!id.isUndefined()) json.update(id.toJson());
+
+        return json;
+    }
+
+    std::string ApiResponse::to_string() {
+        return nlohmann::to_string(to_json());
+    }
+
+    void ApiResponse::setValues(const nlohmann::json &json) {
+        if (!(json.contains(JsonRpcStrings::Keys::JSONRPC) &&
+              json[JsonRpcStrings::Keys::JSONRPC].get<std::string>() == JsonRpcStrings::Constants::VERSION.data())) {
+            char errorMessage[256];
+            sprintf(errorMessage, "Invalid JSON-RPC request: %s must be equal '%s'",
+                    JsonRpcStrings::Keys::JSONRPC.data(),
+                    JsonRpcStrings::Constants::VERSION.data());
+            throw std::invalid_argument(errorMessage);
+        }
+        if (!(json.contains(JsonRpcStrings::Keys::ID) && !json[JsonRpcStrings::Keys::ID].get<std::string>().empty())) {
+            throw std::invalid_argument("Invalid JSON-RPC request: response must contain id");
+        }
+
+        if (json.contains(JsonRpcStrings::ResponseKeys::RESULT) && !json.contains(JsonRpcStrings::ResponseKeys::ERROR))
+            result = json[JsonRpcStrings::ResponseKeys::RESULT];
+        else if (json.contains(JsonRpcStrings::ResponseKeys::ERROR) && !json.contains(
+                     JsonRpcStrings::ResponseKeys::RESULT))
+            error.emplace(
+                json[JsonRpcStrings::ResponseKeys::ERROR]);
+        else throw std::invalid_argument("Invalid JSON-RPC request: response must contain either result or error");
+
+        jsonrpc = json[JsonRpcStrings::Keys::JSONRPC];
+        id = json[JsonRpcStrings::Keys::ID];
+    }
+
+    std::string_view errorCodeToString(const ErrorCodes errorCode) {
+        switch (errorCode) {
+            case ErrorCodes::NO_ERROR:
+                return "No error";
+            case ErrorCodes::PARSE_ERROR:
+                return "Parse error";
+            case ErrorCodes::INVALID_REQUEST:
+                return "Invalid request";
+            case ErrorCodes::METHOD_NOT_FOUND:
+                return "Method not found";
+            case ErrorCodes::INVALID_PARAMS:
+                return "Invalid params";
+            case ErrorCodes::INTERNAL_ERROR:
+                return "Internal error";
+            default:
+                return "Unknown error";
+        }
+    }
+
+    nlohmann::json parseValue(std::string_view value) {
+        // Check int
+        if (std::ranges::all_of(value, isdigit)) {
+            try {
+                return std::stoi(value.data());
+            } catch (...) {
+                // Value is not a valid int, continuing parsing attempts
+            }
+        }
+
+        // Check float
+        if (value.find('.') != std::string_view::npos) {
+            try {
+                return std::stod(value.data());
+            } catch (...) {
+                // Value is not a valid float, continuing parsing attempts
+            }
+        }
+
+        // Check booleans
+        if (value == "true") return true;
+        if (value == "false") return false;
+
+        // Default to string
+        return value;
+    }
+
+    nlohmann::json parseVector(const std::vector<std::string> &values) {
+        nlohmann::json array = nlohmann::json::array();
+
+        for (const auto &value: values) {
+            array.push_back(parseValue(value));
+        }
+
+        return array;
+    }
+
+    void emplaceParameter(nlohmann::json &params, std::string_view parameter) {
+        if (parameter.empty()) return;
+        // Check if parameter is key=value pair
+        const auto equalsPos = parameter.find('=');
+
+        if (equalsPos == std::string_view::npos) {
+            params.emplace_back(parseValue(parameter));
+            return;
+        }
+
+        std::string_view key = parameter.substr(0, equalsPos);
+        std::string_view value = parameter.substr(equalsPos + 1);
+
+        nlohmann::json param;
+
+        bool isJsonParseSuccessful = false;
+        //Check for an JSON object
+        if (nlohmann::json::accept(value)) {
+            try {
+                param[key] = nlohmann::json::parse(value);
+                isJsonParseSuccessful = true;
+            } catch (...) {
+            }
+        }
+        // Check for a value list
+        if (!isJsonParseSuccessful && value.find(',') != std::string_view::npos) {
+            std::vector<std::string> values;
+            boost::split(values, value, boost::is_any_of(","));
+            param[key] = parseVector(values);
+        } else {
+            param[key] = parseValue(value);
+        }
+        params.emplace_back(param);
+    }
+}

--- a/central_unit/src/common/api/api.h
+++ b/central_unit/src/common/api/api.h
@@ -1,0 +1,379 @@
+#pragma once
+
+#include "../types.h"
+
+#include <optional>
+#include <string_view>
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+// TODO !pr add docs to namespace
+namespace SmartHome::JsonRpcStrings {
+    namespace Constants {
+        inline constexpr std::string_view VERSION = "2.0";
+        inline constexpr std::string_view NULL_VALUE = "null";
+    }
+
+    namespace Keys {
+        inline constexpr std::string_view JSONRPC = "jsonrpc";
+        inline constexpr std::string_view ID = "id";
+    }
+
+    namespace RequestKeys {
+        inline constexpr std::string_view METHOD = "method";
+        inline constexpr std::string_view PARAMS = "params";
+    }
+
+    namespace ParamsKeys {
+        inline constexpr std::string_view TARGET = "target";
+        inline constexpr std::string_view METHOD_PARAMS = "method_params";
+    }
+
+    namespace ResponseKeys {
+        inline constexpr std::string_view RESULT = "result";
+        inline constexpr std::string_view ERROR = "error";
+    }
+
+    namespace ErrorKeys {
+        inline constexpr std::string_view CODE = "code";
+        inline constexpr std::string_view MESSAGE = "message";
+        inline constexpr std::string_view DATA = "data";
+    }
+}
+
+
+namespace SmartHome::API {
+    /**
+     * @brief Three-state API identifier container.
+     *
+     * @details Manages JSON-RPC id field with three possible states:
+     *          undefined (no id field), null value, or numeric value.
+     */
+    struct ApiId {
+    private:
+        enum class State {
+            UNDEFINED, ///< ID field not present
+            NULL_VALUE, ///< ID field is null
+            HAS_VALUE ///< ID field has numeric value
+        };
+
+        State mState = State::UNDEFINED;
+        apiId_t mValue = {};
+
+    public:
+        ApiId() = default;
+
+        /**
+         * @brief Sets numeric value for ApiId.
+         *
+         * @param value Numeric value to set ID to.
+         */
+        explicit ApiId(apiId_t value);
+
+        /**
+         * @brief Sets numeric value to null.
+         */
+        explicit ApiId(std::nullptr_t);
+
+        /**
+         * @brief Check if ID is undefined (not present).
+         *
+         * @return true if ID is undefined, false otherwise.
+         */
+        bool isUndefined() const;
+
+        /**
+         * @brief Check if ID is null
+         *
+         * @return true if ID has null value, false otherwise.
+         */
+        bool isNull() const;
+
+        /**
+         * @brief Check if ID has numeric value.
+         *
+         * @return true if ID has numeric value, false otherwise.
+         */
+        bool hasValue() const;
+
+        /**
+         * @brief Get numeric value of ID.
+         *
+         * @return Stored ID value.
+         * @throws std::runtime_error If ID has no value.
+         */
+        apiId_t value() const;
+
+        /**
+         * @brief Convert ID to JSON object.
+         *
+         * @return JSON object with id field.
+         * @throws std::runtime_error If ID is undefined.
+         */
+        nlohmann::json toJson() const;
+
+        /**
+         * @brief Parse ID from JSON object.
+         *
+         * @param json JSON object to parse.
+         * @return Reference to this object.
+         * @throws std::runtime_error If JSON contains invalid ID value.
+         */
+        ApiId fromJson(const nlohmann::json &json);
+
+        /// Assign numeric value to ID
+        ApiId &operator=(apiId_t value);
+
+        /// Assign null value to ID
+        ApiId &operator=(std::nullptr_t);
+    };
+
+    /**
+     * @brief JSON-RPC error codes for API.
+     */
+    enum class ErrorCodes: int {
+        NO_ERROR = 0,
+        PARSE_ERROR = -32700,
+        INVALID_REQUEST = -32600,
+        METHOD_NOT_FOUND = -32601,
+        INVALID_PARAMS = -32602,
+        INTERNAL_ERROR = -32603,
+    };
+
+    /**
+     * @brief JSON-RPC error struct for API.
+     */
+    struct ApiError {
+        ErrorCodes code = ErrorCodes::NO_ERROR; ///< JSON-RPC error code
+        std::string message; ///< Message explaining error code
+        std::string data; ///< Optional additional error data
+
+        ApiError() = default;
+
+        /**
+         * @brief Construct error from JSON object.
+         *
+         * @param value JSON object containing error fields.
+         *
+         * @throws nlohmann::json::parse_error Throws parse error on failed parse.
+         * @throws std::invalid_argument Throws invalid argument when passed JSON object is not in JSON-RPC 2.0 error format.
+         */
+        explicit ApiError(const nlohmann::json &value);
+
+        /**
+         * @brief Construct error from JSON string.
+         *
+         * @param value JSON string containing error object.
+         *
+         * @throws nlohmann::json::parse_error Throws parse error on failed parse.
+         * @throws std::invalid_argument Throws invalid argument when passed JSON string is not in JSON-RPC 2.0 error format.
+         */
+        explicit ApiError(std::string_view value);
+
+        /**
+         * @brief Construct error with specific values.
+         *
+         * @param newCode Error code.
+         * @param newMessage Error message.
+         * @param newData Additional error data.
+         */
+        ApiError(ErrorCodes newCode, std::string_view newMessage, std::string_view newData);
+
+        /**
+         * @brief Convert error to JSON object.
+         *
+         * @return JSON object representation of error.
+         */
+        nlohmann::json to_json();
+
+        /**
+         * @brief Convert error to JSON string.
+         *
+         * @return JSON string representation of error.
+         */
+        std::string to_string();
+
+    private:
+        /**
+         * @brief Setter for struct variables.
+         *
+         * @param json Json object to parse.
+         * @throws std::invalid_argument Throws invalid argument when passed JSON object is not in JSON-RPC 2.0 error format
+         */
+        void setValues(nlohmann::json json);
+    };
+
+    /**
+     * @brief JSON-RPC request struct for API.
+     */
+    struct ApiRequest {
+        std::string jsonrpc = JsonRpcStrings::Constants::VERSION.data(); ///< JSON-RPC version
+        std::string method; ///< Method name to call
+        std::optional<nlohmann::json> params; ///< Optional method parameters
+        ApiId id; ///< Request identifier
+
+
+        ApiRequest() = default;
+
+        /**
+         * @brief Construct request from JSON object.
+         *
+         * @param value JSON object containing request fields.
+         *
+         * @throws nlohmann::json::parse_error Throws parse error on failed parse.
+         * @throws std::invalid_argument Throws invalid argument when passed JSON object is not in JSON-RPC 2.0 format.
+         */
+        explicit ApiRequest(const nlohmann::json &value);
+
+        /**
+         * @brief Construct request from string (JSON or raw format).
+         *
+         * @details Accepts either JSON-RPC formatted string or space-separated raw format:
+         *          "target method [params...]"
+         *
+         * @param value JSON string or raw command string.
+         *
+         * @throws nlohmann::json::parse_error Throws parse error on failed parse.
+         * @throws std::invalid_argument Throws invalid argument when passed JSON string is not in JSON-RPC 2.0 format.
+         *          or raw string formated request does not contain target and method.
+         */
+        explicit ApiRequest(std::string_view value);
+
+        nlohmann::json to_json();
+
+        std::string to_string();
+
+        /// Update request from JSON object.
+        ApiRequest operator()(const nlohmann::json &value);
+
+        /// Update request from string.
+        ApiRequest operator()(std::string_view value);
+
+    private:
+        /**
+         * @brief Setter for struct variables.
+         *
+         * @param json Json object to parse.
+         * @throws std::invalid_argument Throws invalid argument when passed JSON object is not in JSON-RPC 2.0 format.
+         */
+        void setValues(const nlohmann::json &json);
+
+        /**
+         * @brief Setter for struct variables.
+         *
+         * @param string Raw string formatted request.
+         * @throws std::invalid_argument Throws invalid argument when passed string does not contain target and method.
+         */
+        void setValues(std::string_view string);
+    };
+
+
+    /**
+     * @brief JSON-RPC response struct for API.
+     */
+    struct ApiResponse {
+        std::string jsonrpc = JsonRpcStrings::Constants::VERSION.data(); ///< JSON-RPC version
+        std::optional<std::string> result; ///< Result string or JSON object stored as string
+        std::optional<ApiError> error; ///< Error object if request failed
+        ApiId id; ///< Response identifier matching request
+
+        /**
+         * @brief Convert response to JSON object.
+         *
+         * @return JSON object representation of response.
+         * @throws std::invalid_argument If neither result nor error is set.
+         */
+        nlohmann::json to_json();
+
+        /**
+         * @brief Convert response to JSON string.
+         *
+         * @return JSON string representation of response.
+         * @throws std::invalid_argument If neither result nor error is set.
+         */
+        std::string to_string();
+
+        /// Update response from JSON object.
+        ApiResponse operator()(const nlohmann::json &value);
+
+        /// Update response from JSON string.
+        ApiResponse operator()(std::string_view value);
+
+
+    private:
+        /**
+         * @brief Setter for struct variables.
+         *
+         * @param json Json object to parse.
+         * @throws std::invalid_argument Throws invalid argument when passed JSON object is not in JSON-RPC 2.0 format.
+         */
+        void setValues(const nlohmann::json &json);
+    };
+
+
+    /**
+     * @brief Abstract base class for API implementations.
+     */
+    class Api {
+    public:
+        virtual ~Api() = default;
+
+        /**
+         * @brief Handle incoming API request.
+         *
+         * @param connectionId Connection identifier for response routing.
+         * @param request Request string to process.
+         */
+        virtual void handleRequest(connectionId_t connectionId, std::string &&request) = 0;
+
+        /**
+         * @brief Handle outgoing API response.
+         *
+         * @param connectionId Connection identifier.
+         * @param response Response string to process.
+         */
+        virtual void handleResponse(connectionId_t connectionId, std::string &&response) = 0;
+    };
+
+
+    /**
+     * @brief Get string representation of API error codes.
+     *
+     * @param errorCode Error code to get string representation for.
+     * @return String representation of error code.
+     */
+    std::string_view errorCodeToString(ErrorCodes errorCode);
+
+    /**
+     * @brief Parse string value to appropriate JSON type.
+     *
+     * @details Attempts to parse as int, float, bool, defaulting to string.
+     *
+     * @param value String value to parse.
+     * @return JSON object with appropriate type.
+     */
+    nlohmann::json parseValue(std::string_view value);
+
+    /**
+     * @brief Parse vector of strings to JSON array.
+     *
+     * @param values Vector of string values.
+     * @return JSON array with parsed values.
+     */
+    nlohmann::json parseVector(const std::vector<std::string> &values);
+
+    /**
+     * @brief Add parameter to JSON params object.
+     *
+     * @details Parses parameter as key=value pair or single value.
+     *          Supports JSON objects, comma-separated lists, and basic types.
+     *
+     * @param params JSON params object to modify.
+     * @param parameter Parameter string to parse and add.
+     */
+    void emplaceParameter(nlohmann::json &params, std::string_view parameter);
+
+    /// Buffer size for error message formatting
+    inline constexpr uint16_t ERROR_MESSAGE_BUFFER_SIZE = 1024;
+}

--- a/central_unit/src/common/api/api.h
+++ b/central_unit/src/common/api/api.h
@@ -240,7 +240,8 @@ namespace SmartHome::API {
          * @param value JSON string or raw command string.
          *
          * @throws nlohmann::json::parse_error Throws parse error on failed parse.
-         * @throws std::invalid_argument Throws invalid argument when passed JSON string is not in JSON-RPC 2.0 format or raw string formated request does not contain target and method.
+         * @throws std::invalid_argument Throws invalid argument when passed JSON string is not in JSON-RPC 2.0 format
+         *         or raw string formated request does not contain target and method.
          */
         explicit ApiRequest(std::string_view value);
 

--- a/central_unit/src/common/api/api.h
+++ b/central_unit/src/common/api/api.h
@@ -89,7 +89,7 @@ namespace SmartHome::API {
         bool isUndefined() const;
 
         /**
-         * @brief Check if ID is null
+         * @brief Check if ID is null.
          *
          * @return true if ID has null value, false otherwise.
          */
@@ -203,7 +203,7 @@ namespace SmartHome::API {
         /**
          * @brief Setter for struct variables.
          *
-         * @param json Json object to parse.
+         * @param json JSON object to parse.
          * @throws std::invalid_argument Throws invalid argument when passed JSON object is not in JSON-RPC 2.0 error format
          */
         void setValues(nlohmann::json json);
@@ -240,8 +240,7 @@ namespace SmartHome::API {
          * @param value JSON string or raw command string.
          *
          * @throws nlohmann::json::parse_error Throws parse error on failed parse.
-         * @throws std::invalid_argument Throws invalid argument when passed JSON string is not in JSON-RPC 2.0 format.
-         *          or raw string formated request does not contain target and method.
+         * @throws std::invalid_argument Throws invalid argument when passed JSON string is not in JSON-RPC 2.0 format or raw string formated request does not contain target and method.
          */
         explicit ApiRequest(std::string_view value);
 
@@ -310,7 +309,7 @@ namespace SmartHome::API {
         /**
          * @brief Setter for struct variables.
          *
-         * @param json Json object to parse.
+         * @param json JSON object to parse.
          * @throws std::invalid_argument Throws invalid argument when passed JSON object is not in JSON-RPC 2.0 format.
          */
         void setValues(const nlohmann::json &json);

--- a/central_unit/src/common/api/api.h
+++ b/central_unit/src/common/api/api.h
@@ -8,33 +8,38 @@
 
 #include <nlohmann/json.hpp>
 
-// TODO !pr add docs to namespace
 namespace SmartHome::JsonRpcStrings {
+    /// JSON-RPC 2.0 protocol constants
     namespace Constants {
         inline constexpr std::string_view VERSION = "2.0";
         inline constexpr std::string_view NULL_VALUE = "null";
     }
 
+    /// Common JSON-RPC keys
     namespace Keys {
         inline constexpr std::string_view JSONRPC = "jsonrpc";
         inline constexpr std::string_view ID = "id";
     }
 
+    /// JSON-RPC request-specific keys
     namespace RequestKeys {
         inline constexpr std::string_view METHOD = "method";
         inline constexpr std::string_view PARAMS = "params";
     }
 
+    /// Custom parameter keys for SmartHome API
     namespace ParamsKeys {
         inline constexpr std::string_view TARGET = "target";
         inline constexpr std::string_view METHOD_PARAMS = "method_params";
     }
 
+    /// JSON-RPC response-specific keys
     namespace ResponseKeys {
         inline constexpr std::string_view RESULT = "result";
         inline constexpr std::string_view ERROR = "error";
     }
 
+    /// JSON-RPC error object keys
     namespace ErrorKeys {
         inline constexpr std::string_view CODE = "code";
         inline constexpr std::string_view MESSAGE = "message";

--- a/central_unit/src/common/ipc/socket_connection.cpp
+++ b/central_unit/src/common/ipc/socket_connection.cpp
@@ -1,8 +1,10 @@
 #include "socket_connection.h"
 
 namespace SmartHome::IPC {
-    SocketConnection::SocketConnection(ba::io_context &ioContext, const Type socketType, const std::shared_ptr<Utils::Logger> &logger)
-        : mSocket(createSocket(ioContext, socketType)), mType(socketType), mIoContext(ioContext), mpLogger(logger) {
+    SocketConnection::SocketConnection(ba::io_context &ioContext,
+                                       const Type socketType,
+                                       const std::shared_ptr<Utils::Logger> &logger)
+        : mSocket(createSocket(ioContext, socketType)), mType(socketType), mStrand(ioContext), mpLogger(logger) {
     };
 
     SocketConnection::~SocketConnection() {
@@ -37,8 +39,10 @@ namespace SmartHome::IPC {
             }
         };
 
-        std::visit([this, callback](auto &socket) {
-            ba::async_read_until(socket, mStreamBuf, ms_DELIMITER_REGEX, callback);
+        auto strandWrapper = ba::bind_executor(mStrand, callback);
+
+        std::visit([this, strandWrapper](auto &socket) {
+            ba::async_read_until(socket, mStreamBuf, ms_DELIMITER_REGEX, strandWrapper);
         }, mSocket);
     }
 
@@ -47,7 +51,7 @@ namespace SmartHome::IPC {
         if (!isOpen()) return;
 
         try {
-            std::visit([this, message](auto &socket) {
+            std::visit([message](auto &socket) {
                 ba::write(socket, ba::buffer(message + ms_MESSAGE_DELIMITER));
             }, mSocket);
         } catch (bs::system_error &e) {
@@ -66,8 +70,10 @@ namespace SmartHome::IPC {
             }
         };
 
-        std::visit([this, message, callback](auto &socket) {
-            ba::async_write(socket, ba::buffer(message + ms_MESSAGE_DELIMITER), callback);
+        auto strandWrapper = ba::bind_executor(mStrand, callback);
+
+        std::visit([message, strandWrapper](auto &socket) {
+            ba::async_write(socket, ba::buffer(message + ms_MESSAGE_DELIMITER), strandWrapper);
         }, mSocket);
     }
 
@@ -117,6 +123,7 @@ namespace SmartHome::IPC {
                 mpLogger->info("[SOCKET_CONNECTION] IPC operation aborted");
                 break;
             case ba::error::eof:
+                //FIXME SH-206 Logging to terminal with timestamp
                 mpLogger->info("[SOCKET_CONNECTION] IPC connection read EOF");
                 close();
                 break;

--- a/central_unit/src/common/ipc/socket_connection.cpp
+++ b/central_unit/src/common/ipc/socket_connection.cpp
@@ -5,13 +5,13 @@ namespace SmartHome::IPC {
                                        const Type socketType,
                                        const std::shared_ptr<Utils::Logger> &logger)
         : mSocket(createSocket(ioContext, socketType)), mType(socketType), mStrand(ioContext), mpLogger(logger) {
-    };
+    }
 
     SocketConnection::~SocketConnection() {
         SocketConnection::close();
-    };
+    }
 
-    const boost::regex SocketConnection::ms_DELIMITER_REGEX(SocketConnection::ms_MESSAGE_DELIMITER);
+    const boost::regex SocketConnection::ms_DELIMITER_REGEX(ms_MESSAGE_DELIMITER);
 
     std::string SocketConnection::read() {
         if (isOpen()) {
@@ -101,7 +101,7 @@ namespace SmartHome::IPC {
 
     bool SocketConnection::isOpen() const {
         const bool isSocketOpen = std::visit([](const auto &socket) { return socket.is_open(); }, mSocket);
-        return (!mIsClosing && isSocketOpen);
+        return !mIsClosing && isSocketOpen;
     }
 
     std::variant<bai::tcp::socket, bal::stream_protocol::socket> SocketConnection::createSocket(

--- a/central_unit/src/common/ipc/socket_connection.cpp
+++ b/central_unit/src/common/ipc/socket_connection.cpp
@@ -123,7 +123,6 @@ namespace SmartHome::IPC {
                 mpLogger->info("[SOCKET_CONNECTION] IPC operation aborted");
                 break;
             case ba::error::eof:
-                //FIXME SH-206 Logging to terminal with timestamp
                 mpLogger->info("[SOCKET_CONNECTION] IPC connection read EOF");
                 close();
                 break;

--- a/central_unit/src/common/ipc/socket_connection.cpp
+++ b/central_unit/src/common/ipc/socket_connection.cpp
@@ -99,6 +99,13 @@ namespace SmartHome::IPC {
         std::visit(socketVisitor, mSocket);
     }
 
+    void SocketConnection::shutdownSocket(ba::socket_base::shutdown_type mode) {
+        std::visit([mode](auto &socket) {
+            socket.shutdown(mode);
+            //TODO Sockets do not close for incoming traffic consistently - more testing needed
+        },mSocket);
+    }
+
     bool SocketConnection::isOpen() const {
         const bool isSocketOpen = std::visit([](const auto &socket) { return socket.is_open(); }, mSocket);
         return !mIsClosing && isSocketOpen;

--- a/central_unit/src/common/ipc/socket_connection.h
+++ b/central_unit/src/common/ipc/socket_connection.h
@@ -101,6 +101,14 @@ namespace SmartHome::IPC {
         */
         virtual void close();
 
+        //TODO Sockets do not close for incoming traffic consistently - more testing needed
+        /**
+         * @brief Shutdowns connection socket according to passed mode.
+         *
+         * @param mode boost.asio socket shutdown mode.
+         */
+        void shutdownSocket(ba::socket_base::shutdown_type mode);
+
         /**
         * @brief Check if socket is open.
         *

--- a/central_unit/src/common/ipc/socket_connection.h
+++ b/central_unit/src/common/ipc/socket_connection.h
@@ -141,7 +141,7 @@ namespace SmartHome::IPC {
         std::string getMessageFromBuffer(const size_t &bytesTransferred);
 
         Type mType; ///< Socket type
-        ba::io_context &mIoContext; ///< IO context reference
+        ba::io_context::strand mStrand; ///< IO context strand for serialization
         std::shared_ptr<Utils::Logger> mpLogger; ///< Logger instance shared pointer
         ba::streambuf mStreamBuf; ///< Buffer for async read operations
 

--- a/central_unit/src/common/ipc/socket_server.cpp
+++ b/central_unit/src/common/ipc/socket_server.cpp
@@ -193,6 +193,30 @@ namespace SmartHome::IPC {
     void SocketServer::stopSocketServer() {
         mIsSocketServerRunning.store(false);
 
+        if (mIsAcceptingNewConnections) {
+            stopAcceptors();
+        }
+        stopIncomingTraffic();
+
+        // Make a vector of all active connection
+        std::vector<std::shared_ptr<SocketServerConnection> > connectionsToClose; {
+            std::lock_guard lock(mActiveConnectionsMutex);
+
+            for (auto &weakConnection: mActiveConnections | std::views::values) {
+                if (auto connection = weakConnection.lock()) {
+                    connectionsToClose.push_back(connection);
+                }
+            }
+            mActiveConnections.clear();
+        }
+
+        // Close all active connections
+        for (const auto &connection: connectionsToClose) {
+            connection->close();
+        }
+    }
+
+    void SocketServer::stopAcceptors() {
         // Close TCP acceptor
         if (mpTcpAcceptor) {
             mpLogger->debug("[SOCKET_SERVER] Stopping TCP acceptor");
@@ -225,22 +249,16 @@ namespace SmartHome::IPC {
             mpUdsAcceptor.reset();
         }
 
-        // Make a vector of all active connection
-        std::vector<std::shared_ptr<SocketServerConnection> > connectionsToClose;
-        {
-            std::lock_guard lock(mActiveConnectionsMutex);
+        mIsAcceptingNewConnections.store(false);
+    }
 
-            for (auto &weakConnection: mActiveConnections | std::views::values) {
-                if (auto connection = weakConnection.lock()) {
-                    connectionsToClose.push_back(connection);
-                }
+    void SocketServer::stopIncomingTraffic() {
+        std::scoped_lock lock(mActiveConnectionsMutex);
+        for (auto &weakConnection: mActiveConnections | std::views::values) {
+            if (auto connection = weakConnection.lock()) {
+                connection->shutdownSocket(ba::socket_base::shutdown_receive);
+                //TODO Sockets do not close for incoming traffic consistently - more testing needed
             }
-            mActiveConnections.clear();
-        }
-
-        // Close all active connections
-        for (const auto &connection: connectionsToClose) {
-            connection->close();
         }
     }
 

--- a/central_unit/src/common/ipc/socket_server.cpp
+++ b/central_unit/src/common/ipc/socket_server.cpp
@@ -22,10 +22,13 @@ namespace SmartHome::IPC {
 
     bool SocketServer::initializeSocketServer(ba::io_context *ioContext,
                                               const Config &config,
+                                              const std::shared_ptr<API::Api> &api,
                                               const std::shared_ptr<Utils::Logger> &logger) {
+        mpIoContext = ioContext;
         mConfig = config;
         bool isIpcLaunchSuccessful = false;
         mpLogger = logger;
+        mpApi = api;
 
         // Create endpoint and acceptor for TCP connections if enabled
         if (mConfig.tcp.isEnabled) {
@@ -84,45 +87,46 @@ namespace SmartHome::IPC {
     }
 
     void SocketServer::acceptorHandler(const std::shared_ptr<SocketServerConnection> &connection,
-                                       ba::io_context *ioContext,
                                        const bs::error_code &ec,
                                        const SocketConnection::Type type) {
-        if (!ec && mIsSocketServerRunning.load()) {
-            onAccept(connection, ioContext);
+        if (!ec && mIsSocketServerRunning.load() && mIsAcceptingNewConnections.load()) {
+            onAccept(connection);
             if (type == SocketConnection::Type::TCP) {
-                startTcpAcceptor(ioContext);
+                startTcpAcceptor();
             } else {
-                startUdsAcceptor(ioContext);
+                startUdsAcceptor();
             }
         } else if (ec) {
             onAcceptError(ec);
         }
-    };
+    }
 
 
-    void SocketServer::startTcpAcceptor(ba::io_context *ioContext) {
+    void SocketServer::startTcpAcceptor() {
         auto newTcpConnection = std::make_shared<SocketServerConnection>(
-            *ioContext, SocketServerConnection::Type::TCP, mpLogger);
+            *mpIoContext, SocketServerConnection::Type::TCP, mpLogger);
         auto &socket = std::get<bai::tcp::socket>(newTcpConnection->mSocket);
 
-        mpTcpAcceptor->async_accept(socket, [this, newTcpConnection, ioContext](const bs::error_code ec) {
-            acceptorHandler(newTcpConnection, ioContext, ec, SocketConnection::Type::TCP);
+        mIsAcceptingNewConnections.store(true);
+        mpTcpAcceptor->async_accept(socket, [this, newTcpConnection](const bs::error_code ec) {
+            acceptorHandler(newTcpConnection, ec, SocketConnection::Type::TCP);
         });
     }
 
-    void SocketServer::startUdsAcceptor(ba::io_context *ioContext) {
+    void SocketServer::startUdsAcceptor() {
         auto newUdsConnection = std::make_shared<SocketServerConnection>(
-            *ioContext, SocketServerConnection::Type::UDS, mpLogger);
+            *mpIoContext, SocketServerConnection::Type::UDS, mpLogger);
         auto &socket = std::get<bal::stream_protocol::socket>(newUdsConnection->mSocket);
 
-        mpUdsAcceptor->async_accept(socket, [this, newUdsConnection, ioContext](const bs::error_code ec) {
-            acceptorHandler(newUdsConnection, ioContext, ec, SocketConnection::Type::UDS);
+        mIsAcceptingNewConnections.store(true);
+        mpUdsAcceptor->async_accept(socket, [this, newUdsConnection](const bs::error_code ec) {
+            acceptorHandler(newUdsConnection, ec, SocketConnection::Type::UDS);
         });
     }
 
-    void SocketServer::onAccept(const std::shared_ptr<SocketServerConnection> &connection, ba::io_context *ioContext) {
+    void SocketServer::onAccept(const std::shared_ptr<SocketServerConnection> &connection) {
         // Try fetching unused connection id
-        uint32_t connectionId;
+        connectionId_t connectionId;
         try {
             connectionId = getNextConnectionId();
         } catch (std::exception &e) {
@@ -136,7 +140,7 @@ namespace SmartHome::IPC {
         // TODO add active connections limit
         // New connection setup
         connection->setId(connectionId);
-        connection->setCloseCallback([this](const uint32_t id) {
+        connection->setCloseCallback([this](const connectionId_t id) {
             removeActiveConnection(id);
         });
 
@@ -151,21 +155,17 @@ namespace SmartHome::IPC {
         }, connection->mSocket);
 
         // Start reading incoming messages
-        connection->asyncReadLoop([this, connection, connectionId](const std::string &message) {
+        connection->asyncReadLoop([this, connectionId](const std::string &message) {
             mpLogger->debugf("[SOCKET_SERVER] Message received: %s", message.c_str());
-
-            //TODO implement api integration and change line below for an api call
-            connection->writeAsync(message, [message, this]() {
-                mpLogger->debugf("[SOCKET_SERVER] Message sent: %s", message.c_str());
-            });
+            mpApi->handleRequest(connectionId, message.data());
         });
     }
 
-    uint32_t SocketServer::getNextConnectionId() {
+    connectionId_t SocketServer::getNextConnectionId() {
         std::lock_guard lock(mActiveConnectionsMutex);
 
         // TODO consider using another method then iteration from 1
-        for (uint32_t id = 1; id < UINT32_MAX; ++id) {
+        for (connectionId_t id = 1; id < std::numeric_limits<decltype(id)>::max(); ++id) {
             if (!mActiveConnections.contains(id)) {
                 return id;
             }
@@ -174,17 +174,17 @@ namespace SmartHome::IPC {
         throw std::runtime_error("Could not find free connection id");
     }
 
-    void SocketServer::removeActiveConnection(const uint32_t connectionId) {
+    void SocketServer::removeActiveConnection(const connectionId_t connectionId) {
         std::lock_guard lock(mActiveConnectionsMutex);
         mActiveConnections.erase(connectionId);
     }
 
-    void SocketServer::runSocketServer(ba::io_context *ioContext) {
+    void SocketServer::runSocketServer() {
         // Start accepting connections if socket server is initialized
         if (mIsSocketServerInitialized) {
             mIsSocketServerRunning.store(true);
-            if (mpTcpAcceptor) startTcpAcceptor(ioContext);
-            if (mpUdsAcceptor) startUdsAcceptor(ioContext);
+            if (mpTcpAcceptor) startTcpAcceptor();
+            if (mpUdsAcceptor) startUdsAcceptor();
         } else {
             mpLogger->errorf("[SOCKET_SERVER] IPC server not initialized");
         }
@@ -246,5 +246,18 @@ namespace SmartHome::IPC {
 
     bool SocketServer::isRunning() const {
         return mIsSocketServerRunning.load();
+    }
+
+    std::shared_ptr<SocketServerConnection> SocketServer::getConnection(const connectionId_t connectionId) {
+        std::scoped_lock lock(mActiveConnectionsMutex);
+        auto iter = mActiveConnections.find(connectionId);
+        if (iter == mActiveConnections.end()) {
+            return nullptr;
+        }
+        return std::shared_ptr(iter->second);
+    }
+
+    ba::io_context *SocketServer::getIoContext() const {
+        return mpIoContext;
     }
 }

--- a/central_unit/src/common/ipc/socket_server.h
+++ b/central_unit/src/common/ipc/socket_server.h
@@ -2,6 +2,7 @@
 
 #include "socket_server_connection.h"
 #include "async_logger.h"
+#include "api.h"
 
 #include <utility>
 #include <unordered_map>
@@ -14,6 +15,7 @@ namespace ba = boost::asio;
 namespace bai = boost::asio::ip;
 
 namespace SmartHome::IPC {
+
     /**
      * @brief Multi-protocol socket server for Smart Home IPC.
      *
@@ -68,6 +70,7 @@ namespace SmartHome::IPC {
          *
          * @param ioContext Boost::Asio IO context for async operations.
          * @param config Server configuration.
+         * @param api Reference to an API class implementation instance.
          * @param logger Logger shared pointer instance pointer.
          *
          * @return true if at least one protocol initialized successfully.
@@ -76,6 +79,7 @@ namespace SmartHome::IPC {
          */
         bool initializeSocketServer(ba::io_context *ioContext,
                                     const Config &config,
+                                    const std::shared_ptr<API::Api> &api,
                                     const std::shared_ptr<Utils::Logger> &logger);
 
         /**
@@ -84,11 +88,10 @@ namespace SmartHome::IPC {
          * @details Begins asynchronous accept loops for enabled protocols.
          *          Must be called after successful initialization.
          *
-         * @param ioContext Boost::Asio IO context for async operations.
          *
          * @pre initializeSocketServer() must be called successfully.
          */
-        void runSocketServer(ba::io_context *ioContext);
+        void runSocketServer();
 
         /**
          * @brief Stop server and close all connections.
@@ -104,6 +107,21 @@ namespace SmartHome::IPC {
          * @return true if actively accepting connections.
          */
         bool isRunning() const;
+
+        /**
+         * @brief Connection getter.
+         *
+         * @param connectionId Connection to get.
+         * @return Shared pointer to SocketServerConnection instance.
+         */
+        std::shared_ptr<SocketServerConnection> getConnection(connectionId_t connectionId);
+
+        /**
+         * @brief IO context getter.
+         *
+         * @return SocketServer IO context pointer.
+         */
+        ba::io_context *getIoContext() const;
 
     private:
         /**
@@ -127,31 +145,25 @@ namespace SmartHome::IPC {
          * @brief Common accept handler for both protocols.
          *
          * @param connection Connection instance shared pointer reference.
-         * @param ioContext Boost::Asio IO context for async operations.
          * @param ec Boost::System error code.
          * @param type Acceptor type.
          */
         void acceptorHandler(const std::shared_ptr<SocketServerConnection> &connection,
-                             ba::io_context *ioContext,
                              const bs::error_code &ec,
                              SocketConnection::Type type);
 
         /**
          * @brief Start asynchronous TCP accept loop.
          *
-         * @param ioContext Boost::Asio IO context for async operations.
-         *
          */
-        void startTcpAcceptor(ba::io_context *ioContext);
+        void startTcpAcceptor();
 
 
         /**
          * @brief Start asynchronous UDS accept loop.
          *
-         * @param ioContext Boost::Asio IO context for async operations.
-         *
          */
-        void startUdsAcceptor(ba::io_context *ioContext);
+        void startUdsAcceptor();
 
         /**
          * @brief Handles newly accepted connection.
@@ -160,11 +172,10 @@ namespace SmartHome::IPC {
          *          Schedules next accept operation to continue accepting new connections.
          *
          * @param connection Newly accepted connection.
-         * @param ioContext Boost::Asio IO context for async operations.
          *
          * @note Called from async_accept completion handler (acceptorHandler).
          */
-        void onAccept(const std::shared_ptr<SocketServerConnection> &connection, ba::io_context *ioContext);
+        void onAccept(const std::shared_ptr<SocketServerConnection> &connection);
 
         /**
          * @brief Get next available connection ID.
@@ -175,7 +186,7 @@ namespace SmartHome::IPC {
          * @return Unique connection identifier.
          * @throw std::runtime_error if no free IDs available.
          */
-        uint32_t getNextConnectionId();
+        connectionId_t getNextConnectionId();
 
         /**
          * @brief Remove connection from active connections map.
@@ -185,13 +196,15 @@ namespace SmartHome::IPC {
          * @note Thread-safe via mutex.
          *       Called by TcpConnection close callback.
          */
-        void removeActiveConnection(uint32_t connectionId);
+        void removeActiveConnection(connectionId_t connectionId);
 
+        ba::io_context *mpIoContext;
         Config mConfig;
         std::shared_ptr<Utils::Logger> mpLogger; ///< Logger instance shared pointer
+        std::shared_ptr<API::Api> mpApi;
 
         /// Map of active connections (ID: weak_ptr)
-        std::unordered_map<uint32_t, std::weak_ptr<SocketServerConnection> > mActiveConnections;
+        std::unordered_map<connectionId_t, std::weak_ptr<SocketServerConnection> > mActiveConnections;
         std::mutex mActiveConnectionsMutex;
 
         // TCP

--- a/central_unit/src/common/ipc/socket_server.h
+++ b/central_unit/src/common/ipc/socket_server.h
@@ -102,6 +102,17 @@ namespace SmartHome::IPC {
         void stopSocketServer();
 
         /**
+         * @brief Stops acceptors and signals end of accepting new connections.
+         */
+        void stopAcceptors();
+
+        //TODO Sockets do not close for incoming traffic consistently - more testing needed
+        /**
+         * @brief Closes connections sockets for incoming traffic.
+         */
+        void stopIncomingTraffic();
+
+        /**
          * @brief Check if server is running.
          *
          * @return true if actively accepting connections.
@@ -218,5 +229,6 @@ namespace SmartHome::IPC {
         // State flags
         std::atomic<bool> mIsSocketServerInitialized{false}; ///< Server initialized state.
         std::atomic<bool> mIsSocketServerRunning{false}; ///< Server running state.
+        std::atomic<bool> mIsAcceptingNewConnections{false};
     };
 }

--- a/central_unit/src/common/ipc/socket_server_connection.cpp
+++ b/central_unit/src/common/ipc/socket_server_connection.cpp
@@ -12,7 +12,7 @@ namespace SmartHome::IPC {
             handleMessage(message);
 
             if (isOpen()) {
-                ba::post(mIoContext, [this, self, handleMessage]() {
+                ba::post(mStrand, [this, self, handleMessage] {
                     asyncReadLoop(handleMessage);
                 });
             }

--- a/central_unit/src/common/types.h
+++ b/central_unit/src/common/types.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <cstdint>
+
+namespace SmartHome {
+    using apiId_t = uint32_t;
+    using connectionId_t = uint32_t;
+}

--- a/central_unit/src/common/utils/logger/async_logger.cpp
+++ b/central_unit/src/common/utils/logger/async_logger.cpp
@@ -4,12 +4,6 @@ namespace SmartHome::Utils {
     using LL = LogLevels;
 
     AsyncLogger::AsyncLogger(const std::shared_ptr<Logger> &logger, ba::io_context &ioContext) : mIoStrand(ioContext) {
-        try {
-            mBuffer.reserve(ms_BUFFER_RESERVED_CHARS);
-        } catch (std::exception &e) {
-            std::cerr << "[LOGGER_ERROR] " << e.what() << std::endl;
-        }
-
         auto config = logger->getConfig();
         config.logFile.createNew =false;
         config.logFile.archiveOld=false;
@@ -19,11 +13,6 @@ namespace SmartHome::Utils {
     }
 
     AsyncLogger::AsyncLogger(ba::io_context &ioContext): mIoStrand(ioContext) {
-        try {
-            mBuffer.reserve(ms_BUFFER_RESERVED_CHARS);
-        } catch (std::exception &e) {
-            std::cerr << "[LOGGER_ERROR] " << e.what() << std::endl;
-        }
     }
 
     AsyncLogger::~AsyncLogger() {
@@ -34,7 +23,7 @@ namespace SmartHome::Utils {
 
     void AsyncLogger::log(const LogLevels::Level level, const std::string &message) {
         if (level > mLevel) return;
-        ba::post(mIoStrand, [this, level, message]() {
+        ba::post(mIoStrand, [this, level, message] {
             writeLog(level, message);
         });
     }

--- a/central_unit/src/common/utils/logger/logger.cpp
+++ b/central_unit/src/common/utils/logger/logger.cpp
@@ -10,13 +10,7 @@ namespace SmartHome::Utils {
     using LL = LogLevels;
     //TODO add advanced logging options (log file rotation, compression, etc)
 
-    Logger::Logger() {
-        try {
-            mBuffer.reserve(ms_BUFFER_RESERVED_CHARS);
-        } catch (std::exception &e) {
-            std::cerr << "[LOGGER_ERROR] " << e.what() << std::flush;
-        }
-    }
+    Logger::Logger() = default;
 
     Logger::~Logger() {
         if (mIsFileLoggingEnabled && mFileStream.is_open()) {
@@ -114,8 +108,8 @@ namespace SmartHome::Utils {
         // Open empty file in append mode
         mFileStream.open(mFilePath, std::ios::app);
         // Add header
-        mBuffer = "Log started at " + getTimeStamp() + "\n\n";
-        mFileStream << mBuffer << std::flush;
+        const std::string logFileHeader = "Log started at " + getTimeStamp() + "\n\n";
+        mFileStream << logFileHeader << std::flush;
         info("[Logger] New log file created");
     }
 
@@ -172,20 +166,19 @@ namespace SmartHome::Utils {
 
     void Logger::writeLog(const LogLevels::Level level,
                           const std::string &message) {
-        prepareLogMessage(level, message);
-
+        std::string preparedMessage = prepareLogMessage(level, message);
 
         if (mEnableConsoleLogOutput) {
             if (level == LL::Level::CRITICAL || level == LL::Level::ERROR) {
-                std::cerr << mBuffer << std::flush;
+                std::cerr << preparedMessage << std::flush;
             } else if (level == LogLevels::Level::WARNING || level == LL::Level::INFO || level == LL::Level::DEBUG) {
-                std::cout << mBuffer << std::flush;
+                std::cout << preparedMessage << std::flush;
             }
         }
 
         if (mIsFileLoggingEnabled && mFileStream.is_open()) {
-            mBuffer = getTimeStamp() + ' ' + mBuffer;
-            mFileStream << mBuffer << std::flush;
+            preparedMessage = getTimeStamp() + ' ' + preparedMessage;
+            mFileStream << preparedMessage << std::flush;
         }
     }
 
@@ -198,8 +191,7 @@ namespace SmartHome::Utils {
         return ss.str();
     }
 
-    void Logger::prepareLogMessage(const LL::Level level, const std::string_view message) {
-        mBuffer.clear();
-        mBuffer += '[' + std::string(LL::toString(level)) + "] " + std::string(message) + '\n';
+    inline std::string Logger::prepareLogMessage(const LL::Level level, const std::string_view message) {
+        return '[' + std::string(LL::toString(level)) + "] " + message.data() + '\n';
     }
 }

--- a/central_unit/src/common/utils/logger/logger.h
+++ b/central_unit/src/common/utils/logger/logger.h
@@ -75,9 +75,6 @@ namespace SmartHome::Utils {
      *          Supports printf-style formating through template methods.
      *
      * @warning Not thread-safe, use AsyncLogger for thread-safe logging.
-     *
-     * @note Pre-allocates internal buffer for reduced write times.
-     *
      */
     class Logger {
     public:
@@ -99,7 +96,7 @@ namespace SmartHome::Utils {
         /**
          * @brief Construct logger with default setting.
          *
-         * @note Pre-allocates internal buffer. Console logging enabled and file logging disabled by default.
+         * @note Console logging enabled and file logging disabled by default.
          */
         Logger();
 
@@ -348,13 +345,14 @@ namespace SmartHome::Utils {
         /**
          * @brief Prepare log message with level prefix.
          *
-         * @details Formats message as "[LEVEL] message\n" and stores in mBuffer.
+         * @details Formats message as "[LEVEL] message\n".
          *
          * @param level Message verbosity level.
          * @param message Raw message text.
          *
+         * @return String containing formated message.
          */
-        void prepareLogMessage(LogLevels::Level level, std::string_view message);
+        static std::string prepareLogMessage(LogLevels::Level level, std::string_view message);
 
         /**
          * @brief Format message using printf-style formatting.
@@ -367,10 +365,6 @@ namespace SmartHome::Utils {
          */
         template<typename... Args>
         static std::string formatMessage(const char *format, Args... args);
-
-        // Log message buffer
-        static constexpr uint16_t ms_BUFFER_RESERVED_CHARS = 256; ///< Number of chars reserved for mBuffer
-        std::string mBuffer; ///< Log message buffer with space reserved in constructor
 
         /// Logger level, enables logging messages of set level and levels bellow it.
         LogLevels::Level mLevel = LogLevels::defaultLevel;

--- a/central_unit/src/common/utils/logger/logger.tpp
+++ b/central_unit/src/common/utils/logger/logger.tpp
@@ -14,8 +14,7 @@ namespace SmartHome::Utils {
 
     template<typename... Args>
     void Logger::logf(const LogLevels::Level level, const char *format, Args... args) {
-        if (level > mLevel) return;
-        Logger::writeLog(level, Logger::formatMessage(format, args...));
+        log(level,formatMessage(format, args...));
     }
 
     template<typename... Args>

--- a/central_unit/src/core/CMakeLists.txt
+++ b/central_unit/src/core/CMakeLists.txt
@@ -3,6 +3,8 @@ find_package(Boost 1.74 REQUIRED COMPONENTS
         program_options
 )
 
+find_package(nlohmann_json 3.11.2 REQUIRED)
+
 if (ENABLE_SYSTEMD)
     # Required PkgConfig for systemd
     find_package(PkgConfig REQUIRED)
@@ -15,6 +17,8 @@ endif ()
 add_executable(smarthomed
         main.cpp
         core.cpp
+        core_actions.cpp
+        api/internal_api.cpp
         service/service_manager.cpp
         service/systemd_service.cpp
         service/standalone_service.cpp
@@ -29,10 +33,14 @@ if (ENABLE_SYSTEMD)
     target_include_directories(smarthomed PRIVATE ${SYSTEMD_INCLUDE_DIRS})
 endif ()
 
+target_compile_features(smarthomed PRIVATE cxx_std_23)
+target_compile_definitions(smarthomed PRIVATE BOOST_ASIO_HAS_CO_AWAIT)
 
 target_link_libraries(smarthomed PRIVATE
+        smarthome::api
         smarthome::ipc
         smarthome::utility
         Boost::program_options
+        nlohmann_json::nlohmann_json
 )
 

--- a/central_unit/src/core/api/internal_api.cpp
+++ b/central_unit/src/core/api/internal_api.cpp
@@ -160,7 +160,7 @@ namespace SmartHome::API {
         ApiError e;
         if (nlohmann::json::accept(requestView)) {
             //Setting structured result when trimmedRequest contains json object
-            requestStruct.structuredResult = true;
+            requestStruct.isResultStructured = true;
             nlohmann::json requestJson = nlohmann::json::parse(requestView);
 
             if (requestJson.is_array()) {
@@ -215,7 +215,7 @@ namespace SmartHome::API {
             e.message = errorCodeToString(e.code);
             std::string result;
 
-            if (requestStruct.structuredResult) {
+            if (requestStruct.isResultStructured) {
                 ApiResponse errorResponse;
                 errorResponse.error = e;
                 result = errorResponse.to_string();

--- a/central_unit/src/core/api/internal_api.cpp
+++ b/central_unit/src/core/api/internal_api.cpp
@@ -1,0 +1,248 @@
+#include "internal_api.h"
+#include "../core.h"
+#include "../core_actions.h"
+
+#include <unordered_map>
+
+#include <boost/algorithm/string/case_conv.hpp>
+#include <boost/algorithm/string.hpp>
+#include <nlohmann/json_fwd.hpp>
+
+namespace ba = boost::asio;
+
+namespace SmartHome::API {
+    InternalApi::Method::Method(const MethodTypes value) {
+        type = value;
+    }
+
+    InternalApi::Method::Method(const std::string_view value) {
+        to_action(value);
+    }
+
+    InternalApi::Method InternalApi::Method::operator()(const std::string_view value) {
+        to_action(value);
+        return *this;
+    }
+
+    bool InternalApi::Method::operator==(const Method &other) const {
+        return type == other.type;
+    }
+
+    bool InternalApi::Method::operator==(const MethodTypes other) const {
+        return type == other;
+    }
+
+    std::string_view InternalApi::Method::to_string() const {
+        switch (type) {
+            case MethodTypes::GET:
+                return msGET_STRING;
+            case MethodTypes::SET:
+                return msSET_STRING;
+            case MethodTypes::EXECUTE:
+                return msEXECUTE_STRING;
+            case MethodTypes::ECHO_REQUEST:
+                return msECHO_STRING;
+            case MethodTypes::PING_REQUEST:
+                return msPING_STRING;
+            default:
+                return msUNKNOWN_STRING;
+        }
+    }
+
+    void InternalApi::Method::to_action(const std::string_view value) {
+        static const std::unordered_map<std::string_view, MethodTypes> strToActMap{
+            {msGET_STRING, MethodTypes::GET},
+            {msSET_STRING, MethodTypes::SET},
+            {msEXECUTE_STRING, MethodTypes::EXECUTE},
+            {msECHO_STRING, MethodTypes::ECHO_REQUEST},
+            {msPING_STRING, MethodTypes::PING_REQUEST},
+            {msUNKNOWN_STRING, MethodTypes::UNKNOWN}
+        };
+
+        const auto iter = strToActMap.find(boost::algorithm::to_lower_copy(std::string(value)));
+        type = (iter != strToActMap.end()) ? iter->second : MethodTypes::UNKNOWN;
+    }
+
+
+    InternalApi::Target::Target(const TargetTypes value) {
+        type = value;
+    }
+
+    InternalApi::Target::Target(const std::string_view value) {
+        to_target(value);
+    }
+
+    InternalApi::Target InternalApi::Target::operator()(const std::string_view value) {
+        to_target(value);
+        return *this;
+    }
+
+    bool InternalApi::Target::operator==(const Target &other) const {
+        return type == other.type;
+    }
+
+    bool InternalApi::Target::operator==(const TargetTypes other) const {
+        return type == other;
+    }
+
+    std::string_view InternalApi::Target::to_string() const {
+        switch (type) {
+            case TargetTypes::CLI:
+                return msCLI_STRING;
+            case TargetTypes::GUI:
+                return msGUI_STRING;
+            case TargetTypes::WEB_SERVER:
+                return msWEB_SERVER_STRING;
+            case TargetTypes::CORE:
+                return msCORE_STRING;
+            case TargetTypes::MODULE_MEDIATOR:
+                return msMODULE_MEDIATOR_STRING;
+            case TargetTypes::DATABASE:
+                return msDATABASE_STRING;
+            default:
+                return msUNKNOWN_STRING;
+        }
+    }
+
+    void InternalApi::Target::to_target(const std::string_view value) {
+        static const std::unordered_map<std::string_view, TargetTypes> strToTargMap{
+            {msCLI_STRING, TargetTypes::CLI},
+            {msGUI_STRING, TargetTypes::GUI},
+            {msWEB_SERVER_STRING, TargetTypes::WEB_SERVER},
+            {msWEB_STRING, TargetTypes::WEB_SERVER},
+            {msCORE_STRING, TargetTypes::CORE},
+            {msMODULE_MEDIATOR_STRING, TargetTypes::MODULE_MEDIATOR},
+            {msMEDIATOR_STRING, TargetTypes::MODULE_MEDIATOR},
+            {msDATABASE_STRING, TargetTypes::DATABASE}
+        };
+
+        const auto iter = strToTargMap.find(boost::algorithm::to_lower_copy(std::string(value)));
+        type = (iter != strToTargMap.end()) ? iter->second : TargetTypes::UNKNOWN;
+    }
+
+
+    InternalApi::Command::Command(const ApiRequest &value) {
+        if (!value.params.has_value()) {
+            throw std::invalid_argument("Command requires params");
+        }
+
+        if (!value.params->contains(JsonRpcStrings::ParamsKeys::TARGET)) {
+            throw std::invalid_argument("Command params must contain \"target\"");
+        }
+
+        target(value.params.value()[JsonRpcStrings::ParamsKeys::TARGET].get<std::string>());
+
+        if (value.params->contains(JsonRpcStrings::ParamsKeys::METHOD_PARAMS))
+            params = value.params.value()[JsonRpcStrings::ParamsKeys::METHOD_PARAMS].get<nlohmann::json>();
+
+        commandId = value.id;
+        method(value.method);
+    }
+
+    InternalApi::Command::Command(const nlohmann::json &params,
+                                  const ApiId id,
+                                  const Method method,
+                                  const Target target)
+        : params(std::move(params)), commandId(id), method(method), target(target) {
+    }
+
+    void InternalApi::handleRequest(const apiId_t connectionId, std::string &&request) {
+        boost::algorithm::trim(request);
+        std::string_view requestView(request);
+
+        Request requestStruct = {
+            .connectionId = connectionId,
+        };
+
+        const auto logger = Core::Instance().mLogger;
+        logger->debug("[INTERNAL_API] handleRequest");
+
+        ApiError e;
+        if (nlohmann::json::accept(requestView)) {
+            //Setting structured result when trimmedRequest contains json object
+            requestStruct.structuredResult = true;
+            nlohmann::json requestJson = nlohmann::json::parse(requestView);
+
+            if (requestJson.is_array()) {
+                // Parse JSON-RPC batch request by filling Request struct commands vector with parsed ApiRequest structs
+                for (const auto &unpackedRequest: requestJson) {
+                    try {
+                        requestStruct.commands.emplace_back(ApiRequest(unpackedRequest));
+                    } catch (const std::exception &exception) {
+                        // On parse error push command with unknown Method and Target with ApiError in params so it is
+                        // handled and send back as a part of batch response on request completion
+                        requestStruct.commands.emplace_back(
+                            ApiError(
+                                ErrorCodes::PARSE_ERROR,
+                                errorCodeToString(ErrorCodes::PARSE_ERROR).data(),
+                                exception.what()
+                            ).to_json(),
+                            ApiId(nullptr),
+                            Method(MethodTypes::UNKNOWN),
+                            Target(TargetTypes::UNKNOWN));
+
+                        logger->error(
+                            "[INTERNAL_API] [HANDLE_REQUEST] JSON-RPC batch request parse error: " +
+                            std::string(exception.what()));
+                    }
+                }
+            } else {
+                // Parse singular JSON-RPC request
+                try {
+                    requestStruct.commands.emplace_back(ApiRequest(requestJson));
+                } catch (const std::exception &exception) {
+                    e.code = ErrorCodes::PARSE_ERROR;
+                    e.data = exception.what();
+                    logger->error(
+                        "[INTERNAL_API] [HANDLE_REQUEST] JSON-RPC request parse error: " +
+                        std::string(exception.what()));
+                }
+            }
+        } else {
+            // Parse string-based request (from CLI)
+            try {
+                requestStruct.commands.emplace_back(ApiRequest(requestView));
+            } catch (const std::exception &exception) {
+                e.code = ErrorCodes::PARSE_ERROR;
+                e.data = exception.what();
+                logger->error(
+                    "[INTERNAL_API] [HANDLE_REQUEST] unstructured request parse error: " +
+                    std::string(exception.what()));
+            }
+        }
+
+        if (e.code != ErrorCodes::NO_ERROR) {
+            e.message = errorCodeToString(e.code);
+            std::string result;
+
+            if (requestStruct.structuredResult) {
+                ApiResponse errorResponse;
+                errorResponse.error = e;
+                result = errorResponse.to_string();
+            } else {
+                result = "[ERROR] " + e.message + " - " + e.data;
+            }
+
+            handleResponse(connectionId, std::move(result));
+            return;
+        }
+
+        logger->debug("[INTERNAL_API] handler call");
+        CoreActions::handleRequest(requestStruct, [this](const connectionId_t id, std::string &&response) {
+            handleResponse(id, std::move(response));
+        });
+    }
+
+    void InternalApi::handleResponse(const apiId_t connectionId, std::string &&response) {
+        Core::Instance().mLogger->debug("[INTERNAL_API] handle response called");
+        ba::post(*IPC::SocketServer::Instance().getIoContext(), [connectionId, message = std::string(response)] {
+            auto &socketServer = IPC::SocketServer::Instance();
+            if (!socketServer.isRunning()) return;
+
+            const auto connection = socketServer.getConnection(connectionId);
+            if (connection != nullptr && connection->isOpen()) {
+                connection->writeAsync(message);
+            }
+        });
+    }
+}

--- a/central_unit/src/core/api/internal_api.h
+++ b/central_unit/src/core/api/internal_api.h
@@ -204,7 +204,7 @@ namespace SmartHome::API {
             /// Vector storing parsed commands from ApiRequest structs
             std::vector<Command> commands;
             /// Flag representing if result must be sent in JSON-RPC-like structured response
-            bool structuredResult;
+            bool isResultStructured;
         };
 
         /**
@@ -218,7 +218,7 @@ namespace SmartHome::API {
             /// Vector of ApiResponse structs to be converted into string before sending
             std::vector<ApiResponse> apiResponses;
             /// Flag representing if result will be formated into JSON-RPC like object before conversion to string
-            bool structuredResult;
+            bool isResultStructured;
         };
 
         InternalApi() = default;

--- a/central_unit/src/core/api/internal_api.h
+++ b/central_unit/src/core/api/internal_api.h
@@ -1,0 +1,249 @@
+#pragma once
+#include "api.h"
+
+#include <string>
+#include <string_view>
+
+#include<nlohmann/json.hpp>
+
+namespace SmartHome::API {
+    /**
+     * @brief Internal API implementation for SmartHome system communication.
+     *
+     * @details Handles communication between SmartHome components using
+     *          command-based protocol with targets and methods.
+     */
+    class InternalApi final : public Api {
+    public:
+        /**
+         * @brief Supported method types for internal commands.
+         */
+        enum class MethodTypes: uint8_t {
+            /// Value returned on invalid stringToAction conversion
+            UNKNOWN = 0,
+            // Basic actions
+            GET,
+            SET,
+            EXECUTE,
+            //Debug actions
+            ECHO_REQUEST,
+            PING_REQUEST
+        };
+
+        /**
+         * @brief Valid targets for internal API commands.
+         */
+        enum class TargetTypes: uint8_t {
+            /// Value returned on invalid stringToTarget conversion
+            UNKNOWN = 0,
+            // Interfaces
+            CLI,
+            GUI,
+            WEB_SERVER,
+            // SmartHome system components
+            CORE,
+            MODULE_MEDIATOR,
+            DATABASE
+        };
+
+        /**
+         * @brief Method type wrapper with string conversion support.
+         */
+        struct Method {
+            MethodTypes type;
+
+            Method() = default;
+
+
+            /**
+             * @brief Construct from method type.
+             * @param value Method to set.
+             */
+            explicit Method(MethodTypes value);
+
+            /**
+             * @brief Construct from string representation.
+             * @param value String to parse into method.
+             */
+            explicit Method(std::string_view value);
+
+            /**
+             * @brief Convert method to string representation.
+             *
+             * @return String view of method name.
+             */
+            std::string_view to_string() const;
+
+            /**
+             * @brief Parse string to method type.
+             *
+             * @details Case-insensitive conversion from string to MethodTypes.
+             *
+             * @param value String to parse.
+             */
+            void to_action(std::string_view value);
+
+            /// Update method from string
+            Method operator()(std::string_view value);
+
+            /// Compare with another Method
+            bool operator==(const Method &other) const;
+
+            /// Compare with MethodTypes enum
+            bool operator==(MethodTypes other) const;
+
+        private:
+            static constexpr std::string_view msGET_STRING = "get";
+            static constexpr std::string_view msSET_STRING = "set";
+            static constexpr std::string_view msEXECUTE_STRING = "execute";
+            static constexpr std::string_view msECHO_STRING = "echo";
+            static constexpr std::string_view msPING_STRING = "ping";
+            static constexpr std::string_view msUNKNOWN_STRING = "unknown";
+        };
+
+        /**
+         * @brief Target type wrapper with string conversion support.
+         */
+        struct Target {
+            TargetTypes type;
+
+            Target() = default;
+
+            /**
+             * @brief Construct from target type.
+             * @param value Target to set.
+             */
+            explicit Target(TargetTypes value);
+
+            /**
+             * @brief Construct from string representation.
+             * @param value String to parse into method.
+             */
+            explicit Target(std::string_view value);
+
+            /**
+             * @brief Convert target to string representation.
+             *
+             * @return String view of target name.
+             */
+            std::string_view to_string() const;
+
+            /**
+             * @brief Parse string to target type.
+             *
+             * @details Case-insensitive conversion from string to TargetTypes.
+             *          Supports aliases (e.g., "web" for "web_server").
+             *
+             * @param value String to parse.
+             */
+            void to_target(std::string_view value);
+
+            /// Update target from string
+            Target operator()(std::string_view value);
+
+            /// Compare with another Target
+            bool operator==(const Target &other) const;
+
+            /// Compare with TargetTypes enum
+            bool operator==(TargetTypes other) const;
+
+        private:
+            static constexpr std::string_view msCLI_STRING = "cli";
+            static constexpr std::string_view msGUI_STRING = "gui";
+            static constexpr std::string_view msWEB_SERVER_STRING = "web_server";
+            static constexpr std::string_view msWEB_STRING = "web";
+            static constexpr std::string_view msCORE_STRING = "core";
+            static constexpr std::string_view msMODULE_MEDIATOR_STRING = "module_mediator";
+            static constexpr std::string_view msMEDIATOR_STRING = "mediator";
+            static constexpr std::string_view msDATABASE_STRING = "database";
+            static constexpr std::string_view msUNKNOWN_STRING = "unknown";
+        };
+
+
+        /**
+         * @brief Parsed command structure from API request.
+         */
+        struct Command {
+            std::optional<nlohmann::json> params; ///< Optional command parameters
+            ApiId commandId;   ///< Command identifier used for result response.
+            Method method;  ///< Command method to execute
+            Target target;  ///< Target component for command
+
+            /**
+             * @brief Construct command from API request.
+             *
+             * @param value ApiRequest to parse.
+             *
+             * @throws std::invalid_argument If params missing or target not specified.
+             *
+             * @note ApiRequest must contain params with \b target key and value corresponding to one of the values
+             *       in \c SmartHome::API::TargetTypes enum.\n
+             *       Any additional parameters must be assigned to a list under \b method_params key.
+             *       Parameters stored in \b method_params list can be of basic format or an object with key=value format.
+             *       Without additional parameters \b method_params may be omitted.
+             */
+            explicit Command(const ApiRequest &value);
+
+            /**
+             * @brief Construct command with specific values.
+             *
+             * @param params Command parameters.
+             * @param id Command identifier.
+             * @param method Method to execute.
+             * @param target Target component.
+             */
+            Command(const nlohmann::json &params, ApiId id, Method method, Target target);
+        };
+
+        /**
+         * @brief Internal request structure containing parsed commands.
+         */
+        struct Request {
+            /// Unique number for identifying ipc server connection, used for sending response
+            connectionId_t connectionId;
+            /// Vector storing parsed commands from ApiRequest structs
+            std::vector<Command> commands;
+            /// Flag representing if result must be sent in JSON-RPC-like structured response
+            bool structuredResult;
+        };
+
+        /**
+         * @brief Internal response structure for sending results.
+         *
+         * @note If responses vector is empty no response will be sent.
+         */
+        struct Response {
+            /// Unique number for identifying ipc server connection to which response will be sent
+            connectionId_t connectionId;
+            /// Vector of ApiResponse structs to be converted into string before sending
+            std::vector<ApiResponse> apiResponses;
+            /// Flag representing if result will be formated into JSON-RPC like object before conversion to string
+            bool structuredResult;
+        };
+
+        InternalApi() = default;
+
+        ~InternalApi() override = default;
+
+        /**
+         * @brief Handle incoming API request.
+         *
+         * @details Parses request string (JSON-RPC or raw format), creates internal
+         *          command structure, and forwards to CoreActions for processing.
+         *
+         * @param connectionId Connection identifier for response routing.
+         * @param request Request string to process.
+         */
+        void handleRequest(connectionId_t connectionId, std::string &&request) override;
+
+        /**
+         * @brief Handle outgoing API response.
+         *
+         * @details Posts response to IPC socket server for transmission to client.
+         *
+         * @param connectionId Connection identifier for response routing.
+         * @param response Response string to send.
+         */
+        void handleResponse(connectionId_t connectionId, std::string &&response) override;
+    };
+}

--- a/central_unit/src/core/core.cpp
+++ b/central_unit/src/core/core.cpp
@@ -109,10 +109,7 @@ namespace SmartHome {
         for (size_t i = 0; i < coreWorkerThreadCount; i++) {
             ba::post(*mCoreWorkerThreadPool, [this] { mCoreWorkerIoContext.run(); });
         }
-
-        logger->debugf("[TEST] Thread count ipc: %d, main: %d, worker %d", ipcThreadCount, coreThreadCount, coreWorkerThreadCount);
-        logger->debugf("[TEST] Config thread count values ipc: %d, main: %d, worker %d", mConfig.ipcServerThreads, mConfig.coreMainThreads, mConfig.coreWorkerThreads);
-
+        
         mIsInitialized.store(true);
         logger->debug("[CORE] Core successfully initialized");
 

--- a/central_unit/src/core/core.cpp
+++ b/central_unit/src/core/core.cpp
@@ -1,6 +1,7 @@
 #include "core.h"
 #include "config_manager.h"
 #include "service/service_manager.h"
+#include "core_actions.h"
 
 #include <chrono>
 #include <cmath>
@@ -32,23 +33,23 @@ namespace SmartHome {
             return false;
         }
 
-
         // Initialize AsyncLogger, using Logger for further initialization
-        mLogger = std::make_shared<Utils::AsyncLogger>(logger, mCoreIoContext);
+        mLogger = std::make_shared<Utils::AsyncLogger>(logger, mCoreUtilityIoContext);
 
-        mpService = Service::ServiceManager::create(logger, Utils::ServiceType::AUTO);
+        mpService = Service::ServiceManager::create(mLogger, Utils::ServiceType::AUTO);
         if (!mpService->onInitialize()) {
             logger->error("[CORE] Failed to initialize service");
-            stopCoreThread();
+            stopCoreUtilityThread();
             return false;
         }
         // Enable file logging after service init to avoid overwriting logs of already running instance
         logger->enableFileLoggingIfConfigured();
 
         // Create thread running io context for signal handling and service manager
-        mCoreGuard.emplace(ba::make_work_guard(mCoreIoContext));
-        mCoreThread = std::thread([this] {
-            mCoreIoContext.run();
+        mCoreUtilityGuard.emplace(ba::make_work_guard(mCoreUtilityIoContext));
+        mCoreUtilityThread = std::thread([this] {
+            // Unblock signals for utility thread
+            mCoreUtilityIoContext.run();
         });
 
 
@@ -56,40 +57,61 @@ namespace SmartHome {
         // Save config
         mConfig = configStruct;
 
-        // Set IPC server thread count
-        uint threadCount;
-
-        switch (mConfig.ipcServerThreads) {
-            case Config::HALF_CPU_CORES:
-                threadCount = std::ceil(std::thread::hardware_concurrency() / 2);
-                break;
-            case Config::ALL_CPU_CORES:
-                threadCount = std::thread::hardware_concurrency();
-                break;
-            default:
-                if (mConfig.ipcServerThreads > ms_HIGH_THREAD_COUNT_LIMIT) {
-                    logger->warningf("[CORE] IPC server thread count exceeds recommended limit (%d active threads)",
-                                    mConfig.ipcServerThreads);
-                }
-                threadCount = mConfig.ipcServerThreads;
-                break;
+        // get IPC server thread count
+        uint ipcThreadCount = getThreadCount(mConfig.ipcServerThreads);
+        if (ipcThreadCount > ms_HIGH_THREAD_COUNT_LIMIT) {
+            mLogger->warningf("[CORE] IPC server thread count exceeds recommended limit (%d active threads)",
+                              ipcThreadCount);
         }
-
-        if (threadCount < 1) {
-            logger->error("[CORE] IPC server thread count less than 1, setting value to 1");
-            threadCount = 1;
+        if (ipcThreadCount < 1) {
+            mLogger->error("[CORE] Invalid IPC server thread count value (less than 1), setting value to default");
+            ipcThreadCount = Config::TWO_THREADS;
         }
-
         //Create TCP server threads with io context
-        mSocketServerThreadPool.emplace(threadCount);
+        mSocketServerThreadPool.emplace(ipcThreadCount);
         mSocketServerGuard.emplace(ba::make_work_guard(mSocketServerIoContext));
-        for (size_t i = 0; i < threadCount; i++) {
+        for (size_t i = 0; i < ipcThreadCount; i++) {
             ba::post(*mSocketServerThreadPool, [this] {
                 mSocketServerIoContext.run();
             });
         }
-        IPC::SocketServer::Instance();
 
+        // get Core main thread count
+        uint coreThreadCount = getThreadCount(mConfig.coreMainThreads);
+        if (coreThreadCount > ms_HIGH_THREAD_COUNT_LIMIT) {
+            mLogger->warningf("[CORE] Core main thread count exceeds recommended limit (%d active threads)",
+                              coreThreadCount);
+        }
+        if (coreThreadCount < 1) {
+            mLogger->error("[CORE] Invalid Core main thread count value (less than 1), setting value to default");
+            coreThreadCount = Config::TWO_THREADS;
+        }
+        // Create Core main thread pool with io context
+        mCoreThreadPool.emplace(coreThreadCount);
+        mCoreGuard.emplace(ba::make_work_guard(mCoreIoContext));
+        for (size_t i = 0; i < coreThreadCount; i++) {
+            ba::post(*mCoreThreadPool, [this] { mCoreIoContext.run(); });
+        }
+
+        // get Core worker thread count
+        uint coreWorkerThreadCount = getThreadCount(mConfig.coreWorkerThreads);
+        if (coreWorkerThreadCount > ms_HIGH_THREAD_COUNT_LIMIT) {
+            mLogger->warningf("[CORE] Core worker thread count exceeds recommended limit (%d active threads)",
+                              coreWorkerThreadCount);
+        }
+        if (coreWorkerThreadCount < 1) {
+            mLogger->error("[CORE] Invalid Core worker thread count value (less than 1), setting value to default");
+            coreWorkerThreadCount = Config::SINGLE_THREAD;
+        }
+        // Create Core worker thread pool with io context
+        mCoreWorkerThreadPool.emplace(coreWorkerThreadCount);
+        mCoreWorkerGuard.emplace(ba::make_work_guard(mCoreWorkerIoContext));
+        for (size_t i = 0; i < coreWorkerThreadCount; i++) {
+            ba::post(*mCoreWorkerThreadPool, [this] { mCoreWorkerIoContext.run(); });
+        }
+
+        logger->debugf("[TEST] Thread count ipc: %d, main: %d, worker %d", ipcThreadCount, coreThreadCount, coreWorkerThreadCount);
+        logger->debugf("[TEST] Config thread count values ipc: %d, main: %d, worker %d", mConfig.ipcServerThreads, mConfig.coreMainThreads, mConfig.coreWorkerThreads);
 
         mIsInitialized.store(true);
         logger->debug("[CORE] Core successfully initialized");
@@ -121,49 +143,67 @@ namespace SmartHome {
 
         auto &socketServer = IPC::SocketServer::Instance();
         IPC::SocketServer::Config config = {mConfig.tcp, mConfig.uds};
+        mpApi = std::make_shared<API::InternalApi>();
 
-        if (!socketServer.initializeSocketServer(&mSocketServerIoContext, config, mLogger)) {
+        if (!socketServer.initializeSocketServer(&mSocketServerIoContext, config, mpApi, mLogger)) {
             mLogger->critical("[CORE] Failed to initialize IPC socket server");
             shutdown();
             return;
         }
-        socketServer.runSocketServer(&mSocketServerIoContext);
+        socketServer.runSocketServer();
 
+        //TODO implement watchdog working in CoreThread
+        mCoreThreadPool->join();
+        mCoreThreadPool.reset();
 
-        // Main loop
-        while (mIsRunning.load()) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
-            //TODO implement watchdog
-        }
         mLogger->debug("[CORE] Exiting");
-        stopCoreThread();
+        stopCoreUtilityThread();
     }
 
     void Core::shutdown() {
         //TODO add is shutting down check
         mLogger->debug("[CORE] Starting core shutdown");
 
-        // Stop core main loop
+        // Signal and initialize shutdown
         mIsRunning.store(false);
+        auto &ipcServer = IPC::SocketServer::Instance();
+        ipcServer.stopAcceptors();
 
-        mpService->onStop();
+        CoreActions::onCoreShutdown();
 
-        // Stop TCP server
-        if (mConfig.tcp.isEnabled) {
+        // Start shutdown timeout timer
+        ba::steady_timer shutdownTimeout(mCoreUtilityIoContext, std::chrono::milliseconds(ms_SHUTDOWN_TIMEOUT));
+        shutdownTimeout.async_wait([this](const bs::error_code &ec) {
+            if (!ec) {
+                mCoreWorkerThreadPool->stop();
+                mCoreThreadPool->stop();
+                mSocketServerThreadPool->stop();
+            }
+        });
+
+        // Join worker thread
+        mCoreWorkerGuard.reset();
+        mCoreWorkerThreadPool->join();
+
+        // Disable core thread guard for later join
+        mCoreGuard->reset();
+
+        // Stop IPC server
+        if (mConfig.tcp.isEnabled || mConfig.uds.isEnabled) {
             mLogger->debug("[CORE] Shutting down IPC socket server");
-            auto &tcpServer = IPC::SocketServer::Instance();
-            if (tcpServer.isRunning()) {
-                tcpServer.stopSocketServer();
+            if (ipcServer.isRunning()) {
+                ipcServer.stopSocketServer();
             }
         }
 
         // Waiting for IPC server threads to finish
         if (mSocketServerThreadPool.has_value()) {
             mSocketServerGuard.reset();
-            mSocketServerThreadPool->stop();
             mSocketServerThreadPool->join();
             mSocketServerThreadPool.reset();
         }
+
+        mpService->onStop();
 
         // Stop handling signals
         if (mSignals.has_value()) {
@@ -176,6 +216,15 @@ namespace SmartHome {
 
     bool Core::isRunning() const {
         return mIsRunning.load();
+    }
+
+    ba::io_context &Core::getCoreUtilityIoContext() {
+        return mCoreUtilityIoContext;
+    }
+
+
+    ba::io_context &Core::getCoreWorkerIoContext() {
+        return mCoreWorkerIoContext;
     }
 
     ba::io_context &Core::getCoreIoContext() {
@@ -210,11 +259,25 @@ namespace SmartHome {
         }
     }
 
-    void Core::stopCoreThread() {
-        if (mCoreThread.has_value()) {
-            mCoreGuard.reset();
-            mCoreThread->join();
-            mCoreThread.reset();
+    void Core::stopCoreUtilityThread() {
+        if (mCoreUtilityThread.has_value()) {
+            mCoreUtilityGuard.reset();
+            mCoreUtilityThread->join();
+            mCoreUtilityThread.reset();
         }
+    }
+
+    uint Core::getThreadCount(const int threadCountConfigValue) {
+        static const uint coreCount = std::thread::hardware_concurrency();
+
+        if (threadCountConfigValue == Config::ALL_CPU_CORES) {
+            return coreCount;
+        }
+        if (threadCountConfigValue < 0) {
+            // For negative values divide coreCount by |value| + 1
+            return std::ceil(coreCount / static_cast<double>(abs(threadCountConfigValue) + 1));
+        }
+
+        return threadCountConfigValue;
     }
 }

--- a/central_unit/src/core/core.cpp
+++ b/central_unit/src/core/core.cpp
@@ -135,11 +135,14 @@ namespace SmartHome {
         mpService->onStart();
 
         // Start signal handling
-        mSignals.emplace(mCoreIoContext, SIGINT, SIGTERM, SIGHUP); //TODO add more signals
+        mSignals.emplace(mCoreUtilityIoContext); //TODO add more signals
+        for (const auto &sig: ms_SIGNALS_TO_HANDLE) {
+            mSignals->add(sig);
+        }
+
         mSignals->async_wait([this](const bs::error_code &ec, const int sig) {
             signalHandler(ec, sig);
         });
-
 
         auto &socketServer = IPC::SocketServer::Instance();
         IPC::SocketServer::Config config = {mConfig.tcp, mConfig.uds};
@@ -231,31 +234,38 @@ namespace SmartHome {
         return mCoreIoContext;
     }
 
-
     void Core::signalHandler(const boost::system::error_code &ec, const int signal) {
+        mLogger->debug("[CORE] signalHandler called");
         if (!ec) {
             // Handle signal
             switch (signal) {
                 case SIGINT:
                 case SIGTERM:
-                    shutdown();
-                    break;
+                    ba::post(mCoreUtilityIoContext, [this] {
+                        shutdown();
+                    });
+                    return;
                 case SIGHUP:
                     mLogger->debug("[CORE] Not implemented");
                     //TODO implement reload
                     break;
                 default:
+                    mLogger->debug("[CORE] Undefined signal");
                     //TODO handle default
                     break;
             }
         } else {
             // Handle signal error
-            mLogger->errorf("[CORE] Signal handler error: %s", ec.message().c_str());
+            if (ec.value() == ba::error::operation_aborted) {
+                mLogger->debug("Signal handler aborted");
+            } else {
+                mLogger->errorf("[CORE] Signal handler error: %s", ec.message().c_str());
+            }
         }
         if (isRunning()) {
             mSignals->async_wait([this](const bs::error_code &e, const int sig) {
-               signalHandler(e, sig);
-           });
+                signalHandler(e, sig);
+            });
         }
     }
 

--- a/central_unit/src/core/core.cpp
+++ b/central_unit/src/core/core.cpp
@@ -48,7 +48,6 @@ namespace SmartHome {
         // Create thread running io context for signal handling and service manager
         mCoreUtilityGuard.emplace(ba::make_work_guard(mCoreUtilityIoContext));
         mCoreUtilityThread = std::thread([this] {
-            // Unblock signals for utility thread
             mCoreUtilityIoContext.run();
         });
 

--- a/central_unit/src/core/core.cpp
+++ b/central_unit/src/core/core.cpp
@@ -113,7 +113,7 @@ namespace SmartHome {
         mpService->onStart();
 
         // Start signal handling
-        mSignals.emplace(mCoreIoContext, SIGINT, SIGTERM); //TODO add more signals
+        mSignals.emplace(mCoreIoContext, SIGINT, SIGTERM, SIGHUP); //TODO add more signals
         mSignals->async_wait([this](const bs::error_code &ec, const int sig) {
             signalHandler(ec, sig);
         });
@@ -202,6 +202,11 @@ namespace SmartHome {
         } else {
             // Handle signal error
             mLogger->errorf("[CORE] Signal handler error: %s", ec.message().c_str());
+        }
+        if (isRunning()) {
+            mSignals->async_wait([this](const bs::error_code &e, const int sig) {
+               signalHandler(e, sig);
+           });
         }
     }
 

--- a/central_unit/src/core/core.h
+++ b/central_unit/src/core/core.h
@@ -3,6 +3,7 @@
 #include "socket_server.h"
 #include "service/service_manager.h"
 #include "async_logger.h"
+#include "api/internal_api.h"
 
 #include <atomic>
 #include <memory>
@@ -33,12 +34,32 @@ namespace SmartHome {
          */
         struct Config {
             enum IpcServerThreadCount : int {
+                QUARTER_CPU_CORES = -3,
+                THIRD_CPU_CORES = -2,
                 HALF_CPU_CORES = -1,
                 ALL_CPU_CORES = 0,
+                SINGLE_THREAD = 1,
+                TWO_THREADS = 2,
             };
 
-            /// Number of TCP server threads (-1: half CPU cores, 0: all CPU cores, n >= 1: exact thread count).
-            int ipcServerThreads = HALF_CPU_CORES;
+            /** Number of TCP server threads
+             * \li value < 0: ceil(all CPU cores / (|value| + 1))
+             * \li value == 0: all CPU cores
+             * \li value >= 1: exact thread count
+             */
+            int ipcServerThreads = TWO_THREADS;
+            /** Number of Core main threads
+             * \li value < 0: ceil(all CPU cores / (|value| + 1))
+             * \li value == 0: all CPU cores
+             * \li value >= 1: exact thread count
+             */
+            int coreMainThreads = TWO_THREADS;
+            /** Number of Core worker threads
+             * \li value < 0: ceil(all CPU cores / (|value| + 1))
+             * \li value == 0: all CPU cores
+             * \li value >= 1: exact thread count
+             */
+            int coreWorkerThreads = SINGLE_THREAD;
 
             /// Default TCP config from socket server
             IPC::SocketServer::Config::Tcp tcp;
@@ -99,9 +120,23 @@ namespace SmartHome {
         bool isRunning() const;
 
         /**
-         * @brief Core IO context getter
+         * @brief Core utility IO context getter.
          *
-         * @return core IO context
+         * @return Core utility IO context.
+         */
+        ba::io_context &getCoreUtilityIoContext();
+
+        /**
+         * @brief Core worker IO context getter.
+         *
+         * @return Core worker IO context.
+         */
+        ba::io_context &getCoreWorkerIoContext();
+
+        /**
+         * @brief Core IO context getter.
+         *
+         * @return Core IO context.
          */
         ba::io_context &getCoreIoContext();
 
@@ -129,12 +164,27 @@ namespace SmartHome {
         /**
          * @brief Stops core thread.
          */
-        void stopCoreThread();
+        void stopCoreUtilityThread();
+
+        /**
+         * @brief Parse thread count value from config to usable value for initializing thread pools.
+         *
+         * @details Parses values accordingly:
+         *          \li value < 0: ceil(all CPU cores / (|value| + 1))
+         *          \li value == 0: all CPU cores
+         *          \li value >= 1: exact thread count
+         *
+         * @param threadCountConfigValue Thread count value read from config file.
+         *
+         * @return Parsed thread count value.
+         */
+        static uint getThreadCount(int threadCountConfigValue);
 
         // Configuration
         Config mConfig;
 
         std::unique_ptr<Service::ServiceManager> mpService;
+        std::shared_ptr<API::InternalApi> mpApi;
 
         // Socket server resources
         ba::io_context mSocketServerIoContext;
@@ -142,10 +192,28 @@ namespace SmartHome {
         std::optional<ba::executor_work_guard<ba::io_context::executor_type> > mSocketServerGuard;
         static constexpr uint ms_HIGH_THREAD_COUNT_LIMIT = 128; ///< Limit for high thread count warning
 
-        // Signal handling resources
-        ba::io_context mCoreIoContext;
-        std::optional<std::thread> mCoreThread;
+        // Core utilities
+        /// Utility worker IO_context used for handling signals, logging and timeout timers.
+        ba::io_context mCoreUtilityIoContext;
+        /// Thread running utility IO_context
+        std::optional<std::thread> mCoreUtilityThread;
+        std::optional<ba::executor_work_guard<ba::io_context::executor_type> > mCoreUtilityGuard;
         std::optional<ba::signal_set> mSignals;
+        /// Signals defined to handle in signalHandler
+        static constexpr std::array ms_SIGNALS_TO_HANDLE = {SIGINT, SIGTERM, SIGHUP};
+        /// Shutdown timeout timer value in ms
+        static constexpr uint ms_SHUTDOWN_TIMEOUT = 5000;
+
+        //Core workers
+        ba::io_context mCoreWorkerIoContext;
+        std::optional<ba::thread_pool> mCoreWorkerThreadPool;
+        std::optional<ba::executor_work_guard<ba::io_context::executor_type> > mCoreWorkerGuard;
+
+        // Core main loop
+        /// Main event loop used for async operations, request routing, dispatching work
+        ba::io_context mCoreIoContext;
+        /// Thread pool running main event loop IO_context
+        std::optional<ba::thread_pool> mCoreThreadPool;
         std::optional<ba::executor_work_guard<ba::io_context::executor_type> > mCoreGuard;
 
         // State flags

--- a/central_unit/src/core/core_actions.cpp
+++ b/central_unit/src/core/core_actions.cpp
@@ -1,0 +1,621 @@
+#include "core_actions.h"
+#include "core.h"
+
+#include <memory>
+
+using sai = SmartHome::API::InternalApi;
+
+
+namespace SmartHome {
+    void CoreActions::handleRequest(const API::InternalApi::Request &request, const RequestCallback &callback) {
+        if (!Core::Instance().isRunning()) return;
+        const auto logger = Core::Instance().mLogger;
+        const auto requestId = getNextId();
+
+        // TODO add ActiveRequest limit
+
+        // Requests mutex block, attempt to insert new request into msActiveRequest map
+        {
+            std::scoped_lock lock(msActiveRequestsLock);
+            auto [_, inserted] = msActiveRequests.try_emplace(
+                requestId,
+                request,
+                std::make_shared<ba::steady_timer>(
+                    Core::Instance().getCoreUtilityIoContext(), std::chrono::milliseconds(ms_REQUEST_TIMEOUT)),
+                request.commands.size(),
+                callback
+            );
+
+            if (!inserted) {
+                logger->error("[CORE_ACTIONS] Handling new request failed: duplicate request ID");
+                return;
+            }
+        }
+
+        API::ApiError error;
+
+        // Responses mutex block, attempt to prepare response struct in msResponses map
+        {
+            std::scoped_lock lock(msResponsesLock);
+            auto [_, inserted] = msResponses.try_emplace(
+                requestId,
+                request.connectionId,
+                std::vector<API::ApiResponse>{},
+                request.structuredResult
+            );
+
+            if (!inserted) {
+                logger->error("[CORE_ACTIONS] Handling new request failed: Failed to create response object");
+                msActiveRequests.erase(requestId);
+                error.code = API::ErrorCodes::INTERNAL_ERROR;
+                error.data = "Failed to create response object for request";
+            }
+
+            try {
+                msResponses[requestId].apiResponses.reserve(request.commands.size());
+            } catch (const std::exception &e) {
+                logger->errorf("[CORE_ACTIONS] Handling new request failed on reserving responses space: %s", e.what());
+                std::scoped_lock lockAR(msActiveRequestsLock);
+                msActiveRequests.erase(requestId);
+                error.code = API::ErrorCodes::INTERNAL_ERROR;
+                error.data = e.what();
+            }
+        }
+
+        if (error.code != API::ErrorCodes::NO_ERROR) {
+            error.message = API::errorCodeToString(error.code);
+
+            API::ApiResponse response;
+            response.error = error;
+            response.id = API::ApiId(nullptr);
+
+            callback(request.connectionId, response.to_string());
+            return;
+        }
+
+        msActiveRequests.at(requestId).requestTimeoutTimer.load()->async_wait(
+            [requestId](const bs::error_code &ec) {
+                // Request mutex block, returns from callback if request is already completed or does not exist
+                {
+                    std::scoped_lock lock(msActiveRequestsLock);
+                    auto iter = msActiveRequests.find(requestId);
+                    if (iter == msActiveRequests.end() || iter->second.pendingCommands == 0) return;
+                }
+                if (!ec) handleRequestTimeout(requestId);
+            }
+        );
+
+        for (const auto &command: request.commands) {
+            CommandHandler handler = resolveCommand(command);
+            executeCommandAsync(handler, command, requestId);
+        }
+    }
+    void CoreActions::onCoreShutdown() {
+        auto cleanupTimeout = std::make_shared<ba::steady_timer>(Core::Instance().getCoreUtilityIoContext(),
+                                                                 std::chrono::milliseconds(ms_CLEANUP_TIMEOUT));
+        std::atomic_bool cleanupTimeoutCalled = false;
+        auto cleanup = [&cleanupTimeout, &cleanupTimeoutCalled]() {
+            auto expected = false;
+            if (cleanupTimeoutCalled.compare_exchange_strong(expected, true)) return;
+            cleanupTimeout->cancel();
+            std::scoped_lock lock(msActiveRequestsLock, msResponsesLock);
+            msActiveRequests.clear();
+            msResponses.clear();
+        };
+
+        cleanupTimeout->async_wait([cleanup](const bs::error_code &ec) {
+            if (!ec) {
+                cleanup();
+            }
+        });
+
+        // Requests mutex block, cancel active request and add command cancelled error result to responses
+        {
+            std::scoped_lock lock(msActiveRequestsLock);
+            for (auto &request: msActiveRequests | std::views::values) {
+                if (cleanupTimeoutCalled) break;
+                request.cancel();
+
+                for (auto &commandMD: request.commands) {
+                    constexpr bool lockMutex = false;
+                    if (cleanupTimeoutCalled) break;
+                    if (commandMD && commandMD->state == CommandMetadata::State::CANCELLED
+                        && commandMD->command.commandId.hasValue()) {
+                        API::ApiResponse timeoutResult;
+                        timeoutResult.id = commandMD->command.commandId;
+
+                        API::ApiError error;
+                        error.code = API::ErrorCodes::INTERNAL_ERROR;
+                        error.message = API::errorCodeToString(error.code);
+                        error.data = "Command cancelled: Core shutdown cancelled request";
+
+                        timeoutResult.error = error;
+
+                        addCommandResultToResponse(commandMD, std::move(timeoutResult));
+                    }
+                    updateRequestStatus(commandMD->requestId, lockMutex);
+                }
+            }
+        }
+    }
+    CoreActions::CommandKey::CommandKey(const sai::TargetTypes newTarget, const sai::MethodTypes newAction) {
+        target = newTarget;
+        action = newAction;
+    }
+    CoreActions::CommandKey::CommandKey(const API::InternalApi::Command &command) {
+        target = command.target.type;
+        action = command.method.type;
+    }
+
+    bool CoreActions::CommandKey::operator==(const CommandKey &other) const {
+        return target == other.target && action == other.action;
+    }
+
+
+    std::size_t CoreActions::CommandKeyHash::operator()(const CommandKey &key) const {
+        return static_cast<size_t>(key.target) << 8 | static_cast<size_t>(key.action);
+    }
+
+    CoreActions::CommandMetadata::CommandMetadata(API::InternalApi::Command command,
+                                                  std::shared_ptr<ba::steady_timer> commandTimeoutTimer,
+                                                  const apiId_t requestId)
+        : command(std::move(command)),
+          commandTimeoutTimer(std::move(commandTimeoutTimer)),
+          requestId(requestId) {
+    }
+
+    bool CoreActions::CommandMetadata::cancel() {
+        if (auto timer = commandTimeoutTimer.exchange(nullptr)) timer->cancel();
+        auto expected = State::PENDING;
+        if (state.compare_exchange_strong(expected, State::CANCELLED)) return true;
+        return false;
+    }
+
+
+    bool CoreActions::CommandMetadata::isPending() const {
+        if (state.load(std::memory_order::relaxed) == State::PENDING) {
+            return true;
+        }
+        return false;
+    }
+
+
+    CoreActions::RequestMetadata::RequestMetadata(API::InternalApi::Request request,
+                                                  std::shared_ptr<ba::steady_timer> requestTimeoutTimer,
+                                                  const size_t pendingCommands,
+                                                  RequestCallback onComplete)
+        : request(std::move(request)),
+          requestTimeoutTimer(std::move(requestTimeoutTimer)),
+          pendingCommands(pendingCommands),
+          onComplete(std::move(onComplete)) {
+    }
+
+    void CoreActions::RequestMetadata::cancel() {
+        if (pendingCommands == 0) return;
+
+        if (auto reqTimer = requestTimeoutTimer.exchange(nullptr)) reqTimer->cancel();
+
+        for (auto &command: commands) {
+            command->cancel();
+        }
+    }
+
+    apiId_t CoreActions::getNextId() {
+        static std::atomic<apiId_t> id{0};
+        return id.fetch_add(1, std::memory_order::seq_cst) + 1;
+    }
+
+
+    CoreActions::CommandHandler CoreActions::resolveCommand(const API::InternalApi::Command &command) {
+        const auto iter = msCommandsRegistry.find(CommandKey(command));
+        return iter != msCommandsRegistry.end() ? iter->second : nullptr;
+    }
+
+    void CoreActions::executeCommandAsync(CommandHandler handler,
+                                          API::InternalApi::Command newCommand,
+                                          apiId_t requestId) {
+        auto commandMetadata = std::make_shared<CommandMetadata>(
+            newCommand,
+            std::make_shared<ba::steady_timer>(Core::Instance().getCoreUtilityIoContext()),
+            requestId
+        );
+
+        // Request mutex block, add command metadata to request metadata
+        {
+            std::scoped_lock lock(msActiveRequestsLock);
+            msActiveRequests.at(requestId).commands.push_back(commandMetadata);
+        }
+
+
+        if (!handler) {
+            API::ApiError error;
+            auto &&command = commandMetadata->command;
+
+            // Handle parse error signaled by ApiError struct in command.params with UNKNOWN Target and Method
+            if (command.params.has_value() &&
+                command.target == sai::TargetTypes::UNKNOWN &&
+                command.method == sai::MethodTypes::UNKNOWN) {
+                try {
+                    error = API::ApiError(command.params.value());
+                } catch (const std::exception &e) {
+                    error.code = API::ErrorCodes::INTERNAL_ERROR;
+                    error.data = "Unexpected error while parsing error: " + std::string(e.what());
+                }
+            }
+
+            if (error.code == API::ErrorCodes::NO_ERROR) {
+                if (command.target == sai::TargetTypes::UNKNOWN) {
+                    error.code = API::ErrorCodes::INVALID_PARAMS;
+                    error.data = "Unknown target - target key value missing or invalid";
+                } else if (command.method == sai::MethodTypes::UNKNOWN) {
+                    error.code = API::ErrorCodes::METHOD_NOT_FOUND;
+                    error.data = "Unknown method - method key value missing or invalid ";
+                } else {
+                    error.code = API::ErrorCodes::INTERNAL_ERROR;
+                    error.data = "Undefined command";
+                }
+            }
+
+            error.message = errorCodeToString(error.code);
+
+            API::ApiResponse response;
+            response.error = error;
+            response.id = commandMetadata->command.commandId;
+
+            handleCommandResult(commandMetadata, std::move(response));
+
+            return;
+        }
+
+        ba::co_spawn(Core::Instance().getCoreIoContext(),
+                     processCommand(commandMetadata, handler),
+                     ba::detached);
+    }
+
+
+    ba::awaitable<void> CoreActions::processCommand(std::shared_ptr<CommandMetadata> commandMetadata,
+                                                    const CommandHandler handler) {
+        API::ApiResponse response;
+
+        try {
+            response = co_await handler(commandMetadata);
+        } catch (std::exception &exception) {
+            API::ApiError error;
+            error.code = API::ErrorCodes::INTERNAL_ERROR;
+            error.message = API::errorCodeToString(error.code);
+            error.data = exception.what();
+
+            response.error = error;
+            response.id = commandMetadata->command.commandId;
+        }
+
+        if (auto timer = commandMetadata->commandTimeoutTimer.exchange(nullptr)) timer->cancel();
+        handleCommandResult(commandMetadata, std::move(response));
+        co_return;
+    }
+
+    void CoreActions::startCommandTimeoutTimer(const std::shared_ptr<CommandMetadata> &commandMetadata) {
+        if (auto timer = commandMetadata->commandTimeoutTimer.load()) {
+            timer->expires_after(std::chrono::milliseconds(ms_COMMAND_TIMEOUT));
+            timer->async_wait([commandMetadata](const bs::error_code &ec) {
+                if (!ec) {
+                    handleCommandTimeout(commandMetadata);
+                } else {
+                    commandMetadata->cancel();
+                }
+            });
+        }
+    }
+
+
+    void CoreActions::handleCommandResult(const std::shared_ptr<CommandMetadata> &commandMetadata,
+                                          API::ApiResponse &&commandResult) {
+        if (auto timer = commandMetadata->commandTimeoutTimer.exchange(nullptr)) timer->cancel();
+
+        auto expected = CommandMetadata::State::PENDING;
+        if (!commandMetadata->state.compare_exchange_strong(expected, CommandMetadata::State::COMPLETED)) {
+            return;
+        }
+
+        // Add response only if command has an ID
+        // As defined in JSON-RPC docs request w/o ID is a notification — response must not be sent in return
+        if (!commandMetadata->command.commandId.isUndefined()) {
+            addCommandResultToResponse(commandMetadata, std::move(commandResult));
+        }
+        updateRequestStatus(commandMetadata->requestId);
+    }
+
+    void CoreActions::handleCommandTimeout(const std::shared_ptr<CommandMetadata> &commandMetadata) {
+        if (auto timer = commandMetadata->commandTimeoutTimer.exchange(nullptr)) timer->cancel();
+
+        auto expected = CommandMetadata::State::PENDING;
+        if (!commandMetadata->state.compare_exchange_strong(expected, CommandMetadata::State::TIMED_OUT)) return;
+
+        if (commandMetadata->command.commandId.hasValue()) {
+            API::ApiResponse timeoutResponse;
+            timeoutResponse.id = commandMetadata->command.commandId;
+
+            API::ApiError error;
+            error.code = API::ErrorCodes::INTERNAL_ERROR;
+            error.message = API::errorCodeToString(error.code);
+            error.data = "Command timeout: exceeded " + std::to_string(ms_COMMAND_TIMEOUT) + "ms timeout";
+
+            timeoutResponse.error = error;
+
+            addCommandResultToResponse(commandMetadata, std::move(timeoutResponse));
+        }
+        updateRequestStatus(commandMetadata->requestId);
+
+
+        Core::Instance().mLogger->errorf("[CORE_ACTIONS] Command timeout - request ID: %d command ID: %s",
+                                         commandMetadata->requestId,
+                                         commandMetadata->command.commandId.hasValue()
+                                             ? std::to_string(commandMetadata->command.commandId.value()).c_str()
+                                             : "null");
+    }
+
+    void CoreActions::addCommandResultToResponse(const std::shared_ptr<CommandMetadata> &commandMetadata,
+                                                 API::ApiResponse &&apiResponse) {
+        std::scoped_lock lock(msResponsesLock);
+        auto iter = msResponses.find(commandMetadata->requestId);
+        if (iter != msResponses.end()) {
+            iter->second.apiResponses.push_back(std::move(apiResponse));
+        }
+    }
+
+    void CoreActions::updateRequestStatus(const apiId_t requestId, const bool lockMutex) {
+        if (lockMutex) std::scoped_lock lock(msActiveRequestsLock);
+        auto iter = msActiveRequests.find(requestId);
+        if (iter != msActiveRequests.end()) {
+            auto &request = iter->second;
+            if (request.pendingCommands.fetch_sub(1) == 1) {
+                if (auto reqTimer = request.requestTimeoutTimer.load()) reqTimer->cancel();
+                ba::post(Core::Instance().getCoreIoContext(), [requestId] {
+                    handleResponse(requestId);
+                    cleanupRequest(requestId);
+                });
+            }
+        }
+    }
+
+    void CoreActions::handleRequestTimeout(const apiId_t requestId) {
+        Core::Instance().mLogger->errorf("[CORE_ACTIONS] Request timeout - request ID: %d", requestId);
+
+        std::vector<CommandMetadataPtr> commandsMD;
+
+        // Request mutex block, cancel request and copy commandPtr vector
+        {
+            std::scoped_lock lock(msActiveRequestsLock);
+            auto iter = msActiveRequests.find(requestId);
+            if (iter == msActiveRequests.end()) return;
+
+            iter->second.cancel();
+            commandsMD = iter->second.commands;
+        }
+
+        for (auto &commandMD: commandsMD) {
+            if (commandMD && commandMD->state == CommandMetadata::State::CANCELLED
+                && commandMD->command.commandId.hasValue()) {
+                API::ApiResponse timeoutResult;
+                timeoutResult.id = commandMD->command.commandId;
+
+                API::ApiError error;
+                error.code = API::ErrorCodes::INTERNAL_ERROR;
+                error.message = API::errorCodeToString(error.code);
+                error.data = "Command cancelled: request exceeded " + std::to_string(ms_REQUEST_TIMEOUT) + "ms timeout";
+
+                timeoutResult.error = error;
+
+                addCommandResultToResponse(commandMD, std::move(timeoutResult));
+                updateRequestStatus(commandMD->requestId);
+            }
+        }
+    }
+
+    void CoreActions::cleanupRequest(const apiId_t requestId) {
+        std::scoped_lock lock(msActiveRequestsLock, msResponsesLock);
+
+        auto iter = msActiveRequests.find(requestId);
+        if (iter != msActiveRequests.end()) {
+            if (auto reqTimer = iter->second.requestTimeoutTimer.load()) reqTimer->cancel();
+            for (auto &command: iter->second.commands) {
+                if (command == nullptr || command->commandTimeoutTimer.load() == nullptr) continue;
+                command->commandTimeoutTimer.load()->cancel();
+            }
+        }
+
+        msActiveRequests.erase(requestId);
+        msResponses.erase(requestId);
+    }
+
+    void CoreActions::handleResponse(const apiId_t responseId) {
+        const auto logger = Core::Instance().mLogger;
+        RequestCallback requestCallback;
+        std::string responseString;
+        connectionId_t id;
+
+        std::vector<API::ApiResponse> responsesVector;
+        bool isStructured;
+
+        // Responses mutex block, copy responses vector
+        {
+            std::scoped_lock lock(msResponsesLock);
+            const auto iter = msResponses.find(responseId);
+            if (iter == msResponses.end()) {
+                logger->errorf("[CORE_ACTIONS] [HANDLE_RESPONSE] response for request [ID:%d] not found", responseId);
+                return;
+            }
+            const auto &internalResponse = iter->second;
+            responsesVector = internalResponse.apiResponses;
+            isStructured = internalResponse.structuredResult;
+        }
+
+        if (responsesVector.empty()) return;
+
+        // Request mutex block, copy onComplete callback and connection id
+        {
+            std::scoped_lock lock(msActiveRequestsLock);
+            const auto iter = msActiveRequests.find(responseId);
+            if (iter == msActiveRequests.end()) {
+                logger->errorf("[CORE_ACTIONS] [HANDLE_RESPONSE] request [ID:%d] metadata not found", responseId);
+                return;
+            }
+            const auto &requestMetadata = iter->second;
+            id = requestMetadata.request.connectionId;
+            requestCallback = requestMetadata.onComplete;
+        }
+
+        if (isStructured) {
+            nlohmann::json json;
+            if (responsesVector.size() > 1) {
+                json = nlohmann::json::array();
+                for (auto &response: responsesVector) {
+                    json.push_back(response.to_json());
+                }
+            } else {
+                json = responsesVector[0].to_json();
+            }
+            responseString = json.dump();
+        } else {
+            std::string appendToResponse;
+            for (auto &response: responsesVector) {
+                if (response.result.has_value()) {
+                    appendToResponse = response.result.value();
+                } else if (response.error.has_value()) {
+                    auto &error = response.error.value();
+                    appendToResponse = error.message + ": " + error.data;
+                } else {
+                    appendToResponse = "Internal error: invalid response (missing response or error data)";
+                }
+                responseString += appendToResponse + ",";
+            }
+            responseString.erase(responseString.size() - 1);
+        }
+
+        requestCallback(id, std::move(responseString));
+    }
+
+    std::unordered_map<CoreActions::CommandKey, CoreActions::CommandHandler, CoreActions::CommandKeyHash>
+    CoreActions::msCommandsRegistry =
+    {
+        // TODO implement actions needed for basic functionality
+        //Core
+        {{sai::TargetTypes::CORE, sai::MethodTypes::GET}, placeholderHandler},
+        {{sai::TargetTypes::CORE, sai::MethodTypes::SET}, placeholderHandler},
+        {{sai::TargetTypes::CORE, sai::MethodTypes::EXECUTE}, placeholderHandler},
+        {{sai::TargetTypes::CORE, sai::MethodTypes::ECHO_REQUEST}, coreEchoHandler},
+        {{sai::TargetTypes::CORE, sai::MethodTypes::PING_REQUEST}, placeholderHandler},
+        //Mediator
+        {{sai::TargetTypes::MODULE_MEDIATOR, sai::MethodTypes::GET}, placeholderHandler},
+        {{sai::TargetTypes::MODULE_MEDIATOR, sai::MethodTypes::SET}, placeholderHandler},
+        {{sai::TargetTypes::MODULE_MEDIATOR, sai::MethodTypes::EXECUTE}, placeholderHandler},
+        {{sai::TargetTypes::MODULE_MEDIATOR, sai::MethodTypes::PING_REQUEST}, placeholderHandler},
+        //Database
+        {{sai::TargetTypes::DATABASE, sai::MethodTypes::GET}, placeholderHandler},
+        {{sai::TargetTypes::DATABASE, sai::MethodTypes::SET}, placeholderHandler},
+        {{sai::TargetTypes::DATABASE, sai::MethodTypes::EXECUTE}, placeholderHandler},
+        {{sai::TargetTypes::DATABASE, sai::MethodTypes::PING_REQUEST}, placeholderHandler},
+        //CLI
+        {{sai::TargetTypes::CLI, sai::MethodTypes::SET}, placeholderHandler},
+        {{sai::TargetTypes::CLI, sai::MethodTypes::EXECUTE}, placeholderHandler},
+        //GUI
+        {{sai::TargetTypes::GUI, sai::MethodTypes::SET}, placeholderHandler},
+        {{sai::TargetTypes::GUI, sai::MethodTypes::EXECUTE}, placeholderHandler},
+        //Webserver
+        {{sai::TargetTypes::WEB_SERVER, sai::MethodTypes::GET}, placeholderHandler},
+        {{sai::TargetTypes::WEB_SERVER, sai::MethodTypes::SET}, placeholderHandler},
+        {{sai::TargetTypes::WEB_SERVER, sai::MethodTypes::EXECUTE}, placeholderHandler},
+        {{sai::TargetTypes::WEB_SERVER, sai::MethodTypes::PING_REQUEST}, placeholderHandler}
+    };
+
+    std::unordered_map<apiId_t, CoreActions::RequestMetadata> CoreActions::msActiveRequests;
+
+    std::mutex CoreActions::msActiveRequestsLock;
+
+    std::unordered_map<apiId_t, API::InternalApi::Response> CoreActions::msResponses;
+
+    std::mutex CoreActions::msResponsesLock;
+
+    // ======================================== CommandHandler functions ========================================
+
+    // THIS PLACEHOLDER IS AN EXAMPLE AND IT SHOULD BE USED AS A TEMPLATE FOR OTHER COMMAND HANDLERS.
+    ba::awaitable<API::ApiResponse> CoreActions::placeholderHandler(
+        const std::shared_ptr<CommandMetadata> &commandMetadata) {
+        // Optional debug log
+        Core::Instance().mLogger->debug("[CORE_ACTIONS] [PLACEHOLDER] called");
+        // Universal command variables' definition.
+        const auto &command = commandMetadata->command;
+        API::ApiResponse commandResult;
+        commandResult.id = command.commandId;
+
+        // Define variables for operation use.
+        int operationDuration = 15; // In seconds
+
+        // Check for params and handle them accordingly.
+        if (command.params.has_value()) {
+            const auto &params = command.params.value();
+            if (params.is_array() && params.size() > 0 && params[0].is_number()) {
+                operationDuration = params[0].get<int>();
+            }
+        }
+
+        // For longer operations use async functions and post any long blocking operations to coreWorkerIoContext.
+        // Shorter operations that can be executed without any wait may be implemented as synchronous operations.
+        auto promise = std::make_shared<std::promise<std::string> >();
+        auto future = promise->get_future();
+
+        // Be sure to implement timeouts and periodic isPending checks to avoid infinitely running operations.
+        ba::post(Core::Instance().getCoreWorkerIoContext(), [promise, commandMetadata, operationDuration]() {
+            // This example simulates chain of operations with periodic checking for cancellation and command timeout.
+            // While command timeout is not needed as request timeout exists, it is advised to use it especially for
+            // longer operations in batch requests.
+            startCommandTimeoutTimer(commandMetadata);
+
+            for (int i = 0; i < operationDuration * 10; i++) {
+                if (!commandMetadata->isPending()) {
+                    promise->set_exception(std::make_exception_ptr(std::runtime_error("Operation cancelled")));
+                    return;
+                }
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            }
+            promise->set_value("Operation finished successfully");
+        });
+
+        // Wait asynchronously for long operation result.
+        while (future.wait_for(std::chrono::milliseconds(25)) != std::future_status::ready) {
+            co_await ba::steady_timer(co_await ba::this_coro::executor,
+                                      std::chrono::milliseconds(75)).async_wait(ba::use_awaitable);
+        }
+
+        // Handle and return result or error.
+        try {
+            commandResult.result = future.get();
+        } catch (const std::exception &e) {
+            commandResult.error = API::ApiError(
+                API::ErrorCodes::INTERNAL_ERROR,
+                API::errorCodeToString(API::ErrorCodes::INTERNAL_ERROR).data(),
+                e.what()
+            );
+        }
+        co_return commandResult;
+    }
+
+    ba::awaitable<API::ApiResponse> CoreActions::coreEchoHandler(
+        const std::shared_ptr<CommandMetadata> &commandMetadata) {
+        Core::Instance().mLogger->debug("[CORE_ACTIONS] [CORE_ECHO] called");
+        const auto &command = commandMetadata->command;
+        API::ApiResponse commandResult;
+        commandResult.id = command.commandId;
+
+        std::string message;
+
+        if (command.params.has_value()) {
+            const auto &params = command.params.value();
+            message = params.dump();
+        }
+
+        commandResult.result = "Core Echo response: " + message;
+
+        co_return commandResult;
+    }
+}

--- a/central_unit/src/core/core_actions.cpp
+++ b/central_unit/src/core/core_actions.cpp
@@ -41,7 +41,7 @@ namespace SmartHome {
                 requestId,
                 request.connectionId,
                 std::vector<API::ApiResponse>{},
-                request.structuredResult
+                request.isResultStructured
             );
 
             if (!inserted) {
@@ -447,7 +447,7 @@ namespace SmartHome {
             }
             const auto &internalResponse = iter->second;
             responsesVector = internalResponse.apiResponses;
-            isStructured = internalResponse.structuredResult;
+            isStructured = internalResponse.isResultStructured;
         }
 
         if (responsesVector.empty()) return;

--- a/central_unit/src/core/core_actions.h
+++ b/central_unit/src/core/core_actions.h
@@ -1,0 +1,314 @@
+#pragma once
+#include "api/internal_api.h"
+
+#include <boost/asio.hpp>
+
+namespace ba = boost::asio;
+
+namespace SmartHome {
+    /**
+     * @brief Core actions handler for processing internal API commands.
+     *
+     * @details Manages command registry, request lifecycle, and asynchronous
+     *          execution of API commands with timeout handling.
+     */
+    class CoreActions {
+    public:
+        /// Callback type for request completion notification
+        using RequestCallback = std::function<void(connectionId_t connectionId, std::string &&response)>;
+
+        /**
+         * @brief Process incoming API request.
+         *
+         * @details Creates request metadata, validates commands, starts timeout timers,
+         *          and initiates asynchronous command execution.
+         *
+         * @param request Internal API request structure.
+         * @param callback Function called when request processing completes.
+         */
+        static void handleRequest(const API::InternalApi::Request &request, const RequestCallback &callback);
+
+        /**
+         * @brief Cleanup handler for core shutdown.
+         *
+         * @details Cancels all active requests and commands, adds cancellation
+         *          errors to responses, and clears request/response maps.
+         */
+        static void onCoreShutdown();
+
+    private:
+        /**
+         * @brief Command registry key for target-method pairs.
+         */
+        struct CommandKey {
+            API::InternalApi::TargetTypes target; ///< Command target component
+            API::InternalApi::MethodTypes action; ///< Command action type
+
+            CommandKey() = default;
+
+            /**
+             * @brief Construct key from target and action types.
+             *
+             * @param newTarget Target component type.
+             * @param newAction Method type.
+             */
+            CommandKey(API::InternalApi::TargetTypes newTarget, API::InternalApi::MethodTypes newAction);
+
+            /**
+             * @brief Extract key from command structure.
+             *
+             * @param command Command to extract key from.
+             */
+            explicit CommandKey(const API::InternalApi::Command &command);
+
+            /// Compare with another CommandKey
+            bool operator==(const CommandKey &other) const;
+        };
+
+        /**
+         * @brief Hash function for CommandKey map usage.
+         */
+        struct CommandKeyHash {
+            /// Calculate hash value for command key.
+            std::size_t operator()(const CommandKey &key) const;
+        };
+
+        /**
+         * @brief Command execution metadata and state tracking.
+         */
+        struct CommandMetadata {
+            /**
+             * @brief Command execution states.
+             */
+            enum class State : uint8_t {
+                PENDING = 0,
+                COMPLETED = 1,
+                CANCELLED = 2,
+                TIMED_OUT = 3
+            };
+
+            /// Command data
+            API::InternalApi::Command command;
+            /// Command-specific timeout timer
+            std::atomic<std::shared_ptr<ba::steady_timer> > commandTimeoutTimer;
+            /// Parent request ID
+            apiId_t requestId;
+            /// Current command state
+            std::atomic<State> state{State::PENDING};
+
+            /**
+             * @brief Construct command metadata.
+             *
+             * @param command Command to execute.
+             * @param commandTimeoutTimer Timer for command timeout.
+             * @param requestId Parent request identifier.
+             */
+            CommandMetadata(API::InternalApi::Command command,
+                            std::shared_ptr<ba::steady_timer> commandTimeoutTimer,
+                            apiId_t requestId);
+
+            /**
+             * @brief Cancel command execution.
+             *
+             * @return true if successfully cancelled, false if already completed.
+             */
+            bool cancel();
+
+            /**
+             * @brief Check if command is still pending.
+             *
+             * @return true if command state is PENDING, false otherwise.
+             */
+            bool isPending() const;
+        };
+
+        using CommandMetadataPtr = std::shared_ptr<CommandMetadata>;
+
+        /**
+         * @brief Request metadata containing all commands and state.
+         */
+        struct RequestMetadata {
+            /// Original request data
+            API::InternalApi::Request request;
+            /// Command metadata pointers
+            std::vector<CommandMetadataPtr> commands;
+            /// Request-level timeout timer
+            std::atomic<std::shared_ptr<ba::steady_timer> > requestTimeoutTimer;
+            /// Count of incomplete commands
+            std::atomic<size_t> pendingCommands;
+            /// Completion callback
+            RequestCallback onComplete;
+
+            /**
+             * @brief Construct request metadata.
+             *
+             * @param request Original API request.
+             * @param requestTimeoutTimer Timer for request timeout.
+             * @param pendingCommands Initial pending command count.
+             * @param onComplete Callback for request completion.
+             */
+            RequestMetadata(API::InternalApi::Request request,
+                            std::shared_ptr<ba::steady_timer> requestTimeoutTimer,
+                            size_t pendingCommands,
+                            RequestCallback onComplete);
+
+
+            /**
+             * @brief Cancel all commands in request.
+             */
+            void cancel();
+        };
+
+        /**
+         * @brief Generate unique request ID.
+         *
+         * @return Next sequential ID value.
+         */
+        static apiId_t getNextId();
+
+
+        /**
+         * @brief Command handler function type.
+         *
+         * @details Handlers receive command metadata and return API response asynchronously.
+         */
+        using CommandHandler = std::function<ba::awaitable<API::ApiResponse>(const std::shared_ptr<CommandMetadata> &)>;
+
+        /**
+         * @brief Lookup command handler from registry.
+         *
+         * @param command Command to resolve handler for.
+         * @return Handler function or nullptr if not found.
+         */
+        static CommandHandler resolveCommand(const API::InternalApi::Command &command);
+
+
+        /**
+         * @brief Execute command asynchronously.
+         *
+         * @details Creates command metadata, validates handler, and spawns coroutine.
+         *
+         * @param handler Command handler function.
+         * @param newCommand Command to execute.
+         * @param requestId Parent request identifier.
+         */
+        static void executeCommandAsync(CommandHandler handler,
+                                        API::InternalApi::Command newCommand,
+                                        apiId_t requestId);
+
+        /**
+         * @brief Coroutine for command processing.
+         *
+         * @param commandMetadata Command execution metadata.
+         * @param handler Command handler function.
+         * @return Awaitable void result.
+         */
+        static ba::awaitable<void> processCommand(std::shared_ptr<CommandMetadata> commandMetadata,
+                                                  CommandHandler handler);
+
+        /**
+         * @brief Start command timeout timer.
+         *
+         * @param commandMetadata Command to set timeout for.
+         */
+        static void startCommandTimeoutTimer(const std::shared_ptr<CommandMetadata> &commandMetadata);
+
+        /**
+         * @brief Process command execution result.
+         *
+         * @param commandMetadata Command that completed.
+         * @param commandResult Result from command handler.
+         */
+        static void handleCommandResult(const std::shared_ptr<CommandMetadata> &commandMetadata,
+                                        API::ApiResponse &&commandResult);
+
+        /**
+         * @brief Handle command timeout expiration.
+         *
+         * @param commandMetadata Timed-out command metadata.
+         */
+        static void handleCommandTimeout(const std::shared_ptr<CommandMetadata> &commandMetadata);
+
+        /**
+         * @brief Add command result to response collection.
+         *
+         * @param commandMetadata Command metadata with request ID.
+         * @param apiResponse Response to add.
+         */
+        static void addCommandResultToResponse(const std::shared_ptr<CommandMetadata> &commandMetadata,
+                                               API::ApiResponse &&apiResponse);
+
+        /**
+         * @brief Update request completion status.
+         *
+         * @details Decrements pending count and triggers response if complete.
+         *
+         * @param requestId Request to update.
+         * @param lockMutex Whether to lock mutex (false if already locked).
+         */
+        static void updateRequestStatus(apiId_t requestId, bool lockMutex = true);
+
+        /**
+         * @brief Handle request timeout expiration.
+         *
+         * @param requestId Timed-out request identifier.
+         */
+        static void handleRequestTimeout(apiId_t requestId);
+
+        /**
+         * @brief Cleanup request resources.
+         *
+         * @param requestId Request to cleanup.
+         */
+        static void cleanupRequest(apiId_t requestId);
+
+        /**
+         * @brief Send aggregated response for request.
+         *
+         * @param responseId Response identifier matching request ID.
+         */
+        static void handleResponse(apiId_t responseId);
+
+        /// Registry mapping command keys to handler functions
+        static std::unordered_map<CommandKey, CommandHandler, CommandKeyHash> msCommandsRegistry;
+
+        /// Active request tracking map
+        static std::unordered_map<apiId_t, RequestMetadata> msActiveRequests;
+        /// Mutex for active requests map access
+        static std::mutex msActiveRequestsLock;
+
+        /// Response collection map
+        static std::unordered_map<apiId_t, API::InternalApi::Response> msResponses;
+        /// Mutex for responses map access
+        static std::mutex msResponsesLock;
+
+        static constexpr uint ms_REQUEST_TIMEOUT = 30000; ///< Request timeout timer duration in ms
+        static constexpr uint ms_COMMAND_TIMEOUT = 15000; ///< Command timeout timer duration in ms
+        static constexpr uint ms_CLEANUP_TIMEOUT = 5000; ///< Timeout used in onCoreShutdown in ms
+
+        // ======================================== CommandHandler functions ========================================
+
+        /**
+         * @brief Placeholder handler for unimplemented commands.
+         *
+         * @details Template implementation demonstrating proper async handling,
+         *          timeout management, and cancellation checking.
+         *
+         * @param commandMetadata Command execution metadata.
+         * @return API response with result or error.
+         */
+        static ba::awaitable<API::ApiResponse> placeholderHandler(
+            const std::shared_ptr<CommandMetadata> &commandMetadata);
+
+        /**
+         * @brief Echo handler for core testing.
+         *
+         * @details Returns command parameters in response message.
+         *
+         * @param commandMetadata Command execution metadata.
+         * @return API response with echoed parameters.
+         */
+        static ba::awaitable<API::ApiResponse> coreEchoHandler(
+            const std::shared_ptr<CommandMetadata> &commandMetadata);
+    };
+}

--- a/central_unit/src/core/main.cpp
+++ b/central_unit/src/core/main.cpp
@@ -32,6 +32,10 @@ namespace SmartHome {
         configManager.getValue(root + ".config_path", mediatorConfig.configPath);
 
         // Core config
+        root = "core";
+        configManager.getValue(root +".main_threads", coreConfig.coreMainThreads);
+        configManager.getValue(root +".worker_threads", coreConfig.coreWorkerThreads);
+
         root = "core.ipc";
         configManager.getValue(root + ".threads", coreConfig.ipcServerThreads);
 
@@ -92,7 +96,7 @@ namespace SmartHome {
             logTmpOpt.isVerbositySet = true;
         }
 
-        if (logTmpOpt.isVerbositySet) logger->setLevel(Utils::LogLevels::toLevel(logTmpOpt.verboseLevel));;
+        if (logTmpOpt.isVerbositySet) logger->setLevel(Utils::LogLevels::toLevel(logTmpOpt.verboseLevel));
 
         // Load YAML config
         auto configManager = Utils::ConfigManager(logger);
@@ -158,7 +162,7 @@ int main(int argc, char *argv[]) {
     // Define instances
     auto &core = Core::Instance();
     bp::child mediator;
-    auto logger = std::make_shared<SmartHome::Utils::Logger>();
+    auto logger = std::make_shared<Utils::Logger>();
 
     // Define config structs with default values
     Core::Config coreConfig;

--- a/central_unit/src/core/service/systemd_service.cpp
+++ b/central_unit/src/core/service/systemd_service.cpp
@@ -14,7 +14,7 @@ namespace SmartHome::Service {
         if (getenv("NOTIFY_SOCKET")) {
             mIsWatchdogEnabled = sd_watchdog_enabled(0, &mWatchdogInterval) > 0;
             if (mIsWatchdogEnabled) {
-                mWatchdogTimer.emplace(mCore.getCoreIoContext());
+                mWatchdogTimer.emplace(Core::Instance().getCoreIoContext());
             }
             return true;
         }

--- a/central_unit/src/core/service/systemd_service.cpp
+++ b/central_unit/src/core/service/systemd_service.cpp
@@ -14,7 +14,7 @@ namespace SmartHome::Service {
         if (getenv("NOTIFY_SOCKET")) {
             mIsWatchdogEnabled = sd_watchdog_enabled(0, &mWatchdogInterval) > 0;
             if (mIsWatchdogEnabled) {
-                mWatchdogTimer.emplace(Core::Instance().getCoreIoContext());
+                mWatchdogTimer.emplace(Core::Instance().getCoreUtilityIoContext());
             }
             return true;
         }

--- a/central_unit/src/core/service/systemd_service.h
+++ b/central_unit/src/core/service/systemd_service.h
@@ -64,8 +64,6 @@ namespace SmartHome::Service {
          */
         void notifyWatchdog();
 
-        Core &mCore = Core::Instance();
-
         // Watchdog variables
         std::optional<ba::steady_timer> mWatchdogTimer; ///< Watchdog timer for periodic notifications
         uint64_t mWatchdogInterval = 0; ///< Watchdog interval in microseconds


### PR DESCRIPTION
## Add Api, InternalApi and CoreActions classes

**Api:**
- Abstract base class for JSON-RPC-like APIs.
- Provides helper functions, structs and constants for parsing/serializing JSON and parameters.

**InternalApi:** 
- Final class derived from `Api`.
- Parses incoming requests into `InternalApi::Request` and `Command` structures.
- Handles formatting of structured (JSON-RPC) and raw requests.
- Routes parsed requests to `CoreActions::handleRequest` and forwards the serialized responses back to the IPC server.

**CoreActions:** 
- Processes `InternalApi::Request` objects and manages request lifecycle.
- Executes command handlers asynchronously using Boost.Asio (uses timers for timeouts).
- On completion serializes responses and returns them via `RequestCallback`.
- Designed to make adding new command handlers easy.
- Includes `placeholderHandler` as a template and `coreEchoHandler` as a debug/test handler.

**Other changes:**
- Fixed logger writing timestamps to terminal.
- Improved signal handling.
