### PR TITLE
Central unit/feature/sh 186 action scheduler

### DIFF
--- a/central_unit/configs/db-service.yaml
+++ b/central_unit/configs/db-service.yaml
@@ -9,6 +9,7 @@ preset_values:
 
 db_service:
   service_name: "smarthome-databased"
+  db_triggers_to_listen: [ "modules_changed", "sensors_changed" ]
   db_server:
     connections: 4
     host: "127.0.0.0" # Overwritten by env var "SH_DB_HOST"

--- a/central_unit/configs/smart_home.yaml
+++ b/central_unit/configs/smart_home.yaml
@@ -53,6 +53,11 @@ services:
     service_type: *standalone_daemon
     exec_path: ~ #Option for standalone mode - Default: /usr/local/bin/smarthome-mediator
     config_path: ~ # Default: /etc/smarthome/mediator.yaml
+  db-service:
+    enabled: true
+    service_type: *standalone_daemon
+    exec_path: ~ #Option for standalone mode - Default: /usr/local/bin/db-service
+    config_path: ~ # Default: /etc/smarthome/db-serivce.yaml
 
 # TODO add more config options for gui
 gui:

--- a/central_unit/database/smart_home_schema.sql
+++ b/central_unit/database/smart_home_schema.sql
@@ -163,8 +163,8 @@ CREATE TRIGGER modules_notify
     AFTER INSERT OR
 DELETE
 OR
-UPDATE
-    ON public.modules
+UPDATE OF id,logic_address, name,config,created_at
+ON public.modules
     FOR EACH STATEMENT
     EXECUTE PROCEDURE public.notify_table_change();
 -- ddl-end --

--- a/central_unit/database/smart_home_schema.sql
+++ b/central_unit/database/smart_home_schema.sql
@@ -18,6 +18,11 @@ CREATE ROLE smart_home_admin WITH LOGIN PASSWORD 'insert_password';
 -- ddl-end --
 
 
+SET
+check_function_bodies = false;
+-- ddl-end --
+
+
 -- object: public.modules | type: TABLE --
 -- DROP TABLE IF EXISTS public.modules CASCADE;
 CREATE TABLE public.modules
@@ -124,6 +129,56 @@ CREATE INDEX idx_logs_timestamp ON public.logs
     "timestamp" DESC NULLS LAST
     )
     INCLUDE (type,content,module_id);
+-- ddl-end --
+
+-- object: public.notify_table_change | type: FUNCTION --
+-- DROP FUNCTION IF EXISTS public.notify_table_change() CASCADE;
+CREATE FUNCTION public.notify_table_change()
+    RETURNS trigger
+    LANGUAGE plpgsql
+	VOLATILE
+	CALLED ON NULL INPUT
+	SECURITY INVOKER
+	PARALLEL UNSAFE
+	COST 1
+	AS $$
+BEGIN
+    PERFORM
+pg_notify(
+        TG_TABLE_NAME || '_changed',
+        json_build_object(
+            'operation', TG_OP
+        )::text
+    );
+RETURN NULL;
+END;
+$$;
+-- ddl-end --
+ALTER FUNCTION public.notify_table_change() OWNER TO smart_home_admin;
+-- ddl-end --
+
+-- object: modules_notify | type: TRIGGER --
+-- DROP TRIGGER IF EXISTS modules_notify ON public.modules CASCADE;
+CREATE TRIGGER modules_notify
+    AFTER INSERT OR
+DELETE
+OR
+UPDATE
+    ON public.modules
+    FOR EACH STATEMENT
+    EXECUTE PROCEDURE public.notify_table_change();
+-- ddl-end --
+
+-- object: sensors_notify | type: TRIGGER --
+-- DROP TRIGGER IF EXISTS sensors_notify ON public.sensors CASCADE;
+CREATE TRIGGER sensors_notify
+    AFTER INSERT OR
+DELETE
+OR
+UPDATE
+    ON public.sensors
+    FOR EACH STATEMENT
+    EXECUTE PROCEDURE public.notify_table_change();
 -- ddl-end --
 
 -- object: fk_modules_id_sensors | type: CONSTRAINT --

--- a/central_unit/src/common/CMakeLists.txt
+++ b/central_unit/src/common/CMakeLists.txt
@@ -28,7 +28,6 @@ if (ENABLE_SYSTEMD)
 endif ()
 
 
-
 # SMARTHOME LOGGER
 add_library(smarthome_logger STATIC
         logger/logger.cpp
@@ -107,4 +106,12 @@ target_link_libraries(smarthome_utility
         yaml-cpp
         PUBLIC
         smarthome::logger
+)
+
+# SMARTHOME CONSTANTS
+add_library(smarthome_constants INTERFACE)
+add_library(smarthome::constants ALIAS smarthome_constants)
+
+target_include_directories(smarthome_constants INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/constants>
 )

--- a/central_unit/src/common/api/api.cpp
+++ b/central_unit/src/common/api/api.cpp
@@ -488,9 +488,10 @@ namespace SmartHome::API {
     }
 
     apiId_t getNextApiId() {
-        static std::atomic<apiId_t> id = 0;
+        static std::atomic<apiId_t> id = 1;
         apiId_t expected = std::numeric_limits<apiId_t>::max(); // Wrap around check
-        if (id.compare_exchange_strong(expected, 0, std::memory_order::relaxed)) [[unlikely]] {
+        // Set to 1 after wrap around
+        if (id.compare_exchange_strong(expected, 1, std::memory_order::relaxed)) [[unlikely]] {
             return expected; // Return max value before wrap around
         }
         return id.fetch_add(1, std::memory_order::relaxed);

--- a/central_unit/src/common/api/api.cpp
+++ b/central_unit/src/common/api/api.cpp
@@ -356,6 +356,8 @@ namespace SmartHome::API {
                 return "Mediator runtime error";
             case ErrorCodes::NOT_IMPLEMENTED:
                 return "Not implemented";
+            case ErrorCodes::NOT_FOUND:
+                return "Not found";
             case ErrorCodes::UNKNOWN_ERROR:
                 return "Unknown error";
             default:

--- a/central_unit/src/common/api/api.cpp
+++ b/central_unit/src/common/api/api.cpp
@@ -1,4 +1,5 @@
 #include "api.h"
+#include "../constants/constants.h"
 
 #include <atomic>
 #include <iostream>
@@ -312,10 +313,10 @@ namespace SmartHome::API {
 
     std::string getTargetMethodString(std::string_view target, std::string_view method) {
         if (target.empty()) {
-            target = "<undefined>";
+            target = Constants::Common::UNDEFINED_BRACKETS;
         }
         if (method.empty()) {
-            method = "<undefined>";
+            method = Constants::Common::UNDEFINED_BRACKETS;
         }
         return std::string(target) + "." + std::string(method);
     }

--- a/central_unit/src/common/api/api.h
+++ b/central_unit/src/common/api/api.h
@@ -33,6 +33,7 @@ namespace SmartHome::JsonRpcStrings {
         inline constexpr std::string_view MODULE_ID = "module_id";
         inline constexpr std::string_view TYPE = "type";
         inline constexpr std::string_view ARGS = "args";
+        inline constexpr std::string_view DATA = "data";
     }
 
     namespace ModuleInfoKeys {

--- a/central_unit/src/common/api/api.h
+++ b/central_unit/src/common/api/api.h
@@ -34,6 +34,25 @@ namespace SmartHome::JsonRpcStrings {
         inline constexpr std::string_view TYPE = "type";
         inline constexpr std::string_view ARGS = "args";
         inline constexpr std::string_view DATA = "data";
+
+        // Database API specific keys
+        // Request parameter keys for database operations
+        inline constexpr std::string_view SUBSELECT = "$subselect";
+        inline constexpr std::string_view TABLE = "table";
+        inline constexpr std::string_view COLUMNS = "columns";
+        inline constexpr std::string_view COLUMN = "column";
+        inline constexpr std::string_view AGGREGATES = "aggregates";
+        inline constexpr std::string_view WHERE = "where";
+        inline constexpr std::string_view ORDER_BY = "order_by";
+        inline constexpr std::string_view ORDER = "order";
+        inline constexpr std::string_view LIMIT = "limit";
+        inline constexpr std::string_view VALUES = "values";
+        inline constexpr std::string_view RETURNING = "returning";
+
+        // Result keys for database query responses
+        inline constexpr std::string_view AFFECTED_ROWS = "affected_rows";
+        inline constexpr std::string_view ROWS = "rows";
+        inline constexpr std::string_view ERROR = "error";
     }
 
     namespace ModuleInfoKeys {

--- a/central_unit/src/common/api/api.h
+++ b/central_unit/src/common/api/api.h
@@ -449,6 +449,8 @@ namespace SmartHome::API {
      * @brief Get next unique API identifier.
      *
      * @return Next unique API identifier.
+     *
+     * @note Starts from 1, and wraps around to 1 after reaching maximum value of apiId_t.
      */
     apiId_t getNextApiId();
 

--- a/central_unit/src/common/api/api.h
+++ b/central_unit/src/common/api/api.h
@@ -34,6 +34,7 @@ namespace SmartHome::JsonRpcStrings {
         inline constexpr std::string_view TYPE = "type";
         inline constexpr std::string_view ARGS = "args";
         inline constexpr std::string_view DATA = "data";
+        inline constexpr std::string_view FORCE = "force";
 
         // Database API specific keys
         // Request parameter keys for database operations
@@ -177,6 +178,7 @@ namespace SmartHome::API {
         MEDIATOR_COMMUNICATION_ERROR = -32002,
         MEDIATOR_RUNTIME_ERROR = -32003,
         NOT_IMPLEMENTED = -32004,
+        NOT_FOUND = -32005,
     };
 
     /**

--- a/central_unit/src/common/constants/constants.h
+++ b/central_unit/src/common/constants/constants.h
@@ -57,8 +57,21 @@ namespace SmartHome::Constants {
     }
 
     namespace CoreTypes {
-        // Set keys strings
+        // Config / metadata endpoints (get only, read from cache)
+        inline constexpr std::string_view MODULES = "modules";
+        inline constexpr std::string_view MODULE = "module";
+        inline constexpr std::string_view MODULE_SENSORS = "module_sensors";
+        inline constexpr std::string_view SENSORS = "sensors";
+        inline constexpr std::string_view SENSOR = "sensor";
+
+        // Historical data endpoints (get only, sent to database)
+        inline constexpr std::string_view SENSOR_READINGS = "sensor_readings";
+        inline constexpr std::string_view LOGS = "logs";
+
+        // Core config keys (set only)
         inline constexpr std::string_view CONNECTION_TYPE = "connection_type";
+        // Core keys (get only)
+        inline constexpr std::string_view _DEBUG_CACHE = "_debug_cache";
     }
 
     namespace MediatorTypes {
@@ -75,7 +88,7 @@ namespace SmartHome::Constants {
         inline constexpr std::string_view ACTUATOR_VALUE = "actuator_value";
         inline constexpr std::string_view FORCE_READ_SENSOR_VALUE = "force_read_sensor_value";
         inline constexpr std::string_view BATTERY_LEVEL = "battery_level";
-        inline constexpr std::string_view LOGS = "logs";
+        inline constexpr std::string_view MODULE_LOGS = "module_logs";
 
         // Notify types strings
         // Sent to modules
@@ -96,7 +109,7 @@ namespace SmartHome::Constants {
         inline constexpr std::string_view SENSORS_CHANGED = "sensors_changed";
     }
 
-    namespace MediatorArgs {
+    namespace MediatorSpecial {
         inline constexpr std::string_view ALL_OPTIONS = "all_options";
         inline constexpr std::string_view CHANNEL = "channel";
     }

--- a/central_unit/src/common/constants/constants.h
+++ b/central_unit/src/common/constants/constants.h
@@ -1,0 +1,113 @@
+#pragma once
+#include <c++/12/string_view>
+
+namespace SmartHome::Constants {
+    namespace Common {
+        inline constexpr std::string_view UNDEFINED = "undefined";
+        inline constexpr std::string_view UNKNOWN = "unknown";
+
+        // Special
+        inline constexpr std::string_view UNDEFINED_BRACKETS = "<undefined>";
+        inline constexpr std::string_view NONE_BRACKETS = "<none>";
+        inline constexpr std::string_view DEFAULT_UPPER = "DEFAULT";
+        inline constexpr std::string_view CRLF = "\r\n";
+    }
+
+    namespace DefaultPaths {
+        inline constexpr std::string_view UDS = "/var/run/smarthomed.sock";
+
+        inline constexpr std::string_view MEDIATOR_CONFIG = "/etc/smarthome/mediator.yaml";
+        inline constexpr std::string_view MEDIATOR_LOGFILE = "/var/log/smarthome/mediator.log";
+        inline constexpr std::string_view MEDIATOR_EXEC = "/usr/local/bin/smarthome-mediator";
+
+        inline constexpr std::string_view DB_SERVICE_CONFIG = "/etc/smarthome/db-service.yaml";
+        inline constexpr std::string_view DB_SERVICE_LOGFILE = "/var/log/smarthome/db-service.log";
+        inline constexpr std::string_view DB_SERVICE_EXEC = "/usr/local/bin/smarthome-database";
+
+        inline constexpr std::string_view CORE_CONFIG = "/etc/smarthome/smart_home.yaml";
+        inline constexpr std::string_view CORE_LOGFILE = "/var/log/smarthome/core.log";
+    }
+
+    namespace DefaultServiceNames {
+        inline constexpr std::string_view MEDIATOR = "smarthome-radiod";
+        inline constexpr std::string_view DATABASE = "smarthome-databased";
+        inline constexpr std::string_view CORE = "smarthomed";
+    }
+
+    namespace Methods {
+        inline constexpr std::string_view GET = "get";
+        inline constexpr std::string_view SET = "set";
+        inline constexpr std::string_view NOTIFY = "notify";
+        inline constexpr std::string_view EXECUTE = "execute";
+        inline constexpr std::string_view PING = "ping";
+        /// \c ECHO is a macro, \c ECHO_STR is used to avoid conflicts
+        inline constexpr std::string_view ECHO_STR = "echo";
+        inline constexpr std::string_view DELETE = "delete";
+    }
+
+    namespace Targets {
+        inline constexpr std::string_view MODULE_MEDIATOR = "module_mediator";
+        inline constexpr std::string_view MEDIATOR = "mediator";
+        inline constexpr std::string_view CORE = "core";
+        inline constexpr std::string_view DATABASE = "database";
+        inline constexpr std::string_view CLI = "cli";
+        inline constexpr std::string_view GUI = "gui";
+        inline constexpr std::string_view WEB_SERVER = "web_server";
+        inline constexpr std::string_view WEB = "web";
+    }
+
+    namespace CoreTypes {
+        // Set keys strings
+        inline constexpr std::string_view CONNECTION_TYPE = "connection_type";
+    }
+
+    namespace MediatorTypes {
+        // Set/Get type strings
+        inline constexpr std::string_view CONFIG_OPTION = "config_option";
+
+        // Set type strings
+        inline constexpr std::string_view TOGGLE_ACTUATOR = "toggle_actuator";
+        inline constexpr std::string_view SET_ACTUATOR_VALUE = "set_actuator_value";
+
+        // Get type strings
+        inline constexpr std::string_view SENSOR_LIST = "sensor_list";
+        inline constexpr std::string_view SENSOR_VALUE = "sensor_value";
+        inline constexpr std::string_view ACTUATOR_VALUE = "actuator_value";
+        inline constexpr std::string_view FORCE_READ_SENSOR_VALUE = "force_read_sensor_value";
+        inline constexpr std::string_view BATTERY_LEVEL = "battery_level";
+        inline constexpr std::string_view LOGS = "logs";
+
+        // Notify types strings
+        // Sent to modules
+        inline constexpr std::string_view MANUAL_TRIGGER = "manual_trigger";
+        inline constexpr std::string_view POWER_LOSS = "power_loss";
+        inline constexpr std::string_view ALERT = "alert";
+        // Sent to core
+        inline constexpr std::string_view WAKE = "wake";
+
+        // Execute types strings
+        inline constexpr std::string_view SLEEP = "sleep";
+        inline constexpr std::string_view DEEP_SLEEP = "deep_sleep";
+    }
+
+    namespace DatabaseTypes {
+        // Db notifications
+        inline constexpr std::string_view MODULES_CHANGED = "modules_changed";
+        inline constexpr std::string_view SENSORS_CHANGED = "sensors_changed";
+    }
+
+    namespace MediatorArgs {
+        inline constexpr std::string_view ALL_OPTIONS = "all_options";
+        inline constexpr std::string_view CHANNEL = "channel";
+    }
+
+    namespace HumanReadableErrors {
+        inline constexpr std::string_view UNKNOWN_ERROR = "Unknown error";
+        inline constexpr std::string_view BAD_COMMAND = "Bad command";
+        inline constexpr std::string_view UNKNOWN_COMMAND = "Unknown command";
+        inline constexpr std::string_view BAD_ARGUMENT = "Bad argument";
+        inline constexpr std::string_view NOT_IMPLEMENTED = "Not implemented";
+        inline constexpr std::string_view INTERNAL_ERROR = "Internal error";
+        inline constexpr std::string_view UNDEFINED_ERROR = "Undefined error";
+    }
+}

--- a/central_unit/src/common/constants/constants.h
+++ b/central_unit/src/common/constants/constants.h
@@ -114,6 +114,35 @@ namespace SmartHome::Constants {
         inline constexpr std::string_view CHANNEL = "channel";
     }
 
+    namespace SensorConfigKeys {
+        inline constexpr std::string_view USE_CACHE = "use_cache";
+        inline constexpr std::string_view CACHE_TTL = "cache_ttl";
+
+        inline constexpr std::string_view VALUES = "values";
+        // Value keys
+        inline constexpr std::string_view INDEX = "index";
+        inline constexpr std::string_view LABEL = "label";
+        inline constexpr std::string_view UNIT = "unit";
+        inline constexpr std::string_view PRECISION = "precision";
+        // -----------------
+
+        inline constexpr std::string_view EVENTS = "events";
+        // Event keys
+        inline constexpr std::string_view CONDITION = "condition";
+        // -----------------
+
+        inline constexpr std::string_view SCHEDULE = "schedule";
+        // Schedule keys
+        inline constexpr std::string_view RRULE = "rrule";
+        inline constexpr std::string_view DTSTART = "dtstart";
+        // -----------------
+
+        // Events / Schedule keys
+        inline constexpr std::string_view ENABLED = "enabled";
+        inline constexpr std::string_view ACTION = "action";
+        // Action keys - shared with SmartHome::JsonRpcStrings
+    }
+
     namespace HumanReadableErrors {
         inline constexpr std::string_view UNKNOWN_ERROR = "Unknown error";
         inline constexpr std::string_view BAD_COMMAND = "Bad command";

--- a/central_unit/src/common/constants/constants.h
+++ b/central_unit/src/common/constants/constants.h
@@ -143,6 +143,16 @@ namespace SmartHome::Constants {
         // Action keys - shared with SmartHome::JsonRpcStrings
     }
 
+    namespace ModuleConfigKeys {
+        inline constexpr std::string_view TYPE = "type";
+
+        inline constexpr std::string_view CONNECTION = "connection";
+
+        inline constexpr std::string_view SLEEP_AFTER_SEND = "sleep_after_send";
+        inline constexpr std::string_view POWER_SAVING = "power_saving";
+        inline constexpr std::string_view DEFAULT_SLEEP_DURATION = "default_sleep_duration";
+    }
+
     namespace HumanReadableErrors {
         inline constexpr std::string_view UNKNOWN_ERROR = "Unknown error";
         inline constexpr std::string_view BAD_COMMAND = "Bad command";

--- a/central_unit/src/common/ipc/socket_client.cpp
+++ b/central_unit/src/common/ipc/socket_client.cpp
@@ -1,4 +1,5 @@
 #include "socket_client.h"
+#include "../constants/constants.h"
 
 namespace SmartHome::IPC {
     SocketClient::~SocketClient() {
@@ -48,8 +49,8 @@ namespace SmartHome::IPC {
         // Build handshake request
         API::ApiRequest request;
         nlohmann::json jsonParams;
-        request.method = API::getTargetMethodString(msCORE_TARGET_STRING, msSET_METHOD_STRING);
-        jsonParams[msCONNECTION_TYPE_STRING] = mTargetTypeOfClient;
+        request.method = API::getTargetMethodString(Constants::Targets::CORE, Constants::Methods::SET);
+        jsonParams[Constants::CoreTypes::CONNECTION_TYPE] = mTargetTypeOfClient;
         request.params.emplace(jsonParams);
         request.id = API::getNextApiId();
 

--- a/central_unit/src/common/ipc/socket_client.h
+++ b/central_unit/src/common/ipc/socket_client.h
@@ -128,10 +128,6 @@ namespace SmartHome::IPC {
  */
         void send(std::string_view message);
 
-        static constexpr std::string_view msSET_METHOD_STRING = "set";
-        static constexpr std::string_view msCORE_TARGET_STRING = "core";
-        static constexpr std::string_view msCONNECTION_TYPE_STRING = "connection_type";
-
         ba::io_context *mpIoContext;
         std::shared_ptr<su::Logger> mpLogger;
         std::optional<SocketConnection> mConnection;

--- a/central_unit/src/common/ipc/socket_connection.cpp
+++ b/central_unit/src/common/ipc/socket_connection.cpp
@@ -1,4 +1,5 @@
 #include "socket_connection.h"
+#include "../constants/constants.h"
 
 namespace SmartHome::IPC {
     SocketConnection::SocketConnection(ba::io_context &ioContext,
@@ -69,7 +70,7 @@ namespace SmartHome::IPC {
 
         try {
             std::visit([message](auto &socket) {
-                ba::write(socket, ba::buffer(message + ms_MESSAGE_DELIMITER.data()));
+                ba::write(socket, ba::buffer(message + Constants::Common::CRLF.data()));
             }, mSocket);
         } catch (bs::system_error &e) {
             handleError(e.code());
@@ -91,7 +92,7 @@ namespace SmartHome::IPC {
         auto strandWrapper = ba::bind_executor(mStrand, callback);
 
         std::visit([message, strandWrapper](auto &socket) {
-            ba::async_write(socket, ba::buffer(message + ms_MESSAGE_DELIMITER.data()), strandWrapper);
+            ba::async_write(socket, ba::buffer(message + Constants::Common::CRLF.data()), strandWrapper);
         }, mSocket);
     }
 
@@ -131,7 +132,7 @@ namespace SmartHome::IPC {
         return !mIsClosing && isSocketOpen;
     }
 
-    const boost::regex SocketConnection::ms_DELIMITER_REGEX(ms_MESSAGE_DELIMITER.data());
+    const boost::regex SocketConnection::ms_DELIMITER_REGEX(Constants::Common::CRLF.data());
 
     std::variant<bai::tcp::socket, bal::stream_protocol::socket> SocketConnection::createSocket(
         ba::io_context &ioContext, const Type socketType) {
@@ -174,8 +175,8 @@ namespace SmartHome::IPC {
         is.read(&message[0], static_cast<long>(bytesTransferred));
 
         // Cut delimiter from message
-        if (message.size() > ms_MESSAGE_DELIMITER.length() && message.ends_with(ms_MESSAGE_DELIMITER)) {
-            message.resize(message.size() - ms_MESSAGE_DELIMITER.length());
+        if (message.size() > Constants::Common::CRLF.length() && message.ends_with(Constants::Common::CRLF)) {
+            message.resize(message.size() - Constants::Common::CRLF.length());
         }
 
         return message;

--- a/central_unit/src/common/ipc/socket_connection.h
+++ b/central_unit/src/common/ipc/socket_connection.h
@@ -22,7 +22,7 @@ namespace SmartHome::IPC {
     *
     * @details Provides unified interface for TCP and Unix Domain Socket connections.
     *          Supports both synchronous and asynchronous read/write operations.
-    *          Uses CRLF (\r\n) as message delimiter for framing.
+    *          Uses CRLF (\\r\\n) as message delimiter for framing.
     *
     * @warning Not thread-safe for concurrent read/write operations.
     *          Use external synchronization or separate read/write connections.
@@ -46,7 +46,8 @@ namespace SmartHome::IPC {
         *
         * @throw std::invalid_argument if socketType is invalid.
         */
-        explicit SocketConnection(ba::io_context &ioContext, Type socketType, const std::shared_ptr<Utils::Logger> &logger);
+        explicit SocketConnection(ba::io_context &ioContext, Type socketType,
+                                  const std::shared_ptr<Utils::Logger> &logger);
 
         /**
         * @brief Destructor - closes connection if still open.
@@ -78,7 +79,7 @@ namespace SmartHome::IPC {
         /**
         * @brief Synchronously read a message from socket.
         *
-        * @details Blocks until complete message (ending with \r\n) is received.
+        * @details Blocks until complete message (ending with CRLF) is received.
         *          Returns empty string on error or if connection is closed.
         *
         * @return Received message without delimiter, empty string on error.
@@ -142,8 +143,6 @@ namespace SmartHome::IPC {
         std::variant<bai::tcp::socket, bal::stream_protocol::socket> mSocket;
 
     protected:
-        /// Message delimiter
-        static constexpr std::string_view ms_MESSAGE_DELIMITER = "\r\n";
         /// Compiled regex for delimiter matching
         static const boost::regex ms_DELIMITER_REGEX;
 

--- a/central_unit/src/common/ipc/socket_server.h
+++ b/central_unit/src/common/ipc/socket_server.h
@@ -3,6 +3,7 @@
 #include "socket_server_connection.h"
 #include "async_logger.h"
 #include "api.h"
+#include "../constants/constants.h"
 
 #include <utility>
 #include <unordered_map>
@@ -45,7 +46,7 @@ namespace SmartHome::IPC {
              */
             struct Uds {
                 bool isEnabled = true; ///< Enable UDS acceptor
-                std::string endpointPath = "/var/run/smarthomed.sock"; ///< Socket file path
+                std::string endpointPath = Constants::DefaultPaths::UDS.data(); ///< Socket file path
             } uds;
         };
 

--- a/central_unit/src/common/utils/utils.cpp
+++ b/central_unit/src/common/utils/utils.cpp
@@ -22,6 +22,35 @@ namespace SmartHome::Utils {
         return ServiceType::AUTO;
     }
 
+    std::chrono::system_clock::time_point parseTimestampTz(const std::string &timestamp) {
+        std::tm tm;
+        int tzOffsetHours = 0;
+
+        sscanf(timestamp.c_str(), "%d-%d-%d %d:%d:%d",
+               &tm.tm_year, &tm.tm_mon, &tm.tm_mday,
+               &tm.tm_hour, &tm.tm_min, &tm.tm_sec);
+
+        // Adjust tm structure for timegm
+        tm.tm_year -= 1900; // tm_year is years since 1900
+        tm.tm_mon -= 1; // tm_mon is 0-based
+
+        // Check for timezone offset in format ±HH at the end of the string
+        const auto pos = timestamp.find_last_of("+-");
+        // pos > 10 to ensure offset is after date and time
+        if (pos != std::string_view::npos && pos > 10) {
+            try {
+                tzOffsetHours = std::stoi(timestamp.substr(pos));
+            } catch (...) {
+                // If parsing fails, default to 0 offset
+            }
+        }
+
+        auto tp = std::chrono::system_clock::from_time_t(timegm(&tm));
+        tp -= std::chrono::hours(tzOffsetHours); // Adjust for timezone offset
+
+        return tp;
+    }
+
     FileLock::FileLock(const std::string &lockFilePath) {
         mLockFilePath = lockFilePath;
 

--- a/central_unit/src/common/utils/utils.cpp
+++ b/central_unit/src/common/utils/utils.cpp
@@ -51,6 +51,18 @@ namespace SmartHome::Utils {
         return tp;
     }
 
+    std::string timePointToTimestampTz(const std::chrono::system_clock::time_point &timePoint) {
+        const auto timeT = std::chrono::system_clock::to_time_t(timePoint);
+
+        std::tm tmUTC;
+        gmtime_r(&timeT, &tmUTC);
+
+        std::ostringstream oss;
+        oss << std::put_time(&tmUTC, "%Y-%m-%dT%H:%M:%SZ");
+
+        return oss.str();
+    }
+
     FileLock::FileLock(const std::string &lockFilePath) {
         mLockFilePath = lockFilePath;
 

--- a/central_unit/src/common/utils/utils.h
+++ b/central_unit/src/common/utils/utils.h
@@ -36,7 +36,7 @@ namespace SmartHome::Utils {
     /**
      * @brief Parse a timestamp with timezone information into a std::chrono::system_clock::time_point.
      *
-     * @param timestamp Timestamp string in the format "YYYY-MM-DD HH:MM:SS±HH"
+     * @param timestamp Timestamp string ISO 8601 format "YYYY-MM-DDTHH:MM:SS±HH"
      *                  where the last part is an optional timezone offset in hours.
      *
      * @return Parsed time point representing the given timestamp in UTC.
@@ -44,6 +44,15 @@ namespace SmartHome::Utils {
      * @note Used for postgreSQL timestamptz, ignores microseconds.
      */
     std::chrono::system_clock::time_point parseTimestampTz(const std::string &timestamp);
+
+    /**
+     * @brief Convert a std::chrono::system_clock::time_point to a timestamp string with timezone information.
+     *
+     * @param timePoint Time point to convert.
+     *
+     * @return Timestamp string in the ISO 8601 format "YYYY-MM-DDTHH:MM:SSZ" (UTC time).
+     */
+    std::string timePointToTimestampTz(const std::chrono::system_clock::time_point &timePoint);
 
     /**
      * @brief RAII wrapper for exclusive file locking.

--- a/central_unit/src/common/utils/utils.h
+++ b/central_unit/src/common/utils/utils.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <memory>
 
 namespace SmartHome::Utils {
@@ -31,6 +32,18 @@ namespace SmartHome::Utils {
      * @return Corresponding ServiceType enum value, defaults to AUTO.
      */
     ServiceType resolveServiceType(const std::string &typeStr);
+
+    /**
+     * @brief Parse a timestamp with timezone information into a std::chrono::system_clock::time_point.
+     *
+     * @param timestamp Timestamp string in the format "YYYY-MM-DD HH:MM:SS±HH"
+     *                  where the last part is an optional timezone offset in hours.
+     *
+     * @return Parsed time point representing the given timestamp in UTC.
+     *
+     * @note Used for postgreSQL timestamptz, ignores microseconds.
+     */
+    std::chrono::system_clock::time_point parseTimestampTz(const std::string &timestamp);
 
     /**
      * @brief RAII wrapper for exclusive file locking.

--- a/central_unit/src/core/CMakeLists.txt
+++ b/central_unit/src/core/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(smarthomed PRIVATE
         smarthome::api
         smarthome::ipc
         smarthome::utility
+        smarthome::constants
         Boost::program_options
         nlohmann_json::nlohmann_json
 )

--- a/central_unit/src/core/CMakeLists.txt
+++ b/central_unit/src/core/CMakeLists.txt
@@ -12,17 +12,38 @@ if (ENABLE_SYSTEMD)
 
 endif ()
 
+FetchContent_Declare(
+        libical
+        GIT_REPOSITORY https://github.com/libical/libical.git
+        GIT_TAG v3.0.20
+)
+
+set(STATIC_ONLY ON CACHE BOOL "" FORCE)
+set(ICAL_BUILD_DOCS OFF CACHE BOOL "" FORCE)
+set(ICAL_BUILD_TESTING OFF CACHE BOOL "" FORCE)
+set(ICAL_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(ICAL_GLIB OFF CACHE BOOL "" FORCE)
+set(ICAL_GTK_DOC OFF CACHE BOOL "" FORCE)
+
+FetchContent_MakeAvailable(libical)
+
 
 # Target
 add_executable(smarthomed
         main.cpp
         core.cpp
         cache.cpp
+        scheduler.cpp
         api/internal_api.cpp
         actions/actions.cpp
         actions/core_actions.cpp
         actions/mediator_actions.cpp
         actions/database_actions.cpp
+)
+
+target_include_directories(smarthomed PRIVATE
+        ${libical_SOURCE_DIR}/src/libical
+        ${libical_BINARY_DIR}/src/libical
 )
 
 
@@ -44,5 +65,7 @@ target_link_libraries(smarthomed PRIVATE
         smarthome::constants
         Boost::program_options
         nlohmann_json::nlohmann_json
+        ical
+        ical_cxx
 )
 

--- a/central_unit/src/core/CMakeLists.txt
+++ b/central_unit/src/core/CMakeLists.txt
@@ -17,6 +17,7 @@ endif ()
 add_executable(smarthomed
         main.cpp
         core.cpp
+        cache.cpp
         api/internal_api.cpp
         actions/actions.cpp
         actions/core_actions.cpp

--- a/central_unit/src/core/actions/actions.cpp
+++ b/central_unit/src/core/actions/actions.cpp
@@ -709,11 +709,11 @@ namespace SmartHome {
 
     std::unordered_map<connectionId_t, sai::TargetTypes> Actions::msConnectionsMap;
 
-    std::mutex Actions::msConnectionsMapLock;
+    std::shared_mutex Actions::msConnectionsMapLock;
 
     std::unordered_map<sai::TargetTypes, std::unordered_set<connectionId_t> > Actions::msConnectionTypeMap;
 
-    std::mutex Actions::msConnectionTypeMapLock;
+    std::shared_mutex Actions::msConnectionTypeMapLock;
 
     // ======================================== CommandHandler functions ========================================
 

--- a/central_unit/src/core/actions/actions.cpp
+++ b/central_unit/src/core/actions/actions.cpp
@@ -43,7 +43,7 @@ namespace SmartHome {
                 requestId,
                 request,
                 std::make_shared<ba::steady_timer>(
-                    Core::Instance().getCoreUtilityIoContext(), msREQUEST_TIMEOUT),
+                    Core::Instance().coreUtilityIoContext(), msREQUEST_TIMEOUT),
                 request.commands.size(),
                 callback
             );
@@ -345,7 +345,7 @@ namespace SmartHome {
     }
 
     void Actions::onCoreShutdown() {
-        auto cleanupTimeout = std::make_shared<ba::steady_timer>(Core::Instance().getCoreUtilityIoContext(),
+        auto cleanupTimeout = std::make_shared<ba::steady_timer>(Core::Instance().coreUtilityIoContext(),
                                                                  msCLEANUP_TIMEOUT);
         std::atomic_bool cleanupTimeoutCalled = false;
         auto cleanup = [&cleanupTimeout, &cleanupTimeoutCalled] {
@@ -445,7 +445,7 @@ namespace SmartHome {
                                       apiId_t requestId) {
         const auto commandMetadata = std::make_shared<CommandMetadata>(
             newCommand,
-            std::make_shared<ba::steady_timer>(Core::Instance().getCoreUtilityIoContext()),
+            std::make_shared<ba::steady_timer>(Core::Instance().coreUtilityIoContext()),
             requestId
         );
 
@@ -502,7 +502,7 @@ namespace SmartHome {
             return;
         }
 
-        ba::co_spawn(Core::Instance().getCoreIoContext(),
+        ba::co_spawn(Core::Instance().coreIoContext(),
                      processCommand(commandMetadata, handler),
                      ba::detached);
     }
@@ -598,7 +598,7 @@ namespace SmartHome {
             auto &request = iter->second;
             if (request.pendingCommands.fetch_sub(1) == 1) {
                 if (const auto reqTimer = request.requestTimeoutTimer.load()) reqTimer->cancel();
-                ba::post(Core::Instance().getCoreIoContext(), [requestId] {
+                ba::post(Core::Instance().coreIoContext(), [requestId] {
                     handleOutgoingResponse(requestId);
                     cleanupRequest(requestId);
                 });
@@ -744,7 +744,7 @@ namespace SmartHome {
         auto future = promise->get_future();
 
         // Be sure to implement timeouts and periodic isPending checks to avoid infinitely running operations.
-        ba::post(Core::Instance().getCoreWorkerIoContext(), [promise, commandMetadata, operationDuration] {
+        ba::post(Core::Instance().coreWorkerIoContext(), [promise, commandMetadata, operationDuration] {
             // This example simulates chain of operations with periodic checking for cancellation and command timeout.
             // While command timeout is not needed as request timeout exists, it is advised to use it especially for
             // longer operations in batch requests.

--- a/central_unit/src/core/actions/actions.cpp
+++ b/central_unit/src/core/actions/actions.cpp
@@ -208,6 +208,7 @@ namespace SmartHome {
         requestCallback(id, std::move(responseString));
     }
 
+    // FIXME segfault can happen when received unexpected response
     void Actions::handleIncomingResponse(const connectionId_t connectionId, const API::ApiResponse &response) {
         Core::Instance().mpLogger->debug("[ACTIONS] [HANDLE_INCOMING_RESPONSE] called");
         if (!response.id.hasValue()) {

--- a/central_unit/src/core/actions/actions.h
+++ b/central_unit/src/core/actions/actions.h
@@ -98,10 +98,10 @@ namespace SmartHome {
             std::unordered_map<apiId_t, std::shared_ptr<std::promise<API::ApiResponse> > > requestsPromises;
             /// For aggregating request to send in batch
             std::shared_ptr<ba::steady_timer> sendTimer = std::make_shared<ba::steady_timer>(
-                Core::Instance().getCoreIoContext());
+                Core::Instance().coreIoContext());
             /// Request-level timeout timer
             std::shared_ptr<ba::steady_timer> timeoutTimer = std::make_shared<ba::steady_timer>(
-                Core::Instance().getCoreIoContext());
+                Core::Instance().coreIoContext());
         };
 
         /// Callback type for request completion notification

--- a/central_unit/src/core/actions/actions.h
+++ b/central_unit/src/core/actions/actions.h
@@ -370,10 +370,10 @@ namespace SmartHome {
         static std::mutex msResponsesLock;
 
         static std::unordered_map<connectionId_t, sai::TargetTypes> msConnectionsMap;
-        static std::mutex msConnectionsMapLock;
+        static std::shared_mutex msConnectionsMapLock;
 
         static std::unordered_map<sai::TargetTypes, std::unordered_set<connectionId_t> > msConnectionTypeMap;
-        static std::mutex msConnectionTypeMapLock;
+        static std::shared_mutex msConnectionTypeMapLock;
 
         /// After not adding new messages to send for timeout duration, send aggregated batch message.
         static constexpr auto msAGGREGATE_OUTGOING_TIMEOUT = 10ms;

--- a/central_unit/src/core/actions/core_actions.cpp
+++ b/central_unit/src/core/actions/core_actions.cpp
@@ -4,9 +4,13 @@
 
 #include <boost/algorithm/string/case_conv.hpp>
 
+#include "mediator_actions.h"
+
 
 namespace SmartHome {
     namespace jp = JsonRpcStrings::ParamsKeys;
+    namespace cct = Constants::CoreTypes;
+    namespace cmt = Constants::MediatorTypes;
 
     awaitOptApiResponse CoreActions::coreEchoHandler(const cmdMetaPtr &commandMetadata) {
         Core::Instance().mpLogger->debug("[CORE_ACTIONS] [ECHO] called");
@@ -30,82 +34,48 @@ namespace SmartHome {
         Core::Instance().mpLogger->debug("[CORE_ACTIONS] [GET] called");
         const auto &command = commandMetadata->command;
         API::ApiResponse commandResult;
+        API::ApiError error;
         commandResult.id = command.commandId;
 
-        // TODO rework core get handler to use database and cached values
-
-        // TODO implement core cached data object with getter methods
-        // TODO remove - temporary code for API testing
-        static const auto tmpDataGetter = [](const std::string_view value) {
-            const std::map<std::string_view, std::string> tmpMap = {
-                {
-                    "modules_status",
-                    R"([{"id":"1","name":"Lightning","description":"LED lights","values":[{"name":"Brightness","value":"75%"},{"name":"Temperature","value":"3200K"}],"actions":[{"name":"Turn On","method":"turnOn"},{"name":"Turn Off","method":"turnOff"}]},{"id":"2","name":"Thermometer","description":"Thermometer + Hygrometer","values":[{"name":"Temperature","value":"22C"},{"name":"Humidity","value":"44%"}],"actions":[{"name":"Turn On","method":"turnOn"},{"name":"Turn Off","method":"turnOff"},{"name":"Update Values","method":"updateValues"}]},{"id":"1","name":"Lightning","description":"LED lights","values":[{"name":"Brightness","value":"75%"},{"name":"Temperature","value":"3200K"}],"actions":[{"name":"Turn On","method":"turnOn"},{"name":"Turn Off","method":"turnOff"}]},{"id":"1","name":"Lightning","description":"LED lights","values":[{"name":"Brightness","value":"75%"},{"name":"Temperature","value":"3200K"}],"actions":[{"name":"Turn On","method":"turnOn"},{"name":"Turn Off","method":"turnOff"}]},{"id":"1","name":"Lightning","description":"LED lights","values":[{"name":"Brightness","value":"75%"},{"name":"Temperature","value":"3200K"}],"actions":[{"name":"Turn On","method":"turnOn"},{"name":"Turn Off","method":"turnOff"}]},{"id":"1","name":"Lightning","description":"LED lights","values":[{"name":"Brightness","value":"75%"},{"name":"Temperature","value":"3200K"}],"actions":[{"name":"Turn On","method":"turnOn"},{"name":"Turn Off","method":"turnOff"}]},{"id":"1","name":"Lightning","description":"LED lights","values":[{"name":"Brightness","value":"75%"},{"name":"Temperature","value":"3200K"}],"actions":[{"name":"Turn On","method":"turnOn"},{"name":"Turn Off","method":"turnOff"}]},{"id":"1","name":"Lightning","description":"LED lights","values":[{"name":"Brightness","value":"75%"},{"name":"Temperature","value":"3200K"}],"actions":[{"name":"Turn On","method":"turnOn"},{"name":"Turn Off","method":"turnOff"}]},{"id":"1","name":"Lightning","description":"LED lights","values":[{"name":"Brightness","value":"75%"},{"name":"Temperature","value":"3200K"}],"actions":[{"name":"Turn On","method":"turnOn"},{"name":"Turn Off","method":"turnOff"}]},{"id":"1","name":"Lightning","description":"LED lights","values":[{"name":"Brightness","value":"75%"},{"name":"Temperature","value":"3200K"}],"actions":[{"name":"Turn On","method":"turnOn"},{"name":"Turn Off","method":"turnOff"}]}])"
-                },
-                {
-                    "module_status",
-                    R"({"Id":22,"Status":"Online","Battery":"56%","Logs":["Received status request","Woke from sleep - incoming traffic","Going to sleep for 30000000ms","Sent requested value","Received read value request"]})"
-                }
-            };
-
-            const auto iter = tmpMap.find(boost::algorithm::to_lower_copy(std::string(value)));
-            std::string result = (iter != tmpMap.end()) ? iter->second.data() : "";
-
-            return result;
-        };
-
-
-        std::string queryResponse;
-
-        bool invalidParamsFlag = false;
-        if (command.params.has_value()) {
-            const auto &params = command.params.value();
-            size_t paramsSize = 0;
-
-            // params must be an array
-            if (params.is_array()) {
-                paramsSize = params.size();
-            } else {
-                invalidParamsFlag = true;
-            }
-
-            // params must have at least a query target
-            if (!invalidParamsFlag && paramsSize > 0 && params[0].is_string()) {
-                // TODO pass query target into target resolver
-                queryResponse = tmpDataGetter(params[0].get<std::string>());
-                // TODO remove - temporary code for API testing
-                commandResult.result = queryResponse;
-            } else {
-                invalidParamsFlag = true;
-            }
-
-            // params might have query conditions object
-            if (!invalidParamsFlag && paramsSize > 1 && params[1].is_object()) {
-                nlohmann::json conditionParam = params[1];
-                // TODO implement condition handler
-
-                // TODO remove - temporary code for API testing
-                auto index = conditionParam.find("id");
-                if (index != conditionParam.end()) {
-                    if (conditionParam["id"] == 22) {
-                        nlohmann::json response;
-                        response["id"] = 22;
-                        response["object"] = queryResponse;
-                        commandResult.result = nlohmann::to_string(response);
-                    }
-                }
-            }
-
-            //TODO pass query and condition to coreCachedDataGetter
+        error.code = API::ErrorCodes::INVALID_PARAMS;
+        error.message = API::errorCodeToString(error.code);
+        if (!command.params.has_value()) {
+            error.data = "Core get requires params: none received";
+            commandResult.error = error;
+            co_return commandResult;
         }
 
-        if (invalidParamsFlag || !commandResult.result.has_value()) {
-            commandResult.error = API::ApiError(
-                API::ErrorCodes::INVALID_PARAMS,
-                API::errorCodeToString(API::ErrorCodes::INVALID_PARAMS).data(),
-                "Query failed"
-            );
+        const auto &params = command.params.value();
+        if (!params.is_object()) {
+            error.data = "Core get requires params object";
+            commandResult.error = error;
+            co_return commandResult;
         }
+
+        if (!params.contains(jp::TYPE) || !params.at(jp::TYPE).is_string()) {
+            error.data = "Core get requires type parameter of string type";
+            commandResult.error = error;
+            co_return commandResult;
+        }
+
+        const auto iter = msGetTypeHandlersRegistry.find(params.at(jp::TYPE).get<std::string_view>());
+        if (iter == msGetTypeHandlersRegistry.end()) {
+            error.data = "Unsupported core get type: " + params.at(jp::TYPE).get<std::string>();
+            commandResult.error = error;
+            co_return commandResult;
+        }
+
+        Core::Instance().mpLogger->debugf("[TEST] params: %s", params.dump().c_str());
+        const auto handlerResult = co_await iter->second(commandMetadata, params);
+
+        if (handlerResult.has_value()) {
+            co_return handlerResult;
+        }
+
+        error.code = API::ErrorCodes::INTERNAL_ERROR;
+        error.message = API::errorCodeToString(error.code);
+        error.data = "Failed to get value for type: " + params.at(jp::TYPE).get<std::string>();
+        commandResult.error = error;
 
         co_return commandResult;
     }
@@ -168,14 +138,14 @@ namespace SmartHome {
         }
 
         switch (key) {
-            case CoreActions::SetKeys::CONNECTION_TYPE:
-                if (CoreActions::setConnectionType(commandMetadata, value)) break;
+            case SetKeys::CONNECTION_TYPE:
+                if (setConnectionType(commandMetadata, value)) break;
                 error.code = API::ErrorCodes::INTERNAL_ERROR;
                 error.message = API::errorCodeToString(error.code);
                 error.data = "Failed to set connection type";
                 commandResult.error = error;
                 co_return commandResult;
-            case CoreActions::SetKeys::UNDEFINED:
+            case SetKeys::UNDEFINED:
             default:
                 error.data = "Undefined set key";
                 commandResult.error = error;
@@ -254,6 +224,19 @@ namespace SmartHome {
         return (iter != setKeyMap.end()) ? iter->second : SetKeys::UNDEFINED;
     }
 
+    std::optional<std::unordered_set<connectionId_t> > CoreActions::findConnections(
+        std::string_view connectionTypeString) {
+        std::shared_lock lock(Actions::msConnectionTypeMapLock);
+
+        const auto target = sai::Target(connectionTypeString.data());
+        const auto iter = Actions::msConnectionTypeMap.find(target.type);
+        if (iter != Actions::msConnectionTypeMap.end() && !iter->second.empty()) {
+            return iter->second;
+        }
+
+        return std::nullopt;
+    }
+
     bool CoreActions::setConnectionType(const cmdMetaPtr &pMetadata,
                                         std::string_view connectionTypeString) {
         clearStaleConnectionTypes();
@@ -303,16 +286,547 @@ namespace SmartHome {
         }
     }
 
-    std::optional<std::unordered_set<connectionId_t> > CoreActions::findConnections(
-        std::string_view connectionTypeString) {
-        std::shared_lock lock(Actions::msConnectionTypeMapLock);
-
-        const auto target = sai::Target(connectionTypeString.data());
-        const auto iter = Actions::msConnectionTypeMap.find(target.type);
-        if (iter != Actions::msConnectionTypeMap.end() && !iter->second.empty()) {
-            return iter->second;
+    std::expected<uint, API::ApiError> CoreActions::requireModuleId(const nlohmann::json &params) {
+        if (!params.contains(jp::MODULE_ID) ||
+            !params.at(jp::MODULE_ID).is_number_integer()) {
+            return std::unexpected(API::ApiError(
+                API::ErrorCodes::INVALID_PARAMS,
+                errorCodeToString(API::ErrorCodes::INVALID_PARAMS),
+                "Module ID is required and must be an unsigned integer in 'module_id' parameter"));
         }
 
-        return std::nullopt;
+        const int value = params.at(jp::MODULE_ID).get<uint>();
+        return value >= 0 ? static_cast<uint>(value) : 0;
     }
+
+    std::expected<uint, API::ApiError> CoreActions::requireLimitArg(const nlohmann::json &params) {
+        if (!params.contains(jp::ARGS) ||
+            !params.at(jp::ARGS).is_array() ||
+            params.at(jp::ARGS).empty() ||
+            !params.at(jp::ARGS).back().is_number_integer()) {
+            return std::unexpected(API::ApiError(
+                API::ErrorCodes::INVALID_PARAMS,
+                errorCodeToString(API::ErrorCodes::INVALID_PARAMS),
+                "Requires limit argument as unsigned integer in last element of 'args' array parameter"));
+        }
+
+        const int value = params.at(jp::ARGS).back().get<uint>();
+        return value >= 0 ? static_cast<uint>(value) : 0;
+    }
+
+    std::expected<uint, API::ApiError> CoreActions::requireSensorLogicIdArg(const nlohmann::json &params) {
+        if (!params.contains(jp::ARGS) ||
+            !params.at(jp::ARGS).is_array() ||
+            params.at(jp::ARGS).empty() ||
+            !params.at(jp::ARGS).front().is_number_integer()) {
+            return std::unexpected(API::ApiError(
+                API::ErrorCodes::INVALID_PARAMS,
+                errorCodeToString(API::ErrorCodes::INVALID_PARAMS),
+                "Requires sensor logic ID argument as unsigned integer in first element of 'args' array parameter"));
+        }
+
+        const int value = params.at(jp::ARGS).front().get<uint>();
+        return value >= 0 ? static_cast<uint>(value) : 0;
+    }
+
+    std::expected<uint, API::ApiError> CoreActions::resolveSensorId(const nlohmann::json &params) {
+        if (!params.contains(jp::ARGS) ||
+            !params.at(jp::ARGS).is_array() ||
+            params.at(jp::ARGS).empty() ||
+            !params.at(jp::ARGS).front().is_number_integer()) {
+            return std::unexpected(API::ApiError(
+                API::ErrorCodes::INVALID_PARAMS,
+                errorCodeToString(API::ErrorCodes::INVALID_PARAMS),
+                "Requires sensor ID as unsigned integer in first element of 'args' array parameter, "
+                "or module ID in 'module_id' parameter with sensor logic ID as first element of 'args' array"));
+        }
+        int value = 0;
+
+        if (params.contains(jp::MODULE_ID) &&
+            params.at(jp::MODULE_ID).is_number_integer()) {
+            value = params.at(jp::MODULE_ID).get<uint>();
+            const auto moduleId = value >= 0 ? static_cast<uint>(value) : 0;
+
+            value = params.at(jp::ARGS).front().get<uint>();
+            const auto logicId = value >= 0 ? static_cast<uint>(value) : 0;
+            const auto sensorIdOpt = Core::Instance().configCache().findSensorId(moduleId, logicId);
+
+            if (!sensorIdOpt.has_value()) {
+                return std::unexpected(API::ApiError(
+                    API::ErrorCodes::NOT_FOUND,
+                    errorCodeToString(API::ErrorCodes::NOT_FOUND),
+                    "Sensor logic_id [" + std::to_string(logicId) +
+                    "] not found for module [" + std::to_string(moduleId) + "]"));
+            }
+            return sensorIdOpt.value();
+        }
+
+        value = params.at(jp::ARGS).front().get<uint>();
+        return value >= 0 ? static_cast<uint>(value) : 0;
+    }
+
+    ba::awaitable<std::expected<nlohmann::json, API::ApiError> > CoreActions::queryDatabase(
+        const nlohmann::json &dbQuery) {
+        API::ApiRequest request;
+        const API::InternalApi::Target target(API::InternalApi::TargetTypes::DATABASE);
+        const API::InternalApi::Method method(API::InternalApi::MethodTypes::GET);
+        request.method = API::getTargetMethodString(target.to_string(), method.to_string());
+        request.params = dbQuery;
+        request.id = Actions::getNextId();
+        auto response = co_await DatabaseActions::sendRequestToDbService(std::move(request));
+
+        // Handle db response
+        if (response.error.has_value()) {
+            co_return std::unexpected(API::ApiError(
+                API::ErrorCodes::INTERNAL_ERROR,
+                errorCodeToString(API::ErrorCodes::INTERNAL_ERROR),
+                "Database query failed: " + response.error.value().data));
+        }
+
+        if (!response.result.has_value() || !nlohmann::json::accept(response.result.value())) {
+            co_return std::unexpected(API::ApiError(
+                API::ErrorCodes::INTERNAL_ERROR,
+                errorCodeToString(API::ErrorCodes::INTERNAL_ERROR),
+                "Invalid database response"));
+        }
+
+        auto parsedResult = nlohmann::json::parse(response.result.value());
+        if (!parsedResult.contains(jp::ROWS) || !parsedResult[jp::ROWS].is_array()) {
+            co_return std::unexpected(API::ApiError(
+                API::ErrorCodes::INTERNAL_ERROR,
+                errorCodeToString(API::ErrorCodes::INTERNAL_ERROR),
+                "Database response missing rows array"));
+        }
+
+        co_return parsedResult[jp::ROWS];
+    }
+
+    awaitOptApiResponse CoreActions::getModules(const cmdMetaPtr &cmdMetadata, const nlohmann::json &params) {
+        API::ApiResponse handlerResult;
+        handlerResult.id = cmdMetadata->command.commandId;
+
+        const auto modules = Core::Instance().configCache().getAllModules();
+
+        if (modules.empty()) {
+            handlerResult.error = API::ApiError(
+                API::ErrorCodes::NOT_FOUND,
+                errorCodeToString(API::ErrorCodes::NOT_FOUND),
+                "No modules found");
+            co_return handlerResult;
+        }
+
+        nlohmann::json result = nlohmann::json::object();
+        nlohmann::json modulesJsonArray = nlohmann::json::array();
+        for (const auto &module: modules) {
+            modulesJsonArray.push_back(module.to_json());
+        }
+
+        result[cct::MODULES] = modulesJsonArray;
+        handlerResult.result = to_string(result);
+
+        co_return handlerResult;
+    }
+
+    awaitOptApiResponse CoreActions::getModule(const cmdMetaPtr &cmdMetadata, const nlohmann::json &params) {
+        API::ApiResponse handlerResult;
+        handlerResult.id = cmdMetadata->command.commandId;
+
+        const auto moduleId = requireModuleId(params);
+        if (!moduleId.has_value()) {
+            handlerResult.error = moduleId.error();
+            co_return handlerResult;
+        }
+
+        const auto moduleOpt = Core::Instance().configCache().getModule(moduleId.value());
+
+        if (!moduleOpt.has_value()) {
+            handlerResult.error = API::ApiError(
+                API::ErrorCodes::NOT_FOUND,
+                errorCodeToString(API::ErrorCodes::NOT_FOUND),
+                "Module with [" + std::to_string(moduleId.value()) + "] ID not found");
+            co_return handlerResult;
+        }
+
+        nlohmann::json result = nlohmann::json::object();
+        result[cct::MODULE] = moduleOpt.value().to_json();
+        handlerResult.result = to_string(result);
+        co_return handlerResult;
+    }
+
+    awaitOptApiResponse CoreActions::getModuleSensors(const cmdMetaPtr &cmdMetadata, const nlohmann::json &params) {
+        API::ApiResponse handlerResult;
+        handlerResult.id = cmdMetadata->command.commandId;
+
+        const auto moduleId = requireModuleId(params);
+        if (!moduleId.has_value()) {
+            handlerResult.error = moduleId.error();
+            co_return handlerResult;
+        }
+
+        const auto sensors = Core::Instance().configCache().getModuleSensors(moduleId.value());
+
+        if (sensors.empty()) {
+            handlerResult.error = API::ApiError(
+                API::ErrorCodes::NOT_FOUND,
+                errorCodeToString(API::ErrorCodes::NOT_FOUND),
+                "No sensors found for module with [" + std::to_string(moduleId.value()) + "] ID");
+            co_return handlerResult;
+        }
+
+        nlohmann::json result = nlohmann::json::object();
+        nlohmann::json sensorsJsonArray = nlohmann::json::array();
+        for (const auto &sensor: sensors) {
+            sensorsJsonArray.push_back(sensor.to_json());
+        }
+
+        result[cct::MODULE_SENSORS] = sensorsJsonArray;
+        handlerResult.result = to_string(result);
+        co_return handlerResult;
+    }
+
+    awaitOptApiResponse CoreActions::getSensors(const cmdMetaPtr &cmdMetadata, const nlohmann::json &params) {
+        API::ApiResponse handlerResult;
+        handlerResult.id = cmdMetadata->command.commandId;
+
+        const auto &sensors = Core::Instance().configCache().getAllSensors();
+
+        if (sensors.empty()) {
+            handlerResult.error = API::ApiError(
+                API::ErrorCodes::NOT_FOUND,
+                errorCodeToString(API::ErrorCodes::NOT_FOUND),
+                "No sensors found");
+            co_return handlerResult;
+        }
+
+        nlohmann::json result = nlohmann::json::object();
+        nlohmann::json sensorsJsonArray = nlohmann::json::array();
+        for (const auto &sensor: sensors) {
+            sensorsJsonArray.push_back(sensor.to_json());
+        }
+
+        result[cct::SENSORS] = sensorsJsonArray;
+        handlerResult.result = to_string(result);
+
+        co_return handlerResult;
+    }
+
+    awaitOptApiResponse CoreActions::getSensor(const cmdMetaPtr &cmdMetadata, const nlohmann::json &params) {
+        API::ApiResponse handlerResult;
+        handlerResult.id = cmdMetadata->command.commandId;
+
+        const auto sensorId = resolveSensorId(params);
+        if (!sensorId.has_value()) {
+            handlerResult.error = sensorId.error();
+            co_return handlerResult;
+        }
+
+        const auto sensorOpt = Core::Instance().configCache().getSensor(sensorId.value());
+        if (!sensorOpt.has_value()) {
+            handlerResult.error = API::ApiError(
+                API::ErrorCodes::NOT_FOUND,
+                errorCodeToString(API::ErrorCodes::NOT_FOUND),
+                "Sensor with [" + std::to_string(sensorId.value()) + "] ID not found");
+            co_return handlerResult;
+        }
+
+        nlohmann::json result = nlohmann::json::object();
+        result[cct::SENSOR] = sensorOpt.value().to_json();
+        handlerResult.result = to_string(result);
+        co_return handlerResult;
+    }
+
+    awaitOptApiResponse CoreActions::getSensorReadings(const cmdMetaPtr &cmdMetadata, const nlohmann::json &params) {
+        API::ApiResponse handlerResult;
+        handlerResult.id = cmdMetadata->command.commandId;
+
+        const auto sensorId = resolveSensorId(params);
+        if (!sensorId.has_value()) {
+            handlerResult.error = sensorId.error();
+            co_return handlerResult;
+        }
+
+        if (params.at(jp::ARGS).size() < 2) {
+            handlerResult.error = API::ApiError(
+                API::ErrorCodes::INVALID_PARAMS,
+                errorCodeToString(API::ErrorCodes::INVALID_PARAMS),
+                "Requires sensor logic ID as first element and limit as second element of 'args' array parameter, "
+                "or module ID in 'module_id' parameter with sensor logic ID as first element."
+                "Requires limit as last element of 'args' array");
+            co_return handlerResult;
+        }
+
+        const auto limit = requireLimitArg(params);
+        if (!limit.has_value()) {
+            handlerResult.error = limit.error();
+            co_return handlerResult;
+        }
+        if (limit.value() == 1) {
+            const auto readingOpt = Core::Instance().readingsCache().get(sensorId.value());
+            // If reading is in cache return it, otherwise delegate to db
+            if (readingOpt.has_value()) {
+                nlohmann::json result = nlohmann::json::object();
+                result[cct::SENSOR_READINGS] = nlohmann::json::array({readingOpt.value().to_json()});
+                handlerResult.result = to_string(result);
+                co_return handlerResult;
+            }
+        }
+
+        // Delegate to db
+        API::ApiRequest request;
+
+        nlohmann::json dbQuery = {
+            {jp::TABLE, "sensor_readings"},
+            {
+                jp::COLUMNS, nlohmann::json::array(
+                    {"value_text", "value_numeric", "timestamp", "metadata"})
+            },
+            {
+                jp::WHERE, {
+                    {"sensor_id", sensorId.value()}
+                }
+            },
+            {jp::LIMIT, limit.value()}
+        };
+
+        const auto rows = co_await queryDatabase(dbQuery);
+        if (!rows.has_value()) {
+            handlerResult.error = rows.error();
+            co_return handlerResult;
+        }
+        nlohmann::json result = nlohmann::json::object();
+        nlohmann::json readingsJsonArray = nlohmann::json::array();
+        for (const auto &row: rows.value()) {
+            try {
+                nlohmann::json reading = {
+                    {"sensor_id", sensorId.value()},
+                    {"value", row["value_numeric"].is_null() ? row["value_text"] : row["value_numeric"]},
+                    {"timestamp", row["timestamp"]},
+                    {"metadata", row["metadata"]}
+                };
+
+                readingsJsonArray.push_back(reading);
+            } catch (const std::exception &e) {
+                Core::Instance().mpLogger->errorf(
+                    "[CORE_ACTIONS] [GET_SENSOR_READINGS] Failed to parse sensor reading from database response: %s",
+                    e.what());
+            }
+        }
+
+        result[cct::SENSOR_READINGS] = readingsJsonArray;
+        handlerResult.result = to_string(result);
+        co_return handlerResult;
+    }
+
+
+    awaitOptApiResponse CoreActions::getLogs(const cmdMetaPtr &cmdMetadata, const nlohmann::json &params) {
+        API::ApiResponse handlerResult;
+        handlerResult.id = cmdMetadata->command.commandId;
+
+        const auto moduleId = requireModuleId(params);
+        if (!moduleId.has_value()) {
+            handlerResult.error = moduleId.error();
+            co_return handlerResult;
+        }
+
+        const auto limit = requireLimitArg(params);
+        if (!limit.has_value()) {
+            handlerResult.error = limit.error();
+            co_return handlerResult;
+        }
+
+        // Delegate to db
+        API::ApiRequest request;
+
+        nlohmann::json dbQuery = {
+            {jp::TABLE, "logs"},
+            {
+                jp::COLUMNS, nlohmann::json::array(
+                    {"type", "content", "timestamp"})
+            },
+            {
+                jp::WHERE, {
+                    {"module_id", moduleId.value()}
+                }
+            },
+            {jp::LIMIT, limit.value()}
+        };
+
+        const auto rows = co_await queryDatabase(dbQuery);
+        if (!rows.has_value()) {
+            handlerResult.error = rows.error();
+            co_return handlerResult;
+        }
+
+        nlohmann::json result = nlohmann::json::object();
+        nlohmann::json readingsJsonArray = nlohmann::json::array();
+
+        for (const auto &row: rows.value()) {
+            try {
+                nlohmann::json log = {
+                    {"type", row["type"]},
+                    {"content", row["content"]},
+                    {"timestamp", row["timestamp"]}
+                };
+                readingsJsonArray.push_back(log);
+            } catch (const std::exception &e) {
+                Core::Instance().mpLogger->errorf(
+                    "[CORE_ACTIONS] [GET_LOGS] Failed to parse log from database response: %s",
+                    e.what());
+            }
+        }
+
+        result[cct::LOGS] = readingsJsonArray;
+        handlerResult.result = to_string(result);
+        co_return handlerResult;
+    }
+
+    awaitOptApiResponse CoreActions::getDebugCache(const cmdMetaPtr &cmdMetadata, const nlohmann::json &params) {
+        API::ApiResponse handlerResult;
+        handlerResult.id = cmdMetadata->command.commandId;
+
+        nlohmann::json result = nlohmann::json::object();
+        result["modules_cache"] = nlohmann::json::array();
+        for (const auto &module: Core::Instance().configCache().getAllModules()) {
+            result["modules_cache"].push_back(module.to_json());
+        }
+        result["sensors_cache"] = nlohmann::json::array();
+        for (const auto &sensor: Core::Instance().configCache().getAllSensors()) {
+            result["sensors_cache"].push_back(sensor.to_json());
+        }
+        result["readings_cache"] = nlohmann::json::array();
+        for (const auto &reading: Core::Instance().readingsCache().getDebugAll()) {
+            result["readings_cache"].push_back(reading.to_json());
+        }
+
+        handlerResult.result = to_string(result);
+        co_return handlerResult;
+    }
+
+    awaitOptApiResponse CoreActions::getReadingValue(const cmdMetaPtr &cmdMetadata, const nlohmann::json &params) {
+        API::ApiResponse handlerResult;
+        handlerResult.id = cmdMetadata->command.commandId;
+
+        const auto sensorId = resolveSensorId(params);
+        if (!sensorId.has_value()) {
+            handlerResult.error = sensorId.error();
+            co_return handlerResult;
+        }
+
+        const auto sensorOpt = Core::Instance().configCache().getSensor(sensorId.value());
+        if (!sensorOpt.has_value()) {
+            handlerResult.error = API::ApiError(
+                API::ErrorCodes::NOT_FOUND,
+                errorCodeToString(API::ErrorCodes::NOT_FOUND),
+                "Sensor with [" + std::to_string(sensorId.value()) + "] ID not found in cache");
+            co_return handlerResult;
+        }
+
+        const auto &sensor = sensorOpt.value();
+        const uint moduleId = sensor.moduleId;
+        const uint sensorLogicId = sensor.logicId;
+
+        const auto type = params.at(jp::TYPE).get<std::string>();
+        const bool forceRefresh = params.contains(jp::FORCE) &&
+                                  params.at(jp::FORCE).is_boolean() &&
+                                  params.at(jp::FORCE).get<bool>();
+
+        // Try cache if not forced refresh
+        if (!forceRefresh) {
+            if (sensorId.has_value()) {
+                if (const auto cached = Core::Instance().readingsCache().getFresh(sensorId.value())) {
+                    handlerResult.result = cached->value.dump();
+                    co_return handlerResult;
+                }
+            }
+        }
+
+        nlohmann::json mediatorArgs = nlohmann::json::array({sensorLogicId});
+
+        // Delegate to mediator
+        auto response = co_await MediatorActions::sendToModule(cmdMetadata, moduleId, type, mediatorArgs,
+                                                               API::InternalApi::MethodTypes::GET);
+
+        if (response.result.has_value()) handlerResult.result = std::move(response.result);
+        else handlerResult.error = std::move(response.error);
+
+        co_return handlerResult;
+    }
+
+    awaitOptApiResponse CoreActions::getModuleInfo(const cmdMetaPtr &cmdMetadata, const nlohmann::json &params) {
+        API::ApiResponse handlerResult;
+        handlerResult.id = cmdMetadata->command.commandId;
+
+        const auto moduleId = requireModuleId(params);
+        if (!moduleId.has_value()) {
+            handlerResult.error = moduleId.error();
+            co_return handlerResult;
+        }
+
+        const auto type = params.at(jp::TYPE).get<std::string>();
+
+        nlohmann::json mediatorArgs = nlohmann::json::array();
+        if (params.contains(jp::ARGS) && params.at(jp::ARGS).is_array()) {
+            mediatorArgs = params.at(jp::ARGS);
+        }
+
+        // Delegate to mediator
+        auto response = co_await MediatorActions::sendToModule(cmdMetadata, moduleId.value(), type, mediatorArgs,
+                                                               API::InternalApi::MethodTypes::GET);
+
+        if (response.result.has_value()) handlerResult.result = std::move(response.result);
+        else handlerResult.error = std::move(response.error);
+
+        co_return handlerResult;
+    }
+
+    awaitOptApiResponse CoreActions::getModuleLogs(const cmdMetaPtr &cmdMetadata, const nlohmann::json &params) {
+        API::ApiResponse handlerResult;
+        handlerResult.id = cmdMetadata->command.commandId;
+
+        const auto moduleId = requireModuleId(params);
+        if (!moduleId.has_value()) {
+            handlerResult.error = moduleId.error();
+            co_return handlerResult;
+        }
+
+        const auto limit = requireLimitArg(params);
+        if (!limit.has_value()) {
+            handlerResult.error = limit.error();
+            co_return handlerResult;
+        }
+
+        const auto type = params.at(jp::TYPE).get<std::string>();
+
+        // Delegate to mediator
+        auto response = co_await MediatorActions::sendToModule(cmdMetadata, moduleId.value(), type, params.at(jp::ARGS),
+                                                               API::InternalApi::MethodTypes::GET);
+
+        if (response.result.has_value()) handlerResult.result = std::move(response.result);
+        else handlerResult.error = std::move(response.error);
+
+        co_return handlerResult;
+    }
+
+
+    std::unordered_map<std::string_view, CoreActions::getTypeHandler>
+    CoreActions::msGetTypeHandlersRegistry{
+        // Core types
+        {cct::MODULES, getModules},
+        {cct::MODULE, getModule},
+        {cct::MODULE_SENSORS, getModuleSensors},
+        {cct::SENSORS, getSensors},
+        {cct::SENSOR, getSensor},
+        // Debug types
+        {cct::_DEBUG_CACHE, getDebugCache},
+        // Core types delegated to database actions
+        {cct::SENSOR_READINGS, getSensorReadings},
+        {cct::LOGS, getLogs},
+        // Mediator types
+        {cmt::ACTUATOR_VALUE, getReadingValue},
+        {cmt::SENSOR_VALUE, getReadingValue},
+        {cmt::FORCE_READ_SENSOR_VALUE, getReadingValue},
+        {cmt::BATTERY_LEVEL, getModuleInfo},
+        {cmt::SENSOR_LIST, getModuleInfo},
+        {cmt::MODULE_LOGS, getModuleLogs},
+    };
 }

--- a/central_unit/src/core/actions/core_actions.cpp
+++ b/central_unit/src/core/actions/core_actions.cpp
@@ -179,6 +179,7 @@ namespace SmartHome {
 
         if (typeParam == Constants::DatabaseTypes::SENSORS_CHANGED) {
             co_await DatabaseActions::fetchSensorsConfigs();
+            Core::Instance().scheduler().loadFromCache();
             co_return std::nullopt;
         }
 

--- a/central_unit/src/core/actions/core_actions.cpp
+++ b/central_unit/src/core/actions/core_actions.cpp
@@ -287,7 +287,7 @@ namespace SmartHome {
         }
     }
 
-    std::expected<uint, API::ApiError> CoreActions::requireModuleId(const nlohmann::json &params) {
+    CoreActions::ValidationResult<uint> CoreActions::requireModuleId(const nlohmann::json &params) {
         if (!params.contains(jp::MODULE_ID) ||
             !params.at(jp::MODULE_ID).is_number_integer()) {
             return std::unexpected(API::ApiError(
@@ -300,7 +300,7 @@ namespace SmartHome {
         return value >= 0 ? static_cast<uint>(value) : 0;
     }
 
-    std::expected<uint, API::ApiError> CoreActions::requireLimitArg(const nlohmann::json &params) {
+    CoreActions::ValidationResult<uint> CoreActions::requireLimitArg(const nlohmann::json &params) {
         if (!params.contains(jp::ARGS) ||
             !params.at(jp::ARGS).is_array() ||
             params.at(jp::ARGS).empty() ||
@@ -315,7 +315,7 @@ namespace SmartHome {
         return value >= 0 ? static_cast<uint>(value) : 0;
     }
 
-    std::expected<uint, API::ApiError> CoreActions::requireSensorLogicIdArg(const nlohmann::json &params) {
+    CoreActions::ValidationResult<uint> CoreActions::requireSensorLogicIdArg(const nlohmann::json &params) {
         if (!params.contains(jp::ARGS) ||
             !params.at(jp::ARGS).is_array() ||
             params.at(jp::ARGS).empty() ||
@@ -330,7 +330,7 @@ namespace SmartHome {
         return value >= 0 ? static_cast<uint>(value) : 0;
     }
 
-    std::expected<uint, API::ApiError> CoreActions::resolveSensorId(const nlohmann::json &params) {
+    CoreActions::ValidationResult<uint> CoreActions::resolveSensorId(const nlohmann::json &params) {
         if (!params.contains(jp::ARGS) ||
             !params.at(jp::ARGS).is_array() ||
             params.at(jp::ARGS).empty() ||
@@ -366,7 +366,7 @@ namespace SmartHome {
         return value >= 0 ? static_cast<uint>(value) : 0;
     }
 
-    ba::awaitable<std::expected<nlohmann::json, API::ApiError> > CoreActions::queryDatabase(
+    ba::awaitable<CoreActions::ValidationResult<nlohmann::json> > CoreActions::queryDatabase(
         const nlohmann::json &dbQuery) {
         API::ApiRequest request;
         const API::InternalApi::Target target(API::InternalApi::TargetTypes::DATABASE);

--- a/central_unit/src/core/actions/core_actions.cpp
+++ b/central_unit/src/core/actions/core_actions.cpp
@@ -1,8 +1,9 @@
 #include "core_actions.h"
+#include "database_actions.h"
+#include "constants.h"
 
 #include <boost/algorithm/string/case_conv.hpp>
 
-#include "database_actions.h"
 
 namespace SmartHome {
     namespace jp = JsonRpcStrings::ParamsKeys;
@@ -201,42 +202,52 @@ namespace SmartHome {
 
         const auto &typeParam = command.params->at(jp::TYPE);
         // Handle default db trigger notification
-        if (typeParam == "modules_changed") {
+        if (typeParam == Constants::DatabaseTypes::MODULES_CHANGED) {
             co_await DatabaseActions::fetchModulesConfigs();
             co_return std::nullopt;
         }
 
-        if (typeParam == "sensors_changed") {
+        if (typeParam == Constants::DatabaseTypes::SENSORS_CHANGED) {
             co_await DatabaseActions::fetchSensorsConfigs();
             co_return std::nullopt;
         }
 
+        // TODO implement handling module mediator notifications
         // Module mediator notifications
-        if (typeParam == "manual_trigger") {
-            // Handle manually trigger notification from module
+        if (typeParam == Constants::MediatorTypes::MANUAL_TRIGGER) {
+            Core::Instance().mpLogger->infof(
+                "[CORE_ACTIONS] [NOTIFY] Manual trigger notification received with data: %s",
+                command.params->dump().c_str());
         }
 
+        if (typeParam == Constants::MediatorTypes::POWER_LOSS) {
+            Core::Instance().mpLogger->infof(
+                "[CORE_ACTIONS] [NOTIFY] Power loss notification received with data: %s",
+                command.params->dump().c_str());
+        }
 
-        // TODO !pr finish, implement common constant strings
+        if (typeParam == Constants::MediatorTypes::ALERT) {
+            Core::Instance().mpLogger->infof(
+                "[CORE_ACTIONS] [NOTIFY] Alert notification received with data: %s",
+                command.params->dump().c_str());
+        }
 
-        if (typeParam == "")
-
-            co_return std::nullopt;
+        co_return std::nullopt;
     }
 
     std::string_view CoreActions::setKeyToString(const SetKeys setKey) {
         switch (setKey) {
             case SetKeys::CONNECTION_TYPE:
-                return msCONNECTION_TYPE_STRING;
+                return Constants::CoreTypes::CONNECTION_TYPE;
             case SetKeys::UNDEFINED:
             default:
-                return "undefined";
+                return Constants::Common::UNDEFINED;
         }
     }
 
     CoreActions::SetKeys CoreActions::stringToSetKey(const std::string_view setKey) {
         std::map<std::string_view, SetKeys> setKeyMap = {
-            {msCONNECTION_TYPE_STRING, SetKeys::CONNECTION_TYPE}
+            {Constants::CoreTypes::CONNECTION_TYPE, SetKeys::CONNECTION_TYPE}
         };
 
         const auto iter = setKeyMap.find(boost::algorithm::to_lower_copy(std::string(setKey)));

--- a/central_unit/src/core/actions/core_actions.cpp
+++ b/central_unit/src/core/actions/core_actions.cpp
@@ -2,7 +2,11 @@
 
 #include <boost/algorithm/string/case_conv.hpp>
 
+#include "database_actions.h"
+
 namespace SmartHome {
+    namespace jp = JsonRpcStrings::ParamsKeys;
+
     awaitOptApiResponse CoreActions::coreEchoHandler(const cmdMetaPtr &commandMetadata) {
         Core::Instance().mpLogger->debug("[CORE_ACTIONS] [ECHO] called");
         const auto &command = commandMetadata->command;
@@ -184,10 +188,40 @@ namespace SmartHome {
 
     awaitOptApiResponse CoreActions::coreNotifyHandler(const cmdMetaPtr &commandMetadata) {
         Core::Instance().mpLogger->debug("[CORE_ACTIONS] [NOTIFY] called");
+        const auto &command = commandMetadata->command;
 
-        // TODO implement notify logic
 
-        co_return std::nullopt;
+        if (!command.params.has_value() ||
+            !command.params->contains(jp::TYPE) ||
+            !command.params->at(jp::TYPE).is_string()) {
+            Core::Instance().mpLogger->warning(
+                "[CORE_ACTIONS] [NOTIFY] Received notification with missing or invalid type parameter");
+            co_return std::nullopt;
+        }
+
+        const auto &typeParam = command.params->at(jp::TYPE);
+        // Handle default db trigger notification
+        if (typeParam == "modules_changed") {
+            co_await DatabaseActions::fetchModulesConfigs();
+            co_return std::nullopt;
+        }
+
+        if (typeParam == "sensors_changed") {
+            co_await DatabaseActions::fetchSensorsConfigs();
+            co_return std::nullopt;
+        }
+
+        // Module mediator notifications
+        if (typeParam == "manual_trigger") {
+            // Handle manually trigger notification from module
+        }
+
+
+        // TODO !pr finish, implement common constant strings
+
+        if (typeParam == "")
+
+            co_return std::nullopt;
     }
 
     std::string_view CoreActions::setKeyToString(const SetKeys setKey) {
@@ -256,5 +290,18 @@ namespace SmartHome {
             }
             Actions::msConnectionTypeMap[connectionType] = intersectionResult;
         }
+    }
+
+    std::optional<std::unordered_set<connectionId_t> > CoreActions::findConnections(
+        std::string_view connectionTypeString) {
+        std::shared_lock lock(Actions::msConnectionTypeMapLock);
+
+        const auto target = sai::Target(connectionTypeString.data());
+        const auto iter = Actions::msConnectionTypeMap.find(target.type);
+        if (iter != Actions::msConnectionTypeMap.end() && !iter->second.empty()) {
+            return iter->second;
+        }
+
+        return std::nullopt;
     }
 }

--- a/central_unit/src/core/actions/core_actions.h
+++ b/central_unit/src/core/actions/core_actions.h
@@ -3,6 +3,7 @@
 
 #include <string_view>
 #include <memory>
+#include <expected>
 
 
 namespace ba = boost::asio;
@@ -21,8 +22,12 @@ namespace SmartHome {
      */
     class CoreActions {
         using cmdMetaPtr = std::shared_ptr<Actions::CommandMetadata>;
+        using getTypeHandler = std::function<awaitOptApiResponse(const cmdMetaPtr &, const nlohmann::json &params)>;
 
     public:
+        /**
+         * @brief Set keys supported by core SET handler.
+         */
         enum class SetKeys {
             UNDEFINED = 0,
             CONNECTION_TYPE,
@@ -40,19 +45,15 @@ namespace SmartHome {
          */
         static awaitOptApiResponse coreEchoHandler(const cmdMetaPtr &commandMetadata);
 
-        // FIXME Rewrite needed
         /**
          * @brief Handle GET command for core data retrieval.
          *
-         * @details Queries core cached data with optional condition filtering.
-         *          Supports structured queries with target and condition parameters.
+         * @details Parses request params and dispatches to specific GET handlers
+         *          (modules, sensors, readings, logs, or debug cache).
          *
          * @param commandMetadata Command execution metadata.
          *
          * @return API response with requested data or error.
-         *
-         * @note Expected params format: [query_target<string>, (optional)conditions<object>]
-         * @warning Currently uses temporary hardcoded data - TODO implement core cached data object.
          */
         static awaitOptApiResponse coreGetHandler(const cmdMetaPtr &commandMetadata);
 
@@ -104,6 +105,20 @@ namespace SmartHome {
         static SetKeys stringToSetKey(std::string_view setKey);
 
         /**
+         * @brief Find active connections by connection type string.
+         *
+         * @details Uses registered connection type mappings to resolve a set of
+         *          connection ids for a given type (case-insensitive).
+         *
+         * @param connectionTypeString Connection type string (e.g., "module_mediator").
+         *
+         * @return Set of connection ids if found, std::nullopt otherwise.
+         */
+        static std::optional<std::unordered_set<connectionId_t> > findConnections(
+            std::string_view connectionTypeString);
+
+    private:
+        /**
          * @brief Set connection type for specific connection.
          *
          * @details Registers connection with specified target type, clearing stale connections first.
@@ -129,7 +144,173 @@ namespace SmartHome {
          */
         static void clearStaleConnectionTypes();
 
-        static std::optional<std::unordered_set<connectionId_t> > findConnections(
-            std::string_view connectionTypeString);
+        // Handler helpers
+
+        /**
+         * @brief Require module_id in params.
+         *
+         * @param params Request params JSON.
+         *
+         * @return module id on success, API error on validation failure.
+         */
+        static std::expected<uint, API::ApiError> requireModuleId(const nlohmann::json &params);
+
+        /**
+         * @brief Require limit argument in params.
+         *
+         * @param params Request params JSON.
+         *
+         * @return limit value on success, API error on validation failure.
+         */
+        static std::expected<uint, API::ApiError> requireLimitArg(const nlohmann::json &params);
+
+        /**
+         * @brief Require sensor logic id argument in params.
+         *
+         * @param params Request params JSON.
+         *
+         * @return sensor logic id on success, API error on validation failure.
+         */
+        static std::expected<uint, API::ApiError> requireSensorLogicIdArg(const nlohmann::json &params);
+
+        /**
+         * @brief Resolve sensor id from params.
+         *
+         * @details Resolves from either sensor_id or module_id + sensor_logic_id.
+         *
+         * @param params Request params JSON.
+         *
+         * @return resolved sensor id on success, API error on failure.
+         */
+        static std::expected<uint, API::ApiError> resolveSensorId(const nlohmann::json &params);
+
+        /**
+         * @brief Execute database query for core GET handlers.
+         *
+         * @param dbQuery JSON query payload for db-service.
+         *
+         * @return JSON response on success, API error on failure.
+         */
+        static ba::awaitable<std::expected<nlohmann::json, API::ApiError> >
+        queryDatabase(const nlohmann::json &dbQuery);
+
+        // Core type handlers
+
+        /**
+         * @brief Fetch list of modules from database.
+         *
+         * @param cmdMetadata Command execution metadata.
+         * @param params Request params JSON.
+         *
+         * @return API response with modules list or error.
+         */
+        static awaitOptApiResponse getModules(const cmdMetaPtr &cmdMetadata, const nlohmann::json &params);
+
+        /**
+         * @brief Fetch a single module by id.
+         *
+         * @param cmdMetadata Command execution metadata.
+         * @param params Request params JSON (expects module_id).
+         *
+         * @return API response with module data or error.
+         */
+        static awaitOptApiResponse getModule(const cmdMetaPtr &cmdMetadata, const nlohmann::json &params);
+
+        /**
+         * @brief Fetch sensors for a module.
+         *
+         * @param cmdMetadata Command execution metadata.
+         * @param params Request params JSON (expects module_id).
+         *
+         * @return API response with module sensors or error.
+         */
+        static awaitOptApiResponse getModuleSensors(const cmdMetaPtr &cmdMetadata, const nlohmann::json &params);
+
+        /**
+         * @brief Fetch all sensors.
+         *
+         * @param cmdMetadata Command execution metadata.
+         * @param params Request params JSON.
+         *
+         * @return API response with sensors list or error.
+         */
+        static awaitOptApiResponse getSensors(const cmdMetaPtr &cmdMetadata, const nlohmann::json &params);
+
+        /**
+         * @brief Fetch a single sensor by id.
+         *
+         * @param cmdMetadata Command execution metadata.
+         * @param params Request params JSON (expects sensor_id or module_id + sensor_logic_id).
+         *
+         * @return API response with sensor data or error.
+         */
+        static awaitOptApiResponse getSensor(const cmdMetaPtr &cmdMetadata, const nlohmann::json &params);
+
+        /**
+         * @brief Fetch readings for a sensor.
+         *
+         * @param cmdMetadata Command execution metadata.
+         * @param params Request params JSON (expects sensor_id or module_id + sensor_logic_id).
+         *
+         * @return API response with readings list or error.
+         */
+        static awaitOptApiResponse getSensorReadings(const cmdMetaPtr &cmdMetadata, const nlohmann::json &params);
+
+        /**
+         * @brief Fetch log entries for a module.
+         *
+         * @param cmdMetadata Command execution metadata.
+         * @param params Request params JSON (expects module_id, limit).
+         *
+         * @return API response with logs or error.
+         */
+        static awaitOptApiResponse getLogs(const cmdMetaPtr &cmdMetadata, const nlohmann::json &params);
+
+        /**
+         * @brief Fetch debug view of caches.
+         *
+         * @param cmdMetadata Command execution metadata.
+         * @param params Request params JSON.
+         *
+         * @return API response with cache dump or error.
+         */
+        static awaitOptApiResponse getDebugCache(const cmdMetaPtr &cmdMetadata, const nlohmann::json &params);
+
+        // Mediator type handlers
+
+        /**
+         * @brief Fetch a reading value from mediator or cache.
+         *
+         * @param cmdMetadata Command execution metadata.
+         * @param params Request params JSON.
+         *
+         * @return API response with current reading value or error.
+         */
+        static awaitOptApiResponse getReadingValue(const cmdMetaPtr &cmdMetadata, const nlohmann::json &params);
+
+        /**
+         * @brief Fetch module info from mediator.
+         *
+         * @param cmdMetadata Command execution metadata.
+         * @param params Request params JSON.
+         *
+         * @return API response with module info or error.
+         */
+        static awaitOptApiResponse getModuleInfo(const cmdMetaPtr &cmdMetadata, const nlohmann::json &params);
+
+        /**
+         * @brief Fetch module logs from mediator.
+         *
+         * @param cmdMetadata Command execution metadata.
+         * @param params Request params JSON.
+         *
+         * @return API response with module logs or error.
+         */
+        static awaitOptApiResponse getModuleLogs(const cmdMetaPtr &cmdMetadata, const nlohmann::json &params);
+
+        /**
+         * @brief Registry of GET type handlers.
+         */
+        static std::unordered_map<std::string_view, getTypeHandler> msGetTypeHandlersRegistry;
     };
 }

--- a/central_unit/src/core/actions/core_actions.h
+++ b/central_unit/src/core/actions/core_actions.h
@@ -129,6 +129,8 @@ namespace SmartHome {
          */
         static void clearStaleConnectionTypes();
 
+        static std::optional<std::unordered_set<connectionId_t> > findConnections(
+            std::string_view connectionTypeString);
         /// Connection type configuration key string
         static constexpr std::string_view msCONNECTION_TYPE_STRING = "connection_type";
     };

--- a/central_unit/src/core/actions/core_actions.h
+++ b/central_unit/src/core/actions/core_actions.h
@@ -145,6 +145,8 @@ namespace SmartHome {
         static void clearStaleConnectionTypes();
 
         // Handler helpers
+        template<typename T>
+        using ValidationResult = std::expected<T, API::ApiError>;
 
         /**
          * @brief Require module_id in params.
@@ -153,7 +155,7 @@ namespace SmartHome {
          *
          * @return module id on success, API error on validation failure.
          */
-        static std::expected<uint, API::ApiError> requireModuleId(const nlohmann::json &params);
+        static ValidationResult<uint> requireModuleId(const nlohmann::json &params);
 
         /**
          * @brief Require limit argument in params.
@@ -162,7 +164,7 @@ namespace SmartHome {
          *
          * @return limit value on success, API error on validation failure.
          */
-        static std::expected<uint, API::ApiError> requireLimitArg(const nlohmann::json &params);
+        static ValidationResult<uint> requireLimitArg(const nlohmann::json &params);
 
         /**
          * @brief Require sensor logic id argument in params.
@@ -171,7 +173,7 @@ namespace SmartHome {
          *
          * @return sensor logic id on success, API error on validation failure.
          */
-        static std::expected<uint, API::ApiError> requireSensorLogicIdArg(const nlohmann::json &params);
+        static ValidationResult<uint> requireSensorLogicIdArg(const nlohmann::json &params);
 
         /**
          * @brief Resolve sensor id from params.
@@ -182,7 +184,7 @@ namespace SmartHome {
          *
          * @return resolved sensor id on success, API error on failure.
          */
-        static std::expected<uint, API::ApiError> resolveSensorId(const nlohmann::json &params);
+        static ValidationResult<uint> resolveSensorId(const nlohmann::json &params);
 
         /**
          * @brief Execute database query for core GET handlers.
@@ -191,7 +193,7 @@ namespace SmartHome {
          *
          * @return JSON response on success, API error on failure.
          */
-        static ba::awaitable<std::expected<nlohmann::json, API::ApiError> >
+        static ba::awaitable<ValidationResult<nlohmann::json> >
         queryDatabase(const nlohmann::json &dbQuery);
 
         // Core type handlers

--- a/central_unit/src/core/actions/core_actions.h
+++ b/central_unit/src/core/actions/core_actions.h
@@ -153,7 +153,7 @@ namespace SmartHome {
          *
          * @param params Request params JSON.
          *
-         * @return module id on success, API error on validation failure.
+         * @return Module id on success, API error on validation failure.
          */
         static ValidationResult<uint> requireModuleId(const nlohmann::json &params);
 
@@ -162,7 +162,7 @@ namespace SmartHome {
          *
          * @param params Request params JSON.
          *
-         * @return limit value on success, API error on validation failure.
+         * @return Limit value on success, API error on validation failure.
          */
         static ValidationResult<uint> requireLimitArg(const nlohmann::json &params);
 
@@ -171,7 +171,7 @@ namespace SmartHome {
          *
          * @param params Request params JSON.
          *
-         * @return sensor logic id on success, API error on validation failure.
+         * @return Sensor logic id on success, API error on validation failure.
          */
         static ValidationResult<uint> requireSensorLogicIdArg(const nlohmann::json &params);
 
@@ -182,7 +182,7 @@ namespace SmartHome {
          *
          * @param params Request params JSON.
          *
-         * @return resolved sensor id on success, API error on failure.
+         * @return Resolved sensor id on success, API error on failure.
          */
         static ValidationResult<uint> resolveSensorId(const nlohmann::json &params);
 

--- a/central_unit/src/core/actions/core_actions.h
+++ b/central_unit/src/core/actions/core_actions.h
@@ -131,7 +131,5 @@ namespace SmartHome {
 
         static std::optional<std::unordered_set<connectionId_t> > findConnections(
             std::string_view connectionTypeString);
-        /// Connection type configuration key string
-        static constexpr std::string_view msCONNECTION_TYPE_STRING = "connection_type";
     };
 }

--- a/central_unit/src/core/actions/database_actions.cpp
+++ b/central_unit/src/core/actions/database_actions.cpp
@@ -1,4 +1,5 @@
 #include "database_actions.h"
+#include "utils.h"
 
 namespace SmartHome {
     using ai = API::InternalApi;
@@ -36,7 +37,7 @@ namespace SmartHome {
 
         nlohmann::json dbQuery = {
             {"table", "modules"},
-            {"columns", {"logic_address", "config"}},
+            {"columns", {"logic_address", "name", "config", "last_online"}},
             {"where", {{"id", moduleId}}},
         };
 
@@ -47,15 +48,7 @@ namespace SmartHome {
         request.id = Actions::getNextId();
 
         request.params = dbQuery;
-
-        API::InternalApi::Command command(request);
-        auto pCmdMeta = std::make_shared<Actions::CommandMetadata>(
-            command,
-            std::make_shared<ba::steady_timer>(Core::Instance().coreUtilityIoContext()),
-            Actions::getNextId());
-
-
-        auto response = co_await sendRequestToDbService(std::move(request), pCmdMeta);
+        auto response = co_await sendRequestToDbService(std::move(request));
 
         nlohmann::json result;
 
@@ -72,12 +65,29 @@ namespace SmartHome {
                 responseResultJson.contains("rows")) {
                 auto row = responseResultJson["rows"].front();
 
+                // Extract logic address and RF channel from response
                 try {
                     result[jmik::LOGIC_ADDRESS] = row[jmik::LOGIC_ADDRESS];
                     result[jmik::RF_CHANNEL] = row["config"][jmik::RF_CHANNEL];
                 } catch (const std::exception &e) {
                     Core::Instance().mpLogger->errorf(
                         "[DATABASE_ACTIONS] [GET_ADDR_INFO] Failed to parse db response %s", e.what());
+                }
+
+                // Update config cache with retrieved info
+                try {
+                    Core::Instance().configCache().setModule(
+                        CachedModule{
+                            .id = moduleId,
+                            .logicAddress = row[jmik::LOGIC_ADDRESS],
+                            .name = row["name"],
+                            .config = row["config"],
+                            .lastOnline = Utils::parseTimestampTz(row["last_online"])
+                        }
+                    );
+                } catch (const std::exception &e) {
+                    Core::Instance().mpLogger->errorf(
+                        "[DATABASE_ACTIONS] [GET_ADDR_INFO] Failed to update config cache: %s", e.what());
                 }
             } else {
                 result["error"] = "Module not found";
@@ -175,6 +185,130 @@ namespace SmartHome {
         sendNotificationToDbService(std::move(notification));
     }
 
+    ba::awaitable<void> DatabaseActions::fetchModulesConfigs() {
+        auto &cache = Core::Instance().configCache();
+        cache.clearModules(); // Clear modules cache before fetching to avoid stale configs
+        API::ApiRequest request;
+
+        nlohmann::json dbQuery = {
+            {"table", "modules"},
+            {"columns", nlohmann::json::array({"id", "logic_address", "config", "last_online"})},
+        };
+
+        const API::InternalApi::Target target(API::InternalApi::TargetTypes::DATABASE);
+        const API::InternalApi::Method method(API::InternalApi::MethodTypes::GET);
+        request.method = API::getTargetMethodString(target.to_string(), method.to_string());
+
+        request.params = dbQuery;
+        request.id = Actions::getNextId();
+
+
+        auto response = co_await sendRequestToDbService(std::move(request));
+
+        if (response.error.has_value()) {
+            Core::Instance().mpLogger->errorf(
+                "[DATABASE_ACTIONS] [FETCH_MODULE_CONFIGS] Failed to fetch modules configs: %s",
+                response.error.value().data.c_str());
+            co_return;
+        }
+
+        if (response.result.has_value()) {
+            auto responseResultJson = nlohmann::json::parse(response.result.value());
+
+            if (responseResultJson.contains("affected_rows") &&
+                responseResultJson.contains("rows")) {
+                for (const auto &row: responseResultJson["rows"]) {
+                    try {
+                        CachedModule module{
+                            .id = row["id"],
+                            .logicAddress = row["logic_address"],
+                            .config = row["config"],
+                            .lastOnline = Utils::parseTimestampTz(row["last_online"])
+                        };
+                        cache.setModule(module);
+                    } catch (const std::exception &e) {
+                        Core::Instance().mpLogger->errorf(
+                            "[DATABASE_ACTIONS] [FETCH_MODULE_CONFIGS] Failed to parse db response: %s", e.what());
+                    }
+                }
+            } else {
+                Core::Instance().mpLogger->error(
+                    "[DATABASE_ACTIONS] [FETCH_MODULE_CONFIGS] Invalid db response format");
+            }
+        }
+    }
+
+    ba::awaitable<void> DatabaseActions::fetchSensorsConfigs() {
+        // Clear readings cache to avoid stale readings after sensor config changes
+        Core::Instance().readingsCache().clear();
+
+        auto &cache = Core::Instance().configCache();
+        cache.clearSensors(); // Clear sensors cache before fetching to avoid stale configs
+
+        API::ApiRequest request;
+
+        nlohmann::json dbQuery = {
+            {"table", "sensors"},
+            {
+                "columns", nlohmann::json::array(
+                    {"id", "logic_id", "module_id", "name", "type", "config"})
+            },
+        };
+
+        const API::InternalApi::Target target(API::InternalApi::TargetTypes::DATABASE);
+        const API::InternalApi::Method method(API::InternalApi::MethodTypes::GET);
+        request.method = API::getTargetMethodString(target.to_string(), method.to_string());
+
+        request.params = dbQuery;
+        request.id = Actions::getNextId();
+
+
+        auto response = co_await sendRequestToDbService(std::move(request));
+
+        if (response.error.has_value()) {
+            Core::Instance().mpLogger->errorf(
+                "[DATABASE_ACTIONS] [FETCH_SENSORS_CONFIGS] Failed to fetch sensors configs: %s",
+                response.error.value().data.c_str());
+            co_return;
+        }
+
+        if (response.result.has_value()) {
+            auto responseResultJson = nlohmann::json::parse(response.result.value());
+
+            if (responseResultJson.contains("affected_rows") &&
+                responseResultJson.contains("rows")) {
+                for (const auto &row: responseResultJson["rows"]) {
+                    try {
+                        CachedSensor sensor{
+                            .id = row["id"],
+                            .logicId = row["logic_id"],
+                            .moduleId = row["module_id"],
+                            .name = row["name"],
+                            .type = row["type"],
+                            .config = row["config"]
+                        };
+                        cache.setSensor(sensor);
+                    } catch (const std::exception &e) {
+                        Core::Instance().mpLogger->errorf(
+                            "[DATABASE_ACTIONS] [FETCH_SENSORS_CONFIGS] Failed to parse db response: %s", e.what());
+                    }
+                }
+            } else {
+                Core::Instance().mpLogger->error(
+                    "[DATABASE_ACTIONS] [FETCH_SENSORS_CONFIGS] Invalid db response format");
+            }
+        }
+    }
+
+    ba::awaitable<void> DatabaseActions::fetchAllConfigs() {
+        // Make sure cache is cleared before fetching to avoid stale configs
+        Core::Instance().readingsCache().clear();
+        Core::Instance().configCache().clear();
+
+        co_await fetchModulesConfigs();
+        co_await fetchSensorsConfigs();
+    }
+
     void DatabaseActions::sendNotificationToDbService(API::ApiRequest &&notification) {
         connectionId_t dbServiceConnectionId;
         bool foundDbServiceConnection = false;
@@ -258,6 +392,16 @@ namespace SmartHome {
         }
 
         co_return requestResult;
+    }
+
+    ba::awaitable<API::ApiResponse> DatabaseActions::sendRequestToDbService(API::ApiRequest &&request) {
+        API::InternalApi::Command command(request);
+        auto pCmdMeta = std::make_shared<Actions::CommandMetadata>(
+            command,
+            std::make_shared<ba::steady_timer>(Core::Instance().coreUtilityIoContext()),
+            Actions::getNextId());
+
+        co_return co_await sendRequestToDbService(std::move(request), pCmdMeta);
     }
 
     bool DatabaseActions::areParamsValid(API::ApiError &error, const API::InternalApi::Command &command) {

--- a/central_unit/src/core/actions/database_actions.cpp
+++ b/central_unit/src/core/actions/database_actions.cpp
@@ -5,6 +5,7 @@ namespace SmartHome {
     using ai = API::InternalApi;
 
     namespace jmik = JsonRpcStrings::ModuleInfoKeys;
+    namespace jp = JsonRpcStrings::ParamsKeys;
 
     awaitOptApiResponse DatabaseActions::databaseRequestHandler(const cmdMetaPtr &commandMetadata) {
         Core::Instance().mpLogger->debug("[DATABASE_ACTIONS] [REQUEST_HANDLER] called");
@@ -36,9 +37,9 @@ namespace SmartHome {
         API::ApiRequest request;
 
         nlohmann::json dbQuery = {
-            {"table", "modules"},
-            {"columns", {"logic_address", "name", "config", "last_online"}},
-            {"where", {{"id", moduleId}}},
+            {jp::TABLE, "modules"},
+            {jp::COLUMNS, {"logic_address", "name", "config", "last_online"}},
+            {jp::WHERE, {{"id", moduleId}}},
         };
 
         const API::InternalApi::Method method(API::InternalApi::MethodTypes::GET);
@@ -53,17 +54,17 @@ namespace SmartHome {
         nlohmann::json result;
 
         if (response.error.has_value()) {
-            result["error"] = response.error.value().data;
+            result[jp::ERROR] = response.error.value().data;
             co_return result;
         }
 
         if (response.result.has_value()) {
             auto responseResultJson = nlohmann::json::parse(response.result.value());
 
-            if (responseResultJson.contains("affected_rows") &&
-                responseResultJson["affected_rows"] == 1 &&
-                responseResultJson.contains("rows")) {
-                auto row = responseResultJson["rows"].front();
+            if (responseResultJson.contains(jp::AFFECTED_ROWS) &&
+                responseResultJson[jp::AFFECTED_ROWS] == 1 &&
+                responseResultJson.contains(jp::ROWS)) {
+                auto row = responseResultJson[jp::ROWS].front();
 
                 // Extract logic address and RF channel from response
                 try {
@@ -90,7 +91,7 @@ namespace SmartHome {
                         "[DATABASE_ACTIONS] [GET_ADDR_INFO] Failed to update config cache: %s", e.what());
                 }
             } else {
-                result["error"] = "Module not found";
+                result[jp::ERROR] = "Module not found";
             }
         }
         co_return result;
@@ -104,10 +105,10 @@ namespace SmartHome {
 
 
         nlohmann::json dbQuerySubselect = {
-            {"table", "sensors"},
-            {"columns", {"id"}},
+            {jp::TABLE, "sensors"},
+            {jp::COLUMNS, {"id"}},
             {
-                "where", {
+                jp::WHERE, {
                     {"module_id", moduleId},
                     {"logic_id", sensorLogicId}
                 }
@@ -115,10 +116,10 @@ namespace SmartHome {
         };
 
         nlohmann::json dbQuery = {
-            {"table", "sensor_readings"},
+            {jp::TABLE, "sensor_readings"},
             {
-                "values", {
-                    {"sensor_id", {{"$subselect", dbQuerySubselect}}},
+                jp::VALUES, {
+                    {"sensor_id", {{jp::SUBSELECT, dbQuerySubselect}}},
                     {value.is_number() ? "value_numeric" : "value_text", value},
                     {"metadata", metadata}
                 }
@@ -139,9 +140,9 @@ namespace SmartHome {
 
 
         nlohmann::json dbQuery = {
-            {"table", "logs"},
+            {jp::TABLE, "logs"},
             {
-                "values", {
+                jp::VALUES, {
                     {"type", type},
                     {"content", content},
                     {"module_id", moduleId}
@@ -171,9 +172,9 @@ namespace SmartHome {
         oss << std::put_time(&tmUTC, "%Y-%m-%dT%H:%M:%SZ");
 
         nlohmann::json dbQuery = {
-            {"table", "modules"},
-            {"values", {{"last_online", oss.str()}}},
-            {"where", {{"id", moduleId}}}
+            {jp::TABLE, "modules"},
+            {jp::VALUES, {{"last_online", oss.str()}}},
+            {jp::WHERE, {{"id", moduleId}}}
         };
 
         const API::InternalApi::Method method(API::InternalApi::MethodTypes::SET);
@@ -191,8 +192,8 @@ namespace SmartHome {
         API::ApiRequest request;
 
         nlohmann::json dbQuery = {
-            {"table", "modules"},
-            {"columns", nlohmann::json::array({"id", "logic_address", "config", "last_online"})},
+            {jp::TABLE, "modules"},
+            {jp::COLUMNS, nlohmann::json::array({"id", "logic_address", "config", "last_online"})},
         };
 
         const API::InternalApi::Target target(API::InternalApi::TargetTypes::DATABASE);
@@ -215,9 +216,9 @@ namespace SmartHome {
         if (response.result.has_value()) {
             auto responseResultJson = nlohmann::json::parse(response.result.value());
 
-            if (responseResultJson.contains("affected_rows") &&
-                responseResultJson.contains("rows")) {
-                for (const auto &row: responseResultJson["rows"]) {
+            if (responseResultJson.contains(jp::AFFECTED_ROWS) &&
+                responseResultJson.contains(jp::ROWS)) {
+                for (const auto &row: responseResultJson[jp::ROWS]) {
                     try {
                         CachedModule module{
                             .id = row["id"],
@@ -248,9 +249,9 @@ namespace SmartHome {
         API::ApiRequest request;
 
         nlohmann::json dbQuery = {
-            {"table", "sensors"},
+            {jp::TABLE, "sensors"},
             {
-                "columns", nlohmann::json::array(
+                jp::COLUMNS, nlohmann::json::array(
                     {"id", "logic_id", "module_id", "name", "type", "config"})
             },
         };
@@ -275,9 +276,9 @@ namespace SmartHome {
         if (response.result.has_value()) {
             auto responseResultJson = nlohmann::json::parse(response.result.value());
 
-            if (responseResultJson.contains("affected_rows") &&
-                responseResultJson.contains("rows")) {
-                for (const auto &row: responseResultJson["rows"]) {
+            if (responseResultJson.contains(jp::AFFECTED_ROWS) &&
+                responseResultJson.contains(jp::ROWS)) {
+                for (const auto &row: responseResultJson[jp::ROWS]) {
                     try {
                         CachedSensor sensor{
                             .id = row["id"],

--- a/central_unit/src/core/actions/database_actions.cpp
+++ b/central_unit/src/core/actions/database_actions.cpp
@@ -69,7 +69,8 @@ namespace SmartHome {
                 // Extract logic address and RF channel from response
                 try {
                     result[jmik::LOGIC_ADDRESS] = row[jmik::LOGIC_ADDRESS];
-                    result[jmik::RF_CHANNEL] = row["config"][jmik::RF_CHANNEL];
+                    result[Constants::ModuleConfigKeys::CONNECTION] =
+                            row["config"][Constants::ModuleConfigKeys::CONNECTION];
                 } catch (const std::exception &e) {
                     Core::Instance().mpLogger->errorf(
                         "[DATABASE_ACTIONS] [GET_ADDR_INFO] Failed to parse db response %s", e.what());

--- a/central_unit/src/core/actions/database_actions.cpp
+++ b/central_unit/src/core/actions/database_actions.cpp
@@ -77,15 +77,18 @@ namespace SmartHome {
 
                 // Update config cache with retrieved info
                 try {
-                    Core::Instance().configCache().setModule(
-                        CachedModule{
-                            .id = moduleId,
-                            .logicAddress = row[jmik::LOGIC_ADDRESS],
-                            .name = row["name"],
-                            .config = row["config"],
-                            .lastOnline = Utils::parseTimestampTz(row["last_online"])
-                        }
-                    );
+                    auto module = CachedModule{
+                        .id = moduleId,
+                        .logicAddress = row[jmik::LOGIC_ADDRESS],
+                        .name = row["name"],
+                        .config = row["config"],
+                    };
+
+                    if (!row["last_online"].is_null()) {
+                        module.lastOnline = Utils::parseTimestampTz(row["last_online"]);
+                    }
+
+                    Core::Instance().configCache().setModule(module);
                 } catch (const std::exception &e) {
                     Core::Instance().mpLogger->errorf(
                         "[DATABASE_ACTIONS] [GET_ADDR_INFO] Failed to update config cache: %s", e.what());
@@ -174,7 +177,7 @@ namespace SmartHome {
 
         nlohmann::json dbQuery = {
             {jp::TABLE, "modules"},
-            {jp::COLUMNS, nlohmann::json::array({"id", "logic_address", "config", "last_online"})},
+            {jp::COLUMNS, nlohmann::json::array({"id", "name", "logic_address", "config", "last_online"})},
         };
 
         const API::InternalApi::Target target(API::InternalApi::TargetTypes::DATABASE);
@@ -206,8 +209,12 @@ namespace SmartHome {
                             .logicAddress = row["logic_address"],
                             .name = row["name"],
                             .config = row["config"],
-                            .lastOnline = Utils::parseTimestampTz(row["last_online"])
                         };
+
+                        if (!row["last_online"].is_null()) {
+                            module.lastOnline = Utils::parseTimestampTz(row["last_online"]);
+                        }
+
                         cache.setModule(module);
                     } catch (const std::exception &e) {
                         Core::Instance().mpLogger->errorf(

--- a/central_unit/src/core/actions/database_actions.cpp
+++ b/central_unit/src/core/actions/database_actions.cpp
@@ -51,7 +51,7 @@ namespace SmartHome {
         API::InternalApi::Command command(request);
         auto pCmdMeta = std::make_shared<Actions::CommandMetadata>(
             command,
-            std::make_shared<ba::steady_timer>(Core::Instance().getCoreUtilityIoContext()),
+            std::make_shared<ba::steady_timer>(Core::Instance().coreUtilityIoContext()),
             Actions::getNextId());
 
 
@@ -196,7 +196,7 @@ namespace SmartHome {
             return;
         }
 
-        ba::post(Core::Instance().getCoreWorkerIoContext(), [notification, dbServiceConnectionId]()mutable {
+        ba::post(Core::Instance().coreWorkerIoContext(), [notification, dbServiceConnectionId]()mutable {
             Actions::handleOutgoingRequest(dbServiceConnectionId, std::move(notification), nullptr);
         });
     }
@@ -233,7 +233,7 @@ namespace SmartHome {
             co_return requestResult;
         }
 
-        ba::post(Core::Instance().getCoreWorkerIoContext(),
+        ba::post(Core::Instance().coreWorkerIoContext(),
                  [promise, request, dbServiceConnectionId]()mutable {
                      Actions::handleOutgoingRequest(dbServiceConnectionId, std::move(request), promise);
                  });

--- a/central_unit/src/core/actions/database_actions.cpp
+++ b/central_unit/src/core/actions/database_actions.cpp
@@ -98,28 +98,16 @@ namespace SmartHome {
     }
 
 
-    void DatabaseActions::postSensorReading(uint moduleId, uint sensorLogicId,
-                                            nlohmann::json value,
-                                            nlohmann::json metadata) {
+    void DatabaseActions::postSensorReading(
+        uint sensorId,
+        nlohmann::json value, nlohmann::json metadata) {
         API::ApiRequest notification;
-
-
-        nlohmann::json dbQuerySubselect = {
-            {jp::TABLE, "sensors"},
-            {jp::COLUMNS, {"id"}},
-            {
-                jp::WHERE, {
-                    {"module_id", moduleId},
-                    {"logic_id", sensorLogicId}
-                }
-            }
-        };
 
         nlohmann::json dbQuery = {
             {jp::TABLE, "sensor_readings"},
             {
                 jp::VALUES, {
-                    {"sensor_id", {{jp::SUBSELECT, dbQuerySubselect}}},
+                    {"sensor_id", sensorId},
                     {value.is_number() ? "value_numeric" : "value_text", value},
                     {"metadata", metadata}
                 }
@@ -162,18 +150,11 @@ namespace SmartHome {
     void DatabaseActions::updateModuleLastOnline(uint moduleId) {
         API::ApiRequest notification;
 
-        auto nowTimeP = std::chrono::system_clock::now();
-        auto nowTimeT = std::chrono::system_clock::to_time_t(nowTimeP);
-
-        std::tm tmUTC;
-        gmtime_r(&nowTimeT, &tmUTC);
-
-        std::ostringstream oss;
-        oss << std::put_time(&tmUTC, "%Y-%m-%dT%H:%M:%SZ");
+        const auto timestamp = Utils::timePointToTimestampTz(std::chrono::system_clock::now());
 
         nlohmann::json dbQuery = {
             {jp::TABLE, "modules"},
-            {jp::VALUES, {{"last_online", oss.str()}}},
+            {jp::VALUES, {{"last_online", timestamp}}},
             {jp::WHERE, {{"id", moduleId}}}
         };
 
@@ -223,6 +204,7 @@ namespace SmartHome {
                         CachedModule module{
                             .id = row["id"],
                             .logicAddress = row["logic_address"],
+                            .name = row["name"],
                             .config = row["config"],
                             .lastOnline = Utils::parseTimestampTz(row["last_online"])
                         };
@@ -397,7 +379,7 @@ namespace SmartHome {
 
     ba::awaitable<API::ApiResponse> DatabaseActions::sendRequestToDbService(API::ApiRequest &&request) {
         API::InternalApi::Command command(request);
-        auto pCmdMeta = std::make_shared<Actions::CommandMetadata>(
+        const auto pCmdMeta = std::make_shared<Actions::CommandMetadata>(
             command,
             std::make_shared<ba::steady_timer>(Core::Instance().coreUtilityIoContext()),
             Actions::getNextId());

--- a/central_unit/src/core/actions/database_actions.h
+++ b/central_unit/src/core/actions/database_actions.h
@@ -73,6 +73,12 @@ namespace SmartHome {
          */
         static void updateModuleLastOnline(uint moduleId);
 
+        static ba::awaitable<void> fetchModulesConfigs();
+
+        static ba::awaitable<void> fetchSensorsConfigs();
+
+        static ba::awaitable<void> fetchAllConfigs();
+
     private:
         /**
          * @brief Send an asynchronous notification request to db-service.
@@ -98,6 +104,8 @@ namespace SmartHome {
          */
         static ba::awaitable<API::ApiResponse> sendRequestToDbService(API::ApiRequest &&request,
                                                                       cmdMetaPtr commandMetadata);
+
+        static ba::awaitable<API::ApiResponse> sendRequestToDbService(API::ApiRequest &&request);
 
         /**
          * @brief Validate incoming command parameters for database operations.

--- a/central_unit/src/core/actions/database_actions.h
+++ b/central_unit/src/core/actions/database_actions.h
@@ -44,12 +44,11 @@ namespace SmartHome {
          * @details Builds a SET notification which inserts a \c 'sensor_readings' row using a
          *          subselect to resolve sensor id and sends it as an asynchronous notification.
          *
-         * @param moduleId Module id associated with the sensor.
-         * @param sensorLogicId Logical sensor id within the module.
+         * @param sensorId Sensor id for the reading.
          * @param value Sensor value (numeric or textual) to store.
          * @param metadata Additional JSON metadata to store alongside the reading.
          */
-        static void postSensorReading(uint moduleId, uint sensorLogicId, nlohmann::json value, nlohmann::json metadata);
+        static void postSensorReading(uint sensorId, nlohmann::json value, nlohmann::json metadata);
 
         /**
          * @brief Post a log entry to the database for a module.
@@ -73,13 +72,29 @@ namespace SmartHome {
          */
         static void updateModuleLastOnline(uint moduleId);
 
+        /**
+         * @brief Fetch module configuration rows into config cache.
+         *
+         * @details Clears module cache and queries db-service for all modules,
+         *          then populates \c ConfigCache with returned rows.
+         */
         static ba::awaitable<void> fetchModulesConfigs();
 
+        /**
+         * @brief Fetch sensor configuration rows into config cache.
+         *
+         * @details Clears readings and sensor cache, queries db-service for all sensors,
+         *          then populates \c ConfigCache with returned rows.
+         */
         static ba::awaitable<void> fetchSensorsConfigs();
 
+        /**
+         * @brief Fetch module and sensor configurations.
+         *
+         * @details Clears caches and sequentially fetches modules and sensors from db-service.
+         */
         static ba::awaitable<void> fetchAllConfigs();
 
-    private:
         /**
          * @brief Send an asynchronous notification request to db-service.
          *
@@ -105,8 +120,19 @@ namespace SmartHome {
         static ba::awaitable<API::ApiResponse> sendRequestToDbService(API::ApiRequest &&request,
                                                                       cmdMetaPtr commandMetadata);
 
+        /**
+         * @brief Send request to db-service and await response.
+         *
+         * @details Convenience overload that creates command metadata and delegates to the
+         *          main request handler.
+         *
+         * @param request API request to send to db-service.
+         *
+         * @return API response from db-service or error on failure.
+         */
         static ba::awaitable<API::ApiResponse> sendRequestToDbService(API::ApiRequest &&request);
 
+    private:
         /**
          * @brief Validate incoming command parameters for database operations.
          *
@@ -127,7 +153,6 @@ namespace SmartHome {
          *
          * @param request API request to populate.
          * @param command Command providing id and method values.
-         *
          */
         static void prepareRequestToDatabase(API::ApiRequest &request,
                                              const API::InternalApi::Command &command);

--- a/central_unit/src/core/actions/mediator_actions.cpp
+++ b/central_unit/src/core/actions/mediator_actions.cpp
@@ -329,7 +329,18 @@ namespace SmartHome {
     ba::awaitable<bool> MediatorActions::getModuleAddressingInfo(nlohmann::json &preparedParams,
                                                                  const uint moduleId,
                                                                  std::string &error) {
-        const auto moduleInfo = co_await DatabaseActions::getModuleAddressingInfo(moduleId);
+        nlohmann::json moduleInfo;
+        auto module = Core::Instance().configCache().getModule(moduleId);
+        if (module.has_value() && module->config.contains(jmik::RF_CHANNEL)) {
+            Core::Instance().mpLogger->debugf(
+                "[MEDIATOR_ACTIONS] [GET_MODULE_INFO] Fetched module info from cache for module %u",
+                moduleId);
+            moduleInfo[jmik::LOGIC_ADDRESS] = module->logicAddress;
+            moduleInfo[jmik::RF_CHANNEL] = module->config.at(jmik::RF_CHANNEL);
+        } else {
+            moduleInfo = co_await DatabaseActions::getModuleAddressingInfo(moduleId);
+        }
+
 
         if (!moduleInfo.contains(jmik::LOGIC_ADDRESS) || !moduleInfo.contains(jmik::RF_CHANNEL)) {
             if (moduleInfo.contains(jr::ERROR)) error = moduleInfo[jr::ERROR];
@@ -353,6 +364,19 @@ namespace SmartHome {
         if (!parsedParams.args.has_value()) return;
         if (parsedParams.args.value().empty()) return;
 
+        const auto sensorId = Core::Instance().configCache().findSensorId(parsedParams.moduleId.value(),
+                                                                          parsedParams.args.value().front());
+        if (sensorId.has_value()) {
+            Core::Instance().readingsCache().set(sensorId.value(), result);
+            Core::Instance().mpLogger->debugf(
+                "[MEDIATOR_ACTIONS] [POST_READING] Saved sensor reading to cache for sensor ID", sensorId.value());
+        } else {
+            Core::Instance().mpLogger->warningf(
+                "[MEDIATOR_ACTIONS] [POST_READING] Could not find sensor ID for module [%u] "
+                "and logic sensor ID [%u] in cache, skipping saving reading to cache",
+                parsedParams.moduleId.value(),
+                parsedParams.args.value().front().dump().c_str());
+        }
 
         DatabaseActions::postSensorReading(parsedParams.moduleId.value(),
                                            parsedParams.args.value().front(),

--- a/central_unit/src/core/actions/mediator_actions.cpp
+++ b/central_unit/src/core/actions/mediator_actions.cpp
@@ -7,6 +7,7 @@ namespace SmartHome {
     namespace jp = JsonRpcStrings::ParamsKeys;
     namespace jmik = JsonRpcStrings::ModuleInfoKeys;
     namespace jr = JsonRpcStrings::ResponseKeys;
+    namespace cmck = Constants::ModuleConfigKeys;
 
     awaitOptApiResponse MediatorActions::mediatorGetHandler(const cmdMetaPtr &commandMetadata) {
         Core::Instance().mpLogger->debug("[MEDIATOR_ACTIONS] [GET] called");
@@ -239,6 +240,9 @@ namespace SmartHome {
             co_return resultResponse;
         }
 
+        // Send sleep before request, to allow API to batch it together
+        sendSleepIfConfigured(moduleId, rtmParams[jp::MODULE_INFO]);
+
         resultResponse = co_await sendRequestToMediator(std::move(request), commandMetadata);
 
         // Send to db
@@ -327,6 +331,75 @@ namespace SmartHome {
         co_return requestResult;
     }
 
+    void MediatorActions::sendSleepIfConfigured(uint moduleId, const nlohmann::json &moduleInfo) {
+        Core::Instance().mpLogger->debug("[TEST] SLEEP");
+        const auto configOpt = Core::Instance().configCache().getModule(moduleId);
+        if (!configOpt.has_value()) return;
+        Core::Instance().mpLogger->debug("[TEST] SLEEP2");
+
+        const auto &config = configOpt->config;
+        if (!config.contains(cmck::SLEEP_AFTER_SEND) ||
+            !config.at(cmck::SLEEP_AFTER_SEND).is_boolean() ||
+            !config.at(cmck::SLEEP_AFTER_SEND))
+            return;
+        Core::Instance().mpLogger->debug("[TEST] SLEEP3");
+
+        uint sleepDurationMs = 0;
+        const auto nextScheduledRunTimePoint = Core::Instance().scheduler().getNextRunForModule(moduleId);
+        if (nextScheduledRunTimePoint.has_value()) {
+            sleepDurationMs = static_cast<uint>(
+                std::chrono::duration_cast<std::chrono::milliseconds>(nextScheduledRunTimePoint.value() -
+                                                                      std::chrono::system_clock::now()).count());
+        } else if (config.contains(cmck::DEFAULT_SLEEP_DURATION) &&
+                   config.at(cmck::DEFAULT_SLEEP_DURATION).is_number_integer()) {
+            sleepDurationMs = config.at(cmck::DEFAULT_SLEEP_DURATION).get<uint>();
+        } else { return; }
+        Core::Instance().mpLogger->debug("[TEST] SLEEP4");
+
+        if (sleepDurationMs == 0) return;
+        Core::Instance().mpLogger->debug("[TEST] SLEEP5");
+
+        std::string actionStr = Constants::MediatorTypes::SLEEP.data();
+        if (config.contains(cmck::POWER_SAVING) && config.at(cmck::POWER_SAVING).is_boolean() &&
+            config.at(cmck::POWER_SAVING)) {
+            actionStr = Constants::MediatorTypes::DEEP_SLEEP.data();
+        }
+
+        API::ApiRequest sleepNotification;
+        sleepNotification.method = API::getTargetMethodString(Constants::Targets::MODULE_MEDIATOR,
+                                                              Constants::Methods::EXECUTE);
+
+        API::InternalApi::Command command(sleepNotification);
+        auto &params = prepareRequestToMediator(sleepNotification, command);
+        params[jp::TYPE] = actionStr;
+        params[jp::ARGS] = nlohmann::json::array({sleepDurationMs});
+        params[jp::MODULE_INFO] = moduleInfo;
+
+        std::optional<connectionId_t> mediatorConnectionId;
+
+        // Find mediator connection, TODO add function for finding connection
+        {
+            std::scoped_lock lock(Actions::msConnectionTypeMapLock);
+            auto iter = Actions::msConnectionTypeMap.find(sai::TargetTypes::MODULE_MEDIATOR);
+            if (iter != Actions::msConnectionTypeMap.end() && !iter->second.empty()) {
+                mediatorConnectionId = *iter->second.begin();
+            }
+        }
+
+        if (!mediatorConnectionId.has_value()) {
+            return;
+        }
+        Core::Instance().mpLogger->debug("[TEST] SLEEP6");
+
+        const auto mediatorId = mediatorConnectionId.value();
+
+        ba::post(Core::Instance().coreWorkerIoContext(),
+                 [sleepRequest = std::move(sleepNotification), mediatorId]() mutable {
+                     Core::Instance().mpLogger->debug("[TEST] SLEEP7");
+                     Actions::handleOutgoingRequest(mediatorId, std::move(sleepRequest), nullptr);
+                 });
+    }
+
     nlohmann::json &MediatorActions::prepareRequestToMediator(API::ApiRequest &request,
                                                               const API::InternalApi::Command &command) {
         request.id = command.commandId;
@@ -343,26 +416,37 @@ namespace SmartHome {
                                                                  std::string &error) {
         nlohmann::json moduleInfo;
         auto module = Core::Instance().configCache().getModule(moduleId);
-        if (module.has_value() && module->config.contains(jmik::RF_CHANNEL)) {
+
+
+        if (module.has_value() &&
+            module->config.contains(cmck::CONNECTION) &&
+            module->config.at(cmck::CONNECTION).contains(jmik::RF_CHANNEL) &&
+            module->config.at(cmck::CONNECTION)[jmik::RF_CHANNEL].is_number_integer()) {
             Core::Instance().mpLogger->debugf(
                 "[MEDIATOR_ACTIONS] [GET_MODULE_INFO] Fetched module info from cache for module %u",
                 moduleId);
             moduleInfo[jmik::LOGIC_ADDRESS] = module->logicAddress;
-            moduleInfo[jmik::RF_CHANNEL] = module->config.at(jmik::RF_CHANNEL);
+            moduleInfo[cmck::CONNECTION] =
+                    module->config.at(cmck::CONNECTION);
         } else {
             moduleInfo = co_await DatabaseActions::getModuleAddressingInfo(moduleId);
         }
 
 
-        if (!moduleInfo.contains(jmik::LOGIC_ADDRESS) || !moduleInfo.contains(jmik::RF_CHANNEL)) {
-            if (moduleInfo.contains(jr::ERROR)) error = moduleInfo[jr::ERROR];
-            else error = "Failed to fetch module info from database: unknown error";
+        if (!moduleInfo.contains(jmik::LOGIC_ADDRESS) ||
+            !moduleInfo.contains(cmck::CONNECTION) ||
+            !moduleInfo[cmck::CONNECTION].contains(jmik::RF_CHANNEL)) {
+            if (moduleInfo.contains(jr::ERROR)) {
+                error = moduleInfo[jr::ERROR];
+            } else {
+                error = "Failed to fetch module info from database: unknown error";
+            }
             co_return false;
         }
 
         preparedParams[jp::MODULE_INFO] = nlohmann::json::object({
             {jmik::LOGIC_ADDRESS, moduleInfo.at(jmik::LOGIC_ADDRESS)},
-            {jmik::RF_CHANNEL, moduleInfo.at(jmik::RF_CHANNEL)},
+            {jmik::RF_CHANNEL, moduleInfo.at(cmck::CONNECTION).at(jmik::RF_CHANNEL)},
         });
 
         co_return true;

--- a/central_unit/src/core/actions/mediator_actions.cpp
+++ b/central_unit/src/core/actions/mediator_actions.cpp
@@ -15,56 +15,40 @@ namespace SmartHome {
         API::ApiResponse commandResult;
         API::ApiError error;
 
+        if (!command.params.has_value() || !command.params->is_object()) {
+            commandResult.error = API::ApiError(
+                API::ErrorCodes::INVALID_PARAMS,
+                errorCodeToString(API::ErrorCodes::INVALID_PARAMS),
+                "Mediator get requires params object");
+            co_return commandResult;
+        }
+
+        const auto &params = command.params.value();
+
         commandResult.id = command.commandId;
         error.code = API::ErrorCodes::INVALID_PARAMS;
         error.message = API::errorCodeToString(error.code);
 
-        API::ApiRequest requestToMediator;
-        auto &rtmParams = prepareRequestToMediator(requestToMediator, command);
 
-        const auto &params = command.params.value();
+        // If module_id is provided, send request to specific module via mediator, otherwise send to mediator directly.
+        if (params.contains(jp::MODULE_ID) && params.at(jp::MODULE_ID).is_number_integer()) {
+            std::string type;
+            if (params.contains(jp::TYPE) && params.at(jp::TYPE).is_string())
+                type = params.at(jp::TYPE);
 
-        auto parsedParams = parseMediatorParams(params, rtmParams);
+            nlohmann::json args = nlohmann::json::array();
+            if (params.contains(jp::ARGS) && params.at(jp::ARGS).is_array())
+                args = params.at(jp::ARGS);
 
-        if (parsedParams.moduleId.has_value() && !co_await getModuleAddressingInfo(
-                rtmParams, parsedParams.moduleId.value(), error.data)) {
-            error.code = API::ErrorCodes::INTERNAL_ERROR;
-            error.message = API::errorCodeToString(error.code);
-            commandResult.error = error;
+            commandResult = co_await sendToModule(
+                commandMetadata, params.at(jp::MODULE_ID).get<uint>(), type, args, API::InternalApi::MethodTypes::GET);
             co_return commandResult;
         }
 
-        commandResult = co_await sendRequestToMediator(std::move(requestToMediator), commandMetadata);
-
-        // Send to db
-        if (parsedParams.moduleId.has_value()) {
-            static const std::set sensorReadApplicableGetTypes = {
-                Constants::MediatorTypes::SENSOR_VALUE,
-                Constants::MediatorTypes::FORCE_READ_SENSOR_VALUE,
-                Constants::MediatorTypes::ACTUATOR_VALUE
-            };
-
-            if (commandResult.result.has_value()) {
-                DatabaseActions::updateModuleLastOnline(parsedParams.moduleId.value());
-
-                nlohmann::json result;
-                try {
-                    result = nlohmann::json::parse(commandResult.result.value());
-                } catch (const std::exception &e) {
-                    Core::Instance().mpLogger->errorf("[MEDIATOR_ACTIONS] [GET] Failed to parse result as JSON: %s",
-                                                      e.what());
-                    error.code = API::ErrorCodes::INTERNAL_ERROR;
-                    error.message = API::errorCodeToString(error.code);
-                    error.data = e.what();
-                    commandResult.result.reset();
-                    commandResult.error = error;
-                    co_return commandResult;
-                }
-                postSensorReadingIfApplicable(parsedParams, result, sensorReadApplicableGetTypes);
-            } else {
-                postErrorLog(parsedParams.moduleId.value(), commandResult);
-            }
-        }
+        // If no module_id provided, send get request to mediator itself
+        API::ApiRequest request;
+        prepareRequestToMediator(request, command);
+        commandResult = co_await sendRequestToMediator(std::move(request), commandMetadata);
 
         co_return commandResult;
     }
@@ -76,54 +60,40 @@ namespace SmartHome {
         API::ApiResponse commandResult;
         API::ApiError error;
 
+        if (!command.params.has_value() || !command.params->is_object()) {
+            commandResult.error = API::ApiError(
+                API::ErrorCodes::INVALID_PARAMS,
+                errorCodeToString(API::ErrorCodes::INVALID_PARAMS),
+                "Mediator set requires params object");
+            co_return commandResult;
+        }
+
+        const auto &params = command.params.value();
+
         commandResult.id = command.commandId;
         error.code = API::ErrorCodes::INVALID_PARAMS;
         error.message = API::errorCodeToString(error.code);
 
-        API::ApiRequest requestToMediator;
-        auto &rtmParams = prepareRequestToMediator(requestToMediator, command);
 
-        const auto &params = command.params.value();
+        // If module_id is provided, send request to specific module via mediator, otherwise send to mediator directly.
+        if (params.contains(jp::MODULE_ID) && params.at(jp::MODULE_ID).is_number_integer()) {
+            std::string type;
+            if (params.contains(jp::TYPE) && params.at(jp::TYPE).is_string())
+                type = params.at(jp::TYPE);
 
-        auto parsedParams = parseMediatorParams(params, rtmParams);
+            nlohmann::json args = nlohmann::json::array();
+            if (params.contains(jp::ARGS) && params.at(jp::ARGS).is_array())
+                args = params.at(jp::ARGS);
 
-        if (parsedParams.moduleId.has_value() && !co_await getModuleAddressingInfo(
-                rtmParams, parsedParams.moduleId.value(), error.data)) {
-            error.code = API::ErrorCodes::INTERNAL_ERROR;
-            error.message = API::errorCodeToString(error.code);
-            commandResult.error = error;
+            commandResult = co_await sendToModule(
+                commandMetadata, params.at(jp::MODULE_ID).get<uint>(), type, args, API::InternalApi::MethodTypes::SET);
             co_return commandResult;
         }
 
-        commandResult = co_await sendRequestToMediator(std::move(requestToMediator), commandMetadata);
-
-        // Send to db
-        if (parsedParams.moduleId.has_value()) {
-            static const std::set sensorReadApplicableSetTypes = {
-                Constants::MediatorTypes::TOGGLE_ACTUATOR, Constants::MediatorTypes::SET_ACTUATOR_VALUE,
-            };
-
-            if (commandResult.result.has_value()) {
-                DatabaseActions::updateModuleLastOnline(parsedParams.moduleId.value());
-
-                nlohmann::json result;
-                try {
-                    result = nlohmann::json::parse(commandResult.result.value());
-                } catch (const std::exception &e) {
-                    Core::Instance().mpLogger->errorf("[MEDIATOR_ACTIONS] [SET] Failed to parse result as JSON: %s",
-                                                      e.what());
-                    error.code = API::ErrorCodes::INTERNAL_ERROR;
-                    error.message = API::errorCodeToString(error.code);
-                    error.data = e.what();
-                    commandResult.result.reset();
-                    commandResult.error = error;
-                    co_return commandResult;
-                }
-                postSensorReadingIfApplicable(parsedParams, result, sensorReadApplicableSetTypes);
-            } else {
-                postErrorLog(parsedParams.moduleId.value(), commandResult);
-            }
-        }
+        // If no module_id provided, send set request to mediator itself
+        API::ApiRequest request;
+        prepareRequestToMediator(request, command);
+        commandResult = co_await sendRequestToMediator(std::move(request), commandMetadata);
 
         co_return commandResult;
     }
@@ -136,52 +106,62 @@ namespace SmartHome {
         API::ApiResponse commandResult;
         API::ApiError error;
 
+        if (!command.params.has_value() || !command.params->is_object()) {
+            commandResult.error = API::ApiError(
+                API::ErrorCodes::INVALID_PARAMS,
+                errorCodeToString(API::ErrorCodes::INVALID_PARAMS),
+                "Mediator execute requires params object");
+            co_return commandResult;
+        }
+
+        const auto &params = command.params.value();
+
         commandResult.id = command.commandId;
         error.code = API::ErrorCodes::INVALID_PARAMS;
         error.message = API::errorCodeToString(error.code);
 
-        API::ApiRequest requestToMediator;
-        auto &rtmParams = prepareRequestToMediator(requestToMediator, command);
+        // If module_id is provided, send request to specific module via mediator, otherwise send to mediator directly.
+        if (params.contains(jp::MODULE_ID) && params.at(jp::MODULE_ID).is_number_integer()) {
+            auto moduleId = params.at(jp::MODULE_ID).get<uint>();
 
-        const auto &params = command.params.value();
+            std::string type;
+            if (params.contains(jp::TYPE) && params.at(jp::TYPE).is_string())
+                type = params.at(jp::TYPE);
 
-        auto [moduleId, type, args] = parseMediatorParams(params, rtmParams);
+            nlohmann::json args = nlohmann::json::array();
+            if (params.contains(jp::ARGS) && params.at(jp::ARGS).is_array())
+                args = params.at(jp::ARGS);
 
-        if (moduleId.has_value() && !co_await getModuleAddressingInfo(
-                rtmParams, moduleId.value(), error.data)) {
-            error.code = API::ErrorCodes::INTERNAL_ERROR;
-            error.message = API::errorCodeToString(error.code);
-            commandResult.error = error;
+            commandResult = co_await sendToModule(
+                commandMetadata, moduleId, type, args, API::InternalApi::MethodTypes::EXECUTE);
+
+            // Log action execution result
+            char buffer[1024];
+            std::string action = type.empty() ? Constants::Common::NONE_BRACKETS.data() : type;
+            std::string actionArgument = args.empty() ? Constants::Common::NONE_BRACKETS.data() : args.dump();
+
+            std::string loggedResult;
+            if (commandResult.result.has_value()) {
+                loggedResult = "result: " + commandResult.result.value();
+            } else if (commandResult.error.has_value()) {
+                loggedResult = "error: " + commandResult.error.value().to_string();
+            } else {
+                loggedResult = "unexpected error: no result or error returned";
+            }
+
+
+            snprintf(buffer, sizeof(buffer), "Action '%s' with args '%s' executed, with %s",
+                     action.c_str(), actionArgument.c_str(), loggedResult.c_str());
+
+
+            DatabaseActions::postLog(moduleId, "info", buffer);
             co_return commandResult;
         }
 
-        commandResult = co_await sendRequestToMediator(std::move(requestToMediator), commandMetadata);
-
-        // Send to db
-        if (moduleId.has_value()) {
-            if (commandResult.result.has_value()) {
-                DatabaseActions::updateModuleLastOnline(moduleId.value());
-
-                char buffer[1024];
-
-                std::string action = Constants::Common::NONE_BRACKETS.data();
-                std::string actionArgument = Constants::Common::NONE_BRACKETS.data();
-                if (type.has_value()) {
-                    action = type.value();
-                }
-                if (args.has_value()) {
-                    actionArgument = args.value().dump();
-                }
-
-                snprintf(buffer, sizeof(buffer), "Action '%s' with args '%s' executed, with result: %s",
-                         action.c_str(), actionArgument.c_str(), commandResult.result.value().c_str());
-
-
-                DatabaseActions::postLog(moduleId.value(), "info", buffer);
-            } else {
-                postErrorLog(moduleId.value(), commandResult);
-            }
-        }
+        // If no module_id provided, execute command on mediator itself
+        API::ApiRequest request;
+        prepareRequestToMediator(request, command);
+        commandResult = co_await sendRequestToMediator(std::move(request), commandMetadata);
 
         co_return commandResult;
     }
@@ -202,10 +182,12 @@ namespace SmartHome {
 
         const auto &params = command.params.value();
 
+        // Check for module_id for ping targeting. If not provided or invalid, the ping will be sent to mediator itself.
         std::optional<uint> moduleId;
-        if (params.contains(jp::MODULE_ID) && params.at(jp::MODULE_ID).is_number())
+        if (params.contains(jp::MODULE_ID) && params.at(jp::MODULE_ID).is_number_integer())
             moduleId = params.at(jp::MODULE_ID);
 
+        // Try to get module addressing info if module_id is provided.
         if (moduleId.has_value() && !co_await getModuleAddressingInfo(rtmParams, moduleId.value(), error.data)) {
             error.code = API::ErrorCodes::INTERNAL_ERROR;
             error.message = API::errorCodeToString(error.code);
@@ -213,10 +195,9 @@ namespace SmartHome {
             co_return commandResult;
         }
 
+        // Send request with timestamp for ping time measurement.
         const auto requestSendTimestamp = std::chrono::system_clock::now();
-
         commandResult = co_await sendRequestToMediator(std::move(requestToMediator), commandMetadata);
-
         const auto requestDuration = std::chrono::system_clock::now() - requestSendTimestamp;
 
         // Return ping time in ms on received result
@@ -235,6 +216,57 @@ namespace SmartHome {
 
         co_return commandResult;
     }
+
+    ba::awaitable<API::ApiResponse> MediatorActions::sendToModule(const cmdMetaPtr &commandMetadata,
+                                                                  uint moduleId,
+                                                                  std::string_view type,
+                                                                  const nlohmann::json &args,
+                                                                  API::InternalApi::MethodTypes method) {
+        API::ApiResponse resultResponse;
+        API::ApiError error;
+        resultResponse.id = commandMetadata->command.commandId;
+
+        API::ApiRequest request;
+        auto &rtmParams = prepareRequestToMediator(request, commandMetadata->command);
+        rtmParams[jp::TYPE] = type;
+        rtmParams[jp::ARGS] = args;
+
+
+        if (!co_await getModuleAddressingInfo(rtmParams, moduleId, error.data)) {
+            error.code = API::ErrorCodes::INTERNAL_ERROR;
+            error.message = API::errorCodeToString(error.code);
+            resultResponse.error = error;
+            co_return resultResponse;
+        }
+
+        resultResponse = co_await sendRequestToMediator(std::move(request), commandMetadata);
+
+        // Send to db
+        if (resultResponse.result.has_value()) {
+            DatabaseActions::updateModuleLastOnline(moduleId);
+            Core::Instance().configCache().updateModuleLastOnline(moduleId, std::chrono::system_clock::now());
+
+            try {
+                auto parsed = nlohmann::json::parse(resultResponse.result.value());
+                MediatorRequestParams mrp{moduleId, std::string(type), args};
+                postSensorReadingIfApplicable(mrp, parsed, getApplicableTypes(method));
+            } catch (const std::exception &e) {
+                Core::Instance().mpLogger->errorf("[MEDIATOR_ACTIONS] [SET] Failed to parse result as JSON: %s",
+                                                  e.what());
+                error.code = API::ErrorCodes::INTERNAL_ERROR;
+                error.message = API::errorCodeToString(error.code);
+                error.data = e.what();
+                resultResponse.result.reset();
+                resultResponse.error = error;
+                co_return resultResponse;
+            }
+        } else {
+            postErrorLog(moduleId, resultResponse);
+        }
+
+        co_return resultResponse;
+    }
+
 
     ba::awaitable<API::ApiResponse> MediatorActions::sendRequestToMediator(API::ApiRequest &&request,
                                                                            const cmdMetaPtr commandMetadata) {
@@ -306,29 +338,6 @@ namespace SmartHome {
         return request.params.value();
     }
 
-    MediatorActions::MediatorRequestParams MediatorActions::parseMediatorParams(const nlohmann::json &incomingParams,
-        nlohmann::json &rtmParams) {
-        MediatorRequestParams requestParams;
-
-        if (incomingParams.contains(jp::MODULE_ID) && incomingParams.at(jp::MODULE_ID).is_number()) {
-            requestParams.moduleId = incomingParams.at(jp::MODULE_ID);
-        }
-
-        if (incomingParams.contains(jp::TYPE) && incomingParams.at(jp::TYPE).is_string()) {
-            requestParams.type = incomingParams.at(jp::TYPE);
-            rtmParams[jp::TYPE] = incomingParams.at(jp::TYPE);
-        }
-
-        if (incomingParams.contains(jp::ARGS) && incomingParams.at(jp::ARGS).is_array() && !incomingParams.
-            at(jp::ARGS).
-            empty()) {
-            requestParams.args = incomingParams.at(jp::ARGS);
-            rtmParams[jp::ARGS] = incomingParams.at(jp::ARGS);
-        }
-
-        return requestParams;
-    }
-
     ba::awaitable<bool> MediatorActions::getModuleAddressingInfo(nlohmann::json &preparedParams,
                                                                  const uint moduleId,
                                                                  std::string &error) {
@@ -362,29 +371,45 @@ namespace SmartHome {
     void MediatorActions::postSensorReadingIfApplicable(const MediatorRequestParams &parsedParams,
                                                         const nlohmann::json &result,
                                                         const std::set<std::string_view> &applicableTypes) {
-        if (!parsedParams.moduleId.has_value()) return;
-        if (!parsedParams.type.has_value() || !applicableTypes.contains(parsedParams.type.value())) return;
-        if (!parsedParams.args.has_value()) return;
-        if (parsedParams.args.value().empty()) return;
+        if (!parsedParams.args.has_value() ||
+            parsedParams.args.value().empty() ||
+            !parsedParams.args.value().front().is_number_integer())
+            return;
 
-        const auto sensorId = Core::Instance().configCache().findSensorId(parsedParams.moduleId.value(),
-                                                                          parsedParams.args.value().front());
-        if (sensorId.has_value()) {
-            Core::Instance().readingsCache().set(sensorId.value(), result);
-            Core::Instance().mpLogger->debugf(
-                "[MEDIATOR_ACTIONS] [POST_READING] Saved sensor reading to cache for sensor ID", sensorId.value());
+        const int value = parsedParams.args.value().front().get<uint>();
+        uint sensorIdCandidate = value >= 0 ? static_cast<uint>(value) : 0;
+
+        std::optional<uint> sensorIdOpt;
+        // Parse first arg as sensor ID when module_id is not provided
+        if (!parsedParams.moduleId.has_value()) {
+            sensorIdOpt = sensorIdCandidate;
         } else {
-            Core::Instance().mpLogger->warningf(
-                "[MEDIATOR_ACTIONS] [POST_READING] Could not find sensor ID for module [%u] "
-                "and logic sensor ID [%u] in cache, skipping saving reading to cache",
-                parsedParams.moduleId.value(),
-                parsedParams.args.value().front().dump().c_str());
+            sensorIdOpt = Core::Instance().configCache().findSensorId(parsedParams.moduleId.value(),
+                                                                      sensorIdCandidate);
         }
 
-        DatabaseActions::postSensorReading(parsedParams.moduleId.value(),
-                                           parsedParams.args.value().front(),
-                                           result,
-                                           {{jp::TYPE, parsedParams.type.value()}});
+        if (!parsedParams.type.has_value() || !applicableTypes.contains(parsedParams.type.value())) return;
+
+
+        if (sensorIdOpt.has_value()) {
+            Core::Instance().mpLogger->debugf(
+                "[MEDIATOR_ACTIONS] [POST_READING] Saving sensor reading to cache and database for sensor ID [%u]",
+                sensorIdOpt.value());
+
+            const nlohmann::json readingMetadata = {{jp::TYPE, parsedParams.type.value()}};
+
+            Core::Instance().readingsCache().set(sensorIdOpt.value(), result, readingMetadata);
+
+            DatabaseActions::postSensorReading(sensorIdOpt.value(),
+                                               result,
+                                               readingMetadata);
+            return;
+        }
+        Core::Instance().mpLogger->warningf(
+            "[MEDIATOR_ACTIONS] [POST_READING] Could not find sensor ID for module [%u] "
+            "and logic sensor ID [%u] in cache. Skipping saving reading to cache and database.",
+            parsedParams.moduleId.value(),
+            parsedParams.args.value().front().dump().c_str());
     }
 
     void MediatorActions::postErrorLog(const uint moduleId, const API::ApiResponse &result) {
@@ -392,5 +417,24 @@ namespace SmartHome {
         if (result.error.has_value()) errStr = result.error.value().data;
         else errStr = "Invalid response: no result or error";
         DatabaseActions::postLog(moduleId, "error", errStr);
+    }
+
+    std::set<std::string_view> MediatorActions::getApplicableTypes(API::InternalApi::MethodTypes method) {
+        static const std::set getTypes = {
+            Constants::MediatorTypes::SENSOR_VALUE,
+            Constants::MediatorTypes::FORCE_READ_SENSOR_VALUE,
+            Constants::MediatorTypes::ACTUATOR_VALUE
+        };
+        static const std::set setTypes = {
+            Constants::MediatorTypes::TOGGLE_ACTUATOR,
+            Constants::MediatorTypes::SET_ACTUATOR_VALUE
+        };
+        static const std::set<std::string_view> empty = {};
+
+        switch (method) {
+            case API::InternalApi::MethodTypes::GET: return getTypes;
+            case API::InternalApi::MethodTypes::SET: return setTypes;
+            default: return empty;
+        }
     }
 }

--- a/central_unit/src/core/actions/mediator_actions.cpp
+++ b/central_unit/src/core/actions/mediator_actions.cpp
@@ -263,7 +263,7 @@ namespace SmartHome {
 
         const auto mediatorId = mediatorConnectionId.value();
 
-        ba::post(Core::Instance().getCoreWorkerIoContext(),
+        ba::post(Core::Instance().coreWorkerIoContext(),
                  [promise, request, commandMetadata, mediatorId]() mutable {
                      Actions::startCommandTimeoutTimer(commandMetadata);
 

--- a/central_unit/src/core/actions/mediator_actions.cpp
+++ b/central_unit/src/core/actions/mediator_actions.cpp
@@ -1,5 +1,6 @@
 #include "mediator_actions.h"
 #include "database_actions.h"
+#include "constants.h"
 
 namespace SmartHome {
     using ai = API::InternalApi;
@@ -37,8 +38,10 @@ namespace SmartHome {
 
         // Send to db
         if (parsedParams.moduleId.has_value()) {
-            static const std::set<std::string_view> sensorReadApplicableGetTypes = {
-                "sensor_value", "force_read_sensor_value", "actuator_value"
+            static const std::set sensorReadApplicableGetTypes = {
+                Constants::MediatorTypes::SENSOR_VALUE,
+                Constants::MediatorTypes::FORCE_READ_SENSOR_VALUE,
+                Constants::MediatorTypes::ACTUATOR_VALUE
             };
 
             if (commandResult.result.has_value()) {
@@ -96,8 +99,8 @@ namespace SmartHome {
 
         // Send to db
         if (parsedParams.moduleId.has_value()) {
-            static const std::set<std::string_view> sensorReadApplicableSetTypes = {
-                "toggle_actuator", "set_actuator_value",
+            static const std::set sensorReadApplicableSetTypes = {
+                Constants::MediatorTypes::TOGGLE_ACTUATOR, Constants::MediatorTypes::SET_ACTUATOR_VALUE,
             };
 
             if (commandResult.result.has_value()) {
@@ -161,8 +164,8 @@ namespace SmartHome {
 
                 char buffer[1024];
 
-                std::string action = "<none>";
-                std::string actionArgument = "<none>";
+                std::string action = Constants::Common::NONE_BRACKETS.data();
+                std::string actionArgument = Constants::Common::NONE_BRACKETS.data();
                 if (type.has_value()) {
                     action = type.value();
                 }

--- a/central_unit/src/core/actions/mediator_actions.cpp
+++ b/central_unit/src/core/actions/mediator_actions.cpp
@@ -332,19 +332,17 @@ namespace SmartHome {
     }
 
     void MediatorActions::sendSleepIfConfigured(uint moduleId, const nlohmann::json &moduleInfo) {
-        Core::Instance().mpLogger->debug("[TEST] SLEEP");
         const auto configOpt = Core::Instance().configCache().getModule(moduleId);
         if (!configOpt.has_value()) return;
-        Core::Instance().mpLogger->debug("[TEST] SLEEP2");
 
         const auto &config = configOpt->config;
         if (!config.contains(cmck::SLEEP_AFTER_SEND) ||
             !config.at(cmck::SLEEP_AFTER_SEND).is_boolean() ||
             !config.at(cmck::SLEEP_AFTER_SEND))
             return;
-        Core::Instance().mpLogger->debug("[TEST] SLEEP3");
 
         uint sleepDurationMs = 0;
+        // Check if there is a scheduled next run time for the module
         const auto nextScheduledRunTimePoint = Core::Instance().scheduler().getNextRunForModule(moduleId);
         if (nextScheduledRunTimePoint.has_value()) {
             sleepDurationMs = static_cast<uint>(
@@ -352,13 +350,14 @@ namespace SmartHome {
                                                                       std::chrono::system_clock::now()).count());
         } else if (config.contains(cmck::DEFAULT_SLEEP_DURATION) &&
                    config.at(cmck::DEFAULT_SLEEP_DURATION).is_number_integer()) {
+            // If no scheduled run time, check for default sleep duration in config
             sleepDurationMs = config.at(cmck::DEFAULT_SLEEP_DURATION).get<uint>();
         } else { return; }
-        Core::Instance().mpLogger->debug("[TEST] SLEEP4");
 
+        // If no sleep duration configured or duration is 0, do not send sleep
         if (sleepDurationMs == 0) return;
-        Core::Instance().mpLogger->debug("[TEST] SLEEP5");
 
+        // Build sleep notification request to mediator
         std::string actionStr = Constants::MediatorTypes::SLEEP.data();
         if (config.contains(cmck::POWER_SAVING) && config.at(cmck::POWER_SAVING).is_boolean() &&
             config.at(cmck::POWER_SAVING)) {
@@ -386,16 +385,16 @@ namespace SmartHome {
             }
         }
 
+        // If no mediator connection found, skip sending sleep notification
         if (!mediatorConnectionId.has_value()) {
             return;
         }
-        Core::Instance().mpLogger->debug("[TEST] SLEEP6");
 
         const auto mediatorId = mediatorConnectionId.value();
 
+        // Post sleep notification to mediator without waiting for response
         ba::post(Core::Instance().coreWorkerIoContext(),
                  [sleepRequest = std::move(sleepNotification), mediatorId]() mutable {
-                     Core::Instance().mpLogger->debug("[TEST] SLEEP7");
                      Actions::handleOutgoingRequest(mediatorId, std::move(sleepRequest), nullptr);
                  });
     }

--- a/central_unit/src/core/actions/mediator_actions.h
+++ b/central_unit/src/core/actions/mediator_actions.h
@@ -79,6 +79,7 @@ namespace SmartHome {
          */
         static awaitOptApiResponse mediatorPingHandler(const cmdMetaPtr &commandMetadata);
 
+
         /**
          * @brief Send mediator request to a specific module and await response.
          *
@@ -123,6 +124,13 @@ namespace SmartHome {
             std::optional<nlohmann::json> args;
         };
 
+        /**
+         * @brief Send sleep command to module via mediator if configured for the module.
+         *
+         * @param moduleId Target module identifier.
+         * @param moduleInfo Module information JSON containing addressing details.
+         */
+        static void sendSleepIfConfigured(uint moduleId, const nlohmann::json &moduleInfo);
 
         /**
          * @brief Prepare API request structure for mediator.

--- a/central_unit/src/core/actions/mediator_actions.h
+++ b/central_unit/src/core/actions/mediator_actions.h
@@ -3,6 +3,7 @@
 
 #include <string_view>
 #include <memory>
+#include <nlohmann/json_fwd.hpp>
 
 namespace SmartHome {
     /**
@@ -79,6 +80,26 @@ namespace SmartHome {
         static awaitOptApiResponse mediatorPingHandler(const cmdMetaPtr &commandMetadata);
 
         /**
+         * @brief Send mediator request to a specific module and await response.
+         *
+         * @details Prepares mediator request params for module addressing, submits the request,
+         *          and optionally posts sensor reading or error log.
+         *
+         * @param commandMetadata Command execution metadata.
+         * @param moduleId Target module identifier.
+         * @param type Mediator command type string.
+         * @param args Command arguments.
+         * @param method Originating API method (GET/SET/EXECUTE/...).
+         *
+         * @return API response from mediator or error.
+         */
+        static ba::awaitable<API::ApiResponse> sendToModule(const cmdMetaPtr &commandMetadata,
+                                                            uint moduleId,
+                                                            std::string_view type,
+                                                            const nlohmann::json &args,
+                                                            API::InternalApi::MethodTypes method);
+
+        /**
          * @brief Send request to mediator and await response.
          *
          * @details Finds mediator connection, posts request to core worker context,
@@ -118,20 +139,6 @@ namespace SmartHome {
                                                         const API::InternalApi::Command &command);
 
         /**
-         * @brief Parse incoming params for mediator forwarding.
-         *
-         * @details Extracts optional module id, type and args from incoming params and
-         *          mirrors applicable values into the prepared mediator params object.
-         *
-         * @param incomingParams JSON object received with the original command.
-         * @param rtmParams Prepared mediator params to be populated.
-         *
-         * @return Parsed MediatorRequestParams with optional fields set.
-         */
-        static MediatorRequestParams parseMediatorParams(const nlohmann::json &incomingParams,
-                                                         nlohmann::json &rtmParams);
-
-        /**
          * @brief Retrieve RF addressing info for a module from the database.
          *
          * @details Calls \c DatabaseActions::getModuleAddressingInfo and inserts returned
@@ -167,5 +174,14 @@ namespace SmartHome {
          * @param result API response containing error details to be recorded.
          */
         static void postErrorLog(uint moduleId, const API::ApiResponse &result);
+
+        /**
+         * @brief Determine mediator types eligible for sensor reading posting.
+         *
+         * @param method Originating API method.
+         *
+         * @return Set of mediator types that should trigger reading persistence.
+         */
+        static std::set<std::string_view> getApplicableTypes(API::InternalApi::MethodTypes method);
     };
 }

--- a/central_unit/src/core/api/internal_api.cpp
+++ b/central_unit/src/core/api/internal_api.cpp
@@ -179,7 +179,7 @@ namespace SmartHome::API {
                     if (!hasMethod && (hasResult || hasError)) {
                         try {
                             ApiResponse response(candidate);
-                            ba::post(Core::Instance().getCoreIoContext(), [connectionId, response] {
+                            ba::post(Core::Instance().coreIoContext(), [connectionId, response] {
                                 Actions::handleIncomingResponse(connectionId, response);
                             });
                             jsonMessage.erase(jsonMessage.begin() + i);
@@ -197,7 +197,7 @@ namespace SmartHome::API {
                 if (!hasMethod && (hasResult || hasError)) {
                     try {
                         auto response = ApiResponse(jsonMessage);
-                        ba::post(Core::Instance().getCoreIoContext(), [connectionId, response] {
+                        ba::post(Core::Instance().coreIoContext(), [connectionId, response] {
                             Actions::handleIncomingResponse(connectionId, response);
                         });
                         return;

--- a/central_unit/src/core/api/internal_api.cpp
+++ b/central_unit/src/core/api/internal_api.cpp
@@ -1,4 +1,5 @@
 #include "internal_api.h"
+#include "constants.h"
 #include "../core.h"
 #include "../actions/actions.h"
 
@@ -22,34 +23,34 @@ namespace SmartHome::API {
     std::string_view InternalApi::Method::to_string() const {
         switch (type) {
             case MethodTypes::GET:
-                return msGET_STRING;
+                return Constants::Methods::GET;
             case MethodTypes::SET:
-                return msSET_STRING;
+                return Constants::Methods::SET;
             case MethodTypes::NOTIFY:
-                return msNOTIFY_STRING;
+                return Constants::Methods::NOTIFY;
             case MethodTypes::EXECUTE:
-                return msEXECUTE_STRING;
+                return Constants::Methods::EXECUTE;
             case MethodTypes::DELETE:
-                return msDELETE_STRING;
+                return Constants::Methods::DELETE;
             case MethodTypes::ECHO_REQUEST:
-                return msECHO_STRING;
+                return Constants::Methods::ECHO_STR;
             case MethodTypes::PING_REQUEST:
-                return msPING_STRING;
+                return Constants::Methods::PING;
             default:
-                return msUNKNOWN_STRING;
+                return Constants::Common::UNKNOWN;
         }
     }
 
     void InternalApi::Method::to_action(const std::string_view value) {
         static const std::unordered_map<std::string_view, MethodTypes> strToActMap{
-            {msGET_STRING, MethodTypes::GET},
-            {msSET_STRING, MethodTypes::SET},
-            {msNOTIFY_STRING, MethodTypes::NOTIFY},
-            {msEXECUTE_STRING, MethodTypes::EXECUTE},
-            {msDELETE_STRING, MethodTypes::DELETE},
-            {msECHO_STRING, MethodTypes::ECHO_REQUEST},
-            {msPING_STRING, MethodTypes::PING_REQUEST},
-            {msUNKNOWN_STRING, MethodTypes::UNKNOWN}
+            {Constants::Methods::GET, MethodTypes::GET},
+            {Constants::Methods::SET, MethodTypes::SET},
+            {Constants::Methods::NOTIFY, MethodTypes::NOTIFY},
+            {Constants::Methods::EXECUTE, MethodTypes::EXECUTE},
+            {Constants::Methods::DELETE, MethodTypes::DELETE},
+            {Constants::Methods::ECHO_STR, MethodTypes::ECHO_REQUEST},
+            {Constants::Methods::PING, MethodTypes::PING_REQUEST},
+            {Constants::Common::UNKNOWN, MethodTypes::UNKNOWN}
         };
 
         const auto iter = strToActMap.find(boost::algorithm::to_lower_copy(std::string(value)));
@@ -81,32 +82,32 @@ namespace SmartHome::API {
     std::string_view InternalApi::Target::to_string() const {
         switch (type) {
             case TargetTypes::CLI:
-                return msCLI_STRING;
+                return Constants::Targets::CLI;
             case TargetTypes::GUI:
-                return msGUI_STRING;
+                return Constants::Targets::GUI;
             case TargetTypes::WEB_SERVER:
-                return msWEB_SERVER_STRING;
+                return Constants::Targets::WEB_SERVER;
             case TargetTypes::CORE:
-                return msCORE_STRING;
+                return Constants::Targets::CORE;
             case TargetTypes::MODULE_MEDIATOR:
-                return msMODULE_MEDIATOR_STRING;
+                return Constants::Targets::MODULE_MEDIATOR;
             case TargetTypes::DATABASE:
-                return msDATABASE_STRING;
+                return Constants::Targets::DATABASE;
             default:
-                return msUNKNOWN_STRING;
+                return Constants::Common::UNKNOWN;
         }
     }
 
     void InternalApi::Target::to_target(const std::string_view value) {
         static const std::unordered_map<std::string_view, TargetTypes> strToTargMap{
-            {msCLI_STRING, TargetTypes::CLI},
-            {msGUI_STRING, TargetTypes::GUI},
-            {msWEB_SERVER_STRING, TargetTypes::WEB_SERVER},
-            {msWEB_STRING, TargetTypes::WEB_SERVER},
-            {msCORE_STRING, TargetTypes::CORE},
-            {msMODULE_MEDIATOR_STRING, TargetTypes::MODULE_MEDIATOR},
-            {msMEDIATOR_STRING, TargetTypes::MODULE_MEDIATOR},
-            {msDATABASE_STRING, TargetTypes::DATABASE}
+            {Constants::Targets::CLI, TargetTypes::CLI},
+            {Constants::Targets::GUI, TargetTypes::GUI},
+            {Constants::Targets::WEB_SERVER, TargetTypes::WEB_SERVER},
+            {Constants::Targets::WEB, TargetTypes::WEB_SERVER},
+            {Constants::Targets::CORE, TargetTypes::CORE},
+            {Constants::Targets::MODULE_MEDIATOR, TargetTypes::MODULE_MEDIATOR},
+            {Constants::Targets::MEDIATOR, TargetTypes::MODULE_MEDIATOR},
+            {Constants::Targets::DATABASE, TargetTypes::DATABASE}
         };
 
         const auto iter = strToTargMap.find(boost::algorithm::to_lower_copy(std::string(value)));

--- a/central_unit/src/core/api/internal_api.h
+++ b/central_unit/src/core/api/internal_api.h
@@ -93,16 +93,6 @@ namespace SmartHome::API {
 
             /// Compare with MethodTypes enum
             bool operator==(MethodTypes other) const;
-
-        private:
-            static constexpr std::string_view msGET_STRING = "get";
-            static constexpr std::string_view msSET_STRING = "set";
-            static constexpr std::string_view msNOTIFY_STRING = "notify";
-            static constexpr std::string_view msEXECUTE_STRING = "execute";
-            static constexpr std::string_view msDELETE_STRING = "delete";
-            static constexpr std::string_view msECHO_STRING = "echo";
-            static constexpr std::string_view msPING_STRING = "ping";
-            static constexpr std::string_view msUNKNOWN_STRING = "unknown";
         };
 
         /**
@@ -150,17 +140,6 @@ namespace SmartHome::API {
 
             /// Compare with TargetTypes enum
             bool operator==(TargetTypes other) const;
-
-        private:
-            static constexpr std::string_view msCLI_STRING = "cli";
-            static constexpr std::string_view msGUI_STRING = "gui";
-            static constexpr std::string_view msWEB_SERVER_STRING = "web_server";
-            static constexpr std::string_view msWEB_STRING = "web";
-            static constexpr std::string_view msCORE_STRING = "core";
-            static constexpr std::string_view msMODULE_MEDIATOR_STRING = "module_mediator";
-            static constexpr std::string_view msMEDIATOR_STRING = "mediator";
-            static constexpr std::string_view msDATABASE_STRING = "database";
-            static constexpr std::string_view msUNKNOWN_STRING = "unknown";
         };
 
 

--- a/central_unit/src/core/cache.cpp
+++ b/central_unit/src/core/cache.cpp
@@ -49,7 +49,7 @@ namespace SmartHome {
     }
 
     void ConfigCache::updateModuleLastOnline(const int moduleId,
-                                             const std::chrono::steady_clock::time_point timestamp) {
+                                             const std::chrono::system_clock::time_point timestamp) {
         std::unique_lock lock(mMutex);
         const auto iter = mModules.find(moduleId);
         if (iter == mModules.end()) return;
@@ -210,7 +210,7 @@ namespace SmartHome {
         CachedReading reading{
             .sensorId = sensorId,
             .value = value,
-            .timestamp = std::chrono::steady_clock::now(),
+            .timestamp = std::chrono::system_clock::now(),
             .stale = false
         };
         std::unique_lock lock(mMutex);
@@ -241,7 +241,7 @@ namespace SmartHome {
     }
 
     bool ReadingsCache::isFresh(const CachedReading &reading, const std::chrono::seconds ttl) {
-        const auto age = std::chrono::steady_clock::now() - reading.timestamp;
+        const auto age = std::chrono::system_clock::now() - reading.timestamp;
         return age <= ttl;
     }
 }

--- a/central_unit/src/core/cache.cpp
+++ b/central_unit/src/core/cache.cpp
@@ -1,0 +1,247 @@
+#include "cache.h"
+
+#include <mutex>
+
+namespace SmartHome {
+    bool CachedSensor::useCache() const {
+        if (config.contains("use_cache") && config["use_cache"].is_boolean()) {
+            return config["use_cache"].get<bool>();
+        }
+        return true; // Default to using cache if not specified
+    }
+
+    std::chrono::seconds CachedSensor::cacheTTL() const {
+        if (config.contains("cache_ttl") && config["cache_ttl"].is_number_unsigned()) {
+            return std::chrono::seconds(config["cache_ttl"].get<uint64_t>());
+        }
+        return 60s; // Default TTL of 60 seconds
+    }
+
+    void ConfigCache::setModule(const CachedModule &module) {
+        std::unique_lock lock(mMutex);
+
+        // Remove old entry if module with same ID already exists
+        const auto iter = mModules.find(module.id);
+        if (iter != mModules.end()) {
+            removeFromModulesIndex(iter->second.logicAddress);
+        }
+
+        mModules.insert_or_assign(module.id, module);
+        addToModulesIndex(module);
+    }
+
+    std::optional<CachedModule> ConfigCache::getModule(const int moduleId) const {
+        std::shared_lock lock(mMutex);
+
+        const auto iter = mModules.find(moduleId);
+        if (iter == mModules.end()) return std::nullopt;
+        return iter->second;
+    }
+
+    void ConfigCache::eraseModule(const int moduleId) {
+        std::unique_lock lock(mMutex);
+
+        const auto iter = mModules.find(moduleId);
+        if (iter == mModules.end()) return;
+
+        mModules.erase(iter);
+        removeFromModulesIndex(iter->second.logicAddress);
+    }
+
+    void ConfigCache::updateModuleLastOnline(const int moduleId,
+                                             const std::chrono::steady_clock::time_point timestamp) {
+        std::unique_lock lock(mMutex);
+        const auto iter = mModules.find(moduleId);
+        if (iter == mModules.end()) return;
+
+        iter->second.lastOnline = timestamp;
+    }
+
+    void ConfigCache::setSensor(const CachedSensor &sensor) {
+        std::unique_lock lock(mMutex);
+
+        // Remove old entry if sensor with same ID already exists
+        const auto iter = mSensors.find(sensor.id);
+        if (iter != mSensors.end()) {
+            removeFromSensorsIndex(iter->second.moduleId, iter->second.logicId);
+        }
+
+        mSensors.insert_or_assign(sensor.id, sensor);
+        addToSensorsIndex(sensor);
+    }
+
+    std::optional<CachedSensor> ConfigCache::getSensor(const int sensorId) const {
+        std::shared_lock lock(mMutex);
+
+        const auto iter = mSensors.find(sensorId);
+        if (iter == mSensors.end()) return std::nullopt;
+        return iter->second;
+    }
+
+    void ConfigCache::eraseSensor(const int sensorId) {
+        std::unique_lock lock(mMutex);
+
+        const auto iter = mSensors.find(sensorId);
+        if (iter == mSensors.end()) return;
+
+        mSensors.erase(iter);
+        removeFromSensorsIndex(iter->second.moduleId, iter->second.logicId);
+    }
+
+    std::optional<int> ConfigCache::findModuleId(const int logicAddress) const {
+        std::shared_lock lock(mMutex);
+
+        const auto iter = mModulesIndex.find(logicAddress);
+        if (iter == mModulesIndex.end()) return std::nullopt;
+        return iter->second;
+    }
+
+    std::optional<int> ConfigCache::findSensorId(const int moduleId, const int logicId) const {
+        std::shared_lock lock(mMutex);
+
+        const auto iter = mSensorsIndex.find({moduleId, logicId});
+        if (iter == mSensorsIndex.end()) return std::nullopt;
+        return iter->second;
+    }
+
+    std::optional<int> ConfigCache::findSensorIdByLogicAddress(const int moduleLogicAddress,
+                                                               const int sensorLogicId) const {
+        std::shared_lock lock(mMutex);
+
+        const auto moduleIter = mModulesIndex.find(moduleLogicAddress);
+        if (moduleIter == mModulesIndex.end()) return std::nullopt;
+
+        const int moduleId = moduleIter->second;
+        const auto sensorIter = mSensorsIndex.find({moduleId, sensorLogicId});
+        if (sensorIter == mSensorsIndex.end()) return std::nullopt;
+
+        return sensorIter->second;
+    }
+
+    std::vector<int> ConfigCache::getSensorIdsForModule(const int moduleId) const {
+        std::shared_lock lock(mMutex);
+
+        std::vector<int> sensorIds;
+
+        for (const auto &[key, sensorId]: mSensorsIndex) {
+            if (key.first == moduleId) {
+                sensorIds.push_back(sensorId);
+            }
+        }
+        return sensorIds;
+    }
+
+    void ConfigCache::clear() {
+        std::unique_lock lock(mMutex);
+        mModules.clear();
+        mSensors.clear();
+        mModulesIndex.clear();
+        mSensorsIndex.clear();
+    }
+
+    size_t ConfigCache::modulesSize() const {
+        std::shared_lock lock(mMutex);
+        return mModules.size();
+    }
+
+    size_t ConfigCache::sensorsSize() const {
+        std::shared_lock lock(mMutex);
+        return mSensors.size();
+    }
+
+
+    void ConfigCache::addToModulesIndex(const CachedModule &module) {
+        mModulesIndex[module.logicAddress] = module.id;
+    }
+
+    void ConfigCache::removeFromModulesIndex(const int logicAddress) {
+        mModulesIndex.erase(logicAddress);
+    }
+
+    void ConfigCache::addToSensorsIndex(const CachedSensor &sensor) {
+        mSensorsIndex[{sensor.moduleId, sensor.logicId}] = sensor.id;
+    }
+
+    void ConfigCache::removeFromSensorsIndex(int moduleId, int logicId) {
+        mSensorsIndex.erase({moduleId, logicId});
+    }
+
+
+    ReadingsCache::ReadingsCache(const ConfigCache &configCache) : mConfigCache(configCache) {
+    }
+
+    std::optional<CachedReading> ReadingsCache::get(const int sensorId) const {
+        std::shared_lock lock(mMutex);
+
+        const auto iter = mReadings.find(sensorId);
+        if (iter == mReadings.end()) return std::nullopt;
+
+        // Copy reading before releasing lock
+        auto reading = iter->second;
+        lock.unlock();
+
+        // Check if reading is fresh based on sensor's TTL
+        const auto ttl = getTTL(sensorId);
+        if (!isFresh(reading, ttl)) {
+            reading.stale = true;
+        }
+
+        return reading;
+    }
+
+    std::optional<CachedReading> ReadingsCache::getFresh(const int sensorId) const {
+        std::shared_lock lock(mMutex);
+
+        const auto iter = mReadings.find(sensorId);
+        if (iter == mReadings.end()) return std::nullopt;
+
+        // Copy reading before releasing lock
+        const auto &reading = iter->second;
+        lock.unlock();
+
+        // Check if reading is fresh based on sensor's TTL
+        const auto ttl = getTTL(sensorId);
+        if (!isFresh(reading, ttl)) return std::nullopt; // Not fresh, treat as not found
+
+        return reading;
+    }
+
+    void ReadingsCache::set(const int sensorId, const nlohmann::json &value) {
+        CachedReading reading{
+            .sensorId = sensorId,
+            .value = value,
+            .timestamp = std::chrono::steady_clock::now(),
+            .stale = false
+        };
+        std::unique_lock lock(mMutex);
+        mReadings.insert_or_assign(sensorId, std::move(reading));
+    }
+
+    void ReadingsCache::erase(const int sensorId) {
+        std::unique_lock lock(mMutex);
+        mReadings.erase(sensorId);
+    }
+
+    void ReadingsCache::clear() {
+        std::unique_lock lock(mMutex);
+        mReadings.clear();
+    }
+
+    size_t ReadingsCache::size() const {
+        std::shared_lock lock(mMutex);
+        return mReadings.size();
+    }
+
+    std::chrono::seconds ReadingsCache::getTTL(const int sensorId) const {
+        const auto sensor = mConfigCache.getSensor(sensorId);
+        if (sensor.has_value() && sensor->useCache()) {
+            return sensor->cacheTTL();
+        }
+        return 60s; // Default TTL if sensor not found or caching disabled
+    }
+
+    bool ReadingsCache::isFresh(const CachedReading &reading, const std::chrono::seconds ttl) {
+        const auto age = std::chrono::steady_clock::now() - reading.timestamp;
+        return age <= ttl;
+    }
+}

--- a/central_unit/src/core/cache.cpp
+++ b/central_unit/src/core/cache.cpp
@@ -1,8 +1,20 @@
 #include "cache.h"
+#include "utils.h"
 
 #include <mutex>
 
+
 namespace SmartHome {
+    nlohmann::json CachedModule::to_json() const {
+        nlohmann::json json;
+        json["id"] = id;
+        json["logic_address"] = logicAddress;
+        json["name"] = name;
+        json["config"] = config;
+        json["last_online"] = Utils::timePointToTimestampTz(lastOnline);
+        return json;
+    }
+
     bool CachedSensor::useCache() const {
         if (config.contains("use_cache") && config["use_cache"].is_boolean()) {
             return config["use_cache"].get<bool>();
@@ -15,6 +27,27 @@ namespace SmartHome {
             return std::chrono::seconds(config["cache_ttl"].get<uint64_t>());
         }
         return 60s; // Default TTL of 60 seconds
+    }
+
+    nlohmann::json CachedSensor::to_json() const {
+        nlohmann::json json;
+        json["id"] = id;
+        json["logic_id"] = logicId;
+        json["module_id"] = moduleId;
+        json["name"] = name;
+        json["type"] = type;
+        json["config"] = config;
+        return json;
+    }
+
+    nlohmann::json CachedReading::to_json() const {
+        nlohmann::json json;
+        json["sensor_id"] = sensorId;
+        json["value"] = value;
+        json["timestamp"] = Utils::timePointToTimestampTz(timestamp);
+        json["metadata"] = metadata;
+        json["stale"] = stale;
+        return json;
     }
 
     void ConfigCache::setModule(const CachedModule &module) {
@@ -30,7 +63,7 @@ namespace SmartHome {
         addToModulesIndex(module);
     }
 
-    std::optional<CachedModule> ConfigCache::getModule(const int moduleId) const {
+    std::optional<CachedModule> ConfigCache::getModule(const uint moduleId) const {
         std::shared_lock lock(mMutex);
 
         const auto iter = mModules.find(moduleId);
@@ -38,7 +71,33 @@ namespace SmartHome {
         return iter->second;
     }
 
-    void ConfigCache::eraseModule(const int moduleId) {
+    std::vector<CachedModule> ConfigCache::getAllModules() const {
+        std::shared_lock lock(mMutex);
+
+        std::vector<CachedModule> modules;
+        modules.reserve(mModules.size());
+        for (const auto &module: mModules | std::views::values) {
+            modules.push_back(module);
+        }
+        return modules;
+    }
+
+    std::vector<CachedSensor> ConfigCache::getModuleSensors(const uint moduleId) const {
+        const auto sensorsIds = getSensorIdsForModule(moduleId);
+
+        std::vector<CachedSensor> sensors;
+        sensors.reserve(sensorsIds.size());
+        for (const auto sensorId: sensorsIds) {
+            const auto sensorOpt = getSensor(sensorId);
+            if (sensorOpt.has_value()) {
+                sensors.push_back(sensorOpt.value());
+            }
+        }
+
+        return sensors;
+    }
+
+    void ConfigCache::eraseModule(uint moduleId) {
         std::unique_lock lock(mMutex);
 
         const auto iter = mModules.find(moduleId);
@@ -48,7 +107,7 @@ namespace SmartHome {
         removeFromModulesIndex(iter->second.logicAddress);
     }
 
-    void ConfigCache::updateModuleLastOnline(const int moduleId,
+    void ConfigCache::updateModuleLastOnline(uint moduleId,
                                              const std::chrono::system_clock::time_point timestamp) {
         std::unique_lock lock(mMutex);
         const auto iter = mModules.find(moduleId);
@@ -70,7 +129,7 @@ namespace SmartHome {
         addToSensorsIndex(sensor);
     }
 
-    std::optional<CachedSensor> ConfigCache::getSensor(const int sensorId) const {
+    std::optional<CachedSensor> ConfigCache::getSensor(uint sensorId) const {
         std::shared_lock lock(mMutex);
 
         const auto iter = mSensors.find(sensorId);
@@ -78,7 +137,18 @@ namespace SmartHome {
         return iter->second;
     }
 
-    void ConfigCache::eraseSensor(const int sensorId) {
+    std::vector<CachedSensor> ConfigCache::getAllSensors() const {
+        std::shared_lock lock(mMutex);
+
+        std::vector<CachedSensor> sensors;
+        sensors.reserve(mSensors.size());
+        for (const auto &sensor: mSensors | std::views::values) {
+            sensors.push_back(sensor);
+        }
+        return sensors;
+    }
+
+    void ConfigCache::eraseSensor(uint sensorId) {
         std::unique_lock lock(mMutex);
 
         const auto iter = mSensors.find(sensorId);
@@ -88,7 +158,7 @@ namespace SmartHome {
         removeFromSensorsIndex(iter->second.moduleId, iter->second.logicId);
     }
 
-    std::optional<int> ConfigCache::findModuleId(const int logicAddress) const {
+    std::optional<uint> ConfigCache::findModuleId(uint logicAddress) const {
         std::shared_lock lock(mMutex);
 
         const auto iter = mModulesIndex.find(logicAddress);
@@ -96,7 +166,7 @@ namespace SmartHome {
         return iter->second;
     }
 
-    std::optional<int> ConfigCache::findSensorId(const int moduleId, const int logicId) const {
+    std::optional<uint> ConfigCache::findSensorId(uint moduleId, uint logicId) const {
         std::shared_lock lock(mMutex);
 
         const auto iter = mSensorsIndex.find({moduleId, logicId});
@@ -104,8 +174,8 @@ namespace SmartHome {
         return iter->second;
     }
 
-    std::optional<int> ConfigCache::findSensorIdByLogicAddress(const int moduleLogicAddress,
-                                                               const int sensorLogicId) const {
+    std::optional<uint> ConfigCache::findSensorIdByLogicAddress(uint moduleLogicAddress,
+                                                                uint sensorLogicId) const {
         std::shared_lock lock(mMutex);
 
         const auto moduleIter = mModulesIndex.find(moduleLogicAddress);
@@ -118,10 +188,10 @@ namespace SmartHome {
         return sensorIter->second;
     }
 
-    std::vector<int> ConfigCache::getSensorIdsForModule(const int moduleId) const {
+    std::vector<uint> ConfigCache::getSensorIdsForModule(uint moduleId) const {
         std::shared_lock lock(mMutex);
 
-        std::vector<int> sensorIds;
+        std::vector<uint> sensorIds;
 
         for (const auto &[key, sensorId]: mSensorsIndex) {
             if (key.first == moduleId) {
@@ -166,7 +236,7 @@ namespace SmartHome {
         mModulesIndex[module.logicAddress] = module.id;
     }
 
-    void ConfigCache::removeFromModulesIndex(const int logicAddress) {
+    void ConfigCache::removeFromModulesIndex(uint logicAddress) {
         mModulesIndex.erase(logicAddress);
     }
 
@@ -174,7 +244,7 @@ namespace SmartHome {
         mSensorsIndex[{sensor.moduleId, sensor.logicId}] = sensor.id;
     }
 
-    void ConfigCache::removeFromSensorsIndex(int moduleId, int logicId) {
+    void ConfigCache::removeFromSensorsIndex(uint moduleId, uint logicId) {
         mSensorsIndex.erase({moduleId, logicId});
     }
 
@@ -182,7 +252,7 @@ namespace SmartHome {
     ReadingsCache::ReadingsCache(const ConfigCache &configCache) : mConfigCache(configCache) {
     }
 
-    std::optional<CachedReading> ReadingsCache::get(const int sensorId) const {
+    std::optional<CachedReading> ReadingsCache::get(uint sensorId) const {
         std::shared_lock lock(mMutex);
 
         const auto iter = mReadings.find(sensorId);
@@ -201,7 +271,7 @@ namespace SmartHome {
         return reading;
     }
 
-    std::optional<CachedReading> ReadingsCache::getFresh(const int sensorId) const {
+    std::optional<CachedReading> ReadingsCache::getFresh(const uint sensorId) const {
         std::shared_lock lock(mMutex);
 
         const auto iter = mReadings.find(sensorId);
@@ -218,18 +288,30 @@ namespace SmartHome {
         return reading;
     }
 
-    void ReadingsCache::set(const int sensorId, const nlohmann::json &value) {
+    std::vector<CachedReading> ReadingsCache::getDebugAll() const {
+        std::shared_lock lock(mMutex);
+
+        std::vector<CachedReading> readings;
+        readings.reserve(mReadings.size());
+        for (const auto &reading: mReadings | std::views::values) {
+            readings.push_back(reading);
+        }
+        return readings;
+    }
+
+    void ReadingsCache::set(const uint sensorId, const nlohmann::json &value, const nlohmann::json &metadata) {
         CachedReading reading{
             .sensorId = sensorId,
             .value = value,
             .timestamp = std::chrono::system_clock::now(),
+            .metadata = metadata,
             .stale = false
         };
         std::unique_lock lock(mMutex);
         mReadings.insert_or_assign(sensorId, std::move(reading));
     }
 
-    void ReadingsCache::erase(const int sensorId) {
+    void ReadingsCache::erase(const uint sensorId) {
         std::unique_lock lock(mMutex);
         mReadings.erase(sensorId);
     }
@@ -244,16 +326,16 @@ namespace SmartHome {
         return mReadings.size();
     }
 
-    std::chrono::seconds ReadingsCache::getTTL(const int sensorId) const {
+    std::chrono::seconds ReadingsCache::getTTL(const uint sensorId) const {
         const auto sensor = mConfigCache.getSensor(sensorId);
         if (sensor.has_value() && sensor->useCache()) {
             return sensor->cacheTTL();
         }
-        return 60s; // Default TTL if sensor not found or caching disabled
+        return 0s; // 0 TTL if sensor not found or caching disabled
     }
 
     bool ReadingsCache::isFresh(const CachedReading &reading, const std::chrono::seconds ttl) {
         const auto age = std::chrono::system_clock::now() - reading.timestamp;
-        return age <= ttl;
+        return age < ttl;
     }
 }

--- a/central_unit/src/core/cache.cpp
+++ b/central_unit/src/core/cache.cpp
@@ -131,6 +131,18 @@ namespace SmartHome {
         return sensorIds;
     }
 
+    void ConfigCache::clearModules() {
+        std::unique_lock lock(mMutex);
+        mModules.clear();
+        mModulesIndex.clear();
+    }
+
+    void ConfigCache::clearSensors() {
+        std::unique_lock lock(mMutex);
+        mSensors.clear();
+        mSensorsIndex.clear();
+    }
+
     void ConfigCache::clear() {
         std::unique_lock lock(mMutex);
         mModules.clear();

--- a/central_unit/src/core/cache.cpp
+++ b/central_unit/src/core/cache.cpp
@@ -11,7 +11,11 @@ namespace SmartHome {
         json["logic_address"] = logicAddress;
         json["name"] = name;
         json["config"] = config;
-        json["last_online"] = Utils::timePointToTimestampTz(lastOnline);
+        if (lastOnline.has_value()) {
+            json["last_online"] = Utils::timePointToTimestampTz(lastOnline.value());
+        } else {
+            json["last_online"] = nullptr;
+        }
         return json;
     }
 
@@ -97,7 +101,7 @@ namespace SmartHome {
         return sensors;
     }
 
-    void ConfigCache::eraseModule(uint moduleId) {
+    void ConfigCache::eraseModule(const uint moduleId) {
         std::unique_lock lock(mMutex);
 
         const auto iter = mModules.find(moduleId);
@@ -107,7 +111,7 @@ namespace SmartHome {
         removeFromModulesIndex(iter->second.logicAddress);
     }
 
-    void ConfigCache::updateModuleLastOnline(uint moduleId,
+    void ConfigCache::updateModuleLastOnline(const uint moduleId,
                                              const std::chrono::system_clock::time_point timestamp) {
         std::unique_lock lock(mMutex);
         const auto iter = mModules.find(moduleId);
@@ -129,7 +133,7 @@ namespace SmartHome {
         addToSensorsIndex(sensor);
     }
 
-    std::optional<CachedSensor> ConfigCache::getSensor(uint sensorId) const {
+    std::optional<CachedSensor> ConfigCache::getSensor(const uint sensorId) const {
         std::shared_lock lock(mMutex);
 
         const auto iter = mSensors.find(sensorId);
@@ -148,7 +152,7 @@ namespace SmartHome {
         return sensors;
     }
 
-    void ConfigCache::eraseSensor(uint sensorId) {
+    void ConfigCache::eraseSensor(const uint sensorId) {
         std::unique_lock lock(mMutex);
 
         const auto iter = mSensors.find(sensorId);
@@ -158,7 +162,7 @@ namespace SmartHome {
         removeFromSensorsIndex(iter->second.moduleId, iter->second.logicId);
     }
 
-    std::optional<uint> ConfigCache::findModuleId(uint logicAddress) const {
+    std::optional<uint> ConfigCache::findModuleId(const uint logicAddress) const {
         std::shared_lock lock(mMutex);
 
         const auto iter = mModulesIndex.find(logicAddress);
@@ -166,7 +170,7 @@ namespace SmartHome {
         return iter->second;
     }
 
-    std::optional<uint> ConfigCache::findSensorId(uint moduleId, uint logicId) const {
+    std::optional<uint> ConfigCache::findSensorId(const uint moduleId, const uint logicId) const {
         std::shared_lock lock(mMutex);
 
         const auto iter = mSensorsIndex.find({moduleId, logicId});
@@ -174,8 +178,8 @@ namespace SmartHome {
         return iter->second;
     }
 
-    std::optional<uint> ConfigCache::findSensorIdByLogicAddress(uint moduleLogicAddress,
-                                                                uint sensorLogicId) const {
+    std::optional<uint> ConfigCache::findSensorIdByLogicAddress(const uint moduleLogicAddress,
+                                                                const uint sensorLogicId) const {
         std::shared_lock lock(mMutex);
 
         const auto moduleIter = mModulesIndex.find(moduleLogicAddress);
@@ -188,7 +192,7 @@ namespace SmartHome {
         return sensorIter->second;
     }
 
-    std::vector<uint> ConfigCache::getSensorIdsForModule(uint moduleId) const {
+    std::vector<uint> ConfigCache::getSensorIdsForModule(const uint moduleId) const {
         std::shared_lock lock(mMutex);
 
         std::vector<uint> sensorIds;
@@ -236,7 +240,7 @@ namespace SmartHome {
         mModulesIndex[module.logicAddress] = module.id;
     }
 
-    void ConfigCache::removeFromModulesIndex(uint logicAddress) {
+    void ConfigCache::removeFromModulesIndex(const uint logicAddress) {
         mModulesIndex.erase(logicAddress);
     }
 
@@ -244,7 +248,7 @@ namespace SmartHome {
         mSensorsIndex[{sensor.moduleId, sensor.logicId}] = sensor.id;
     }
 
-    void ConfigCache::removeFromSensorsIndex(uint moduleId, uint logicId) {
+    void ConfigCache::removeFromSensorsIndex(const uint moduleId, const uint logicId) {
         mSensorsIndex.erase({moduleId, logicId});
     }
 
@@ -252,7 +256,7 @@ namespace SmartHome {
     ReadingsCache::ReadingsCache(const ConfigCache &configCache) : mConfigCache(configCache) {
     }
 
-    std::optional<CachedReading> ReadingsCache::get(uint sensorId) const {
+    std::optional<CachedReading> ReadingsCache::get(const uint sensorId) const {
         std::shared_lock lock(mMutex);
 
         const auto iter = mReadings.find(sensorId);

--- a/central_unit/src/core/cache.h
+++ b/central_unit/src/core/cache.h
@@ -65,6 +65,10 @@ namespace SmartHome {
 
         [[nodiscard]] std::vector<int> getSensorIdsForModule(int moduleId) const;
 
+        void clearModules();
+
+        void clearSensors();
+
         void clear();
 
         [[nodiscard]] size_t modulesSize() const;

--- a/central_unit/src/core/cache.h
+++ b/central_unit/src/core/cache.h
@@ -23,7 +23,7 @@ namespace SmartHome {
         uint logicAddress; ///< Module logic address used in module mediator communication
         std::string name; ///< Human-readable name
         nlohmann::json config; ///< Module configuration payload
-        std::chrono::system_clock::time_point lastOnline; ///< Last online timestamp
+        std::optional<std::chrono::system_clock::time_point> lastOnline; ///< Last online timestamp
 
         /**
          * @brief Serialize cached module into JSON.

--- a/central_unit/src/core/cache.h
+++ b/central_unit/src/core/cache.h
@@ -8,105 +8,337 @@
 #include <unordered_map>
 
 #include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 
 namespace SmartHome {
     using namespace std::chrono_literals;
 
+    /**
+     * @brief Cached module configuration snapshot.
+     *
+     * @details Holds module metadata and last seen timestamp for fast lookup.
+     */
     struct CachedModule {
-        uint id;
-        uint logicAddress;
-        std::string name;
-        nlohmann::json config;
-        std::chrono::system_clock::time_point lastOnline;
+        uint id; ///< Module database identifier
+        uint logicAddress; ///< Module logic address used in module mediator communication
+        std::string name; ///< Human-readable name
+        nlohmann::json config; ///< Module configuration payload
+        std::chrono::system_clock::time_point lastOnline; ///< Last online timestamp
+
+        /**
+         * @brief Serialize cached module into JSON.
+         *
+         * @return JSON object representing module state.
+         */
+        nlohmann::json to_json() const;
     };
 
+    /**
+     * @brief Cached sensor configuration snapshot.
+     *
+     * @details Stores sensor metadata and cache policy (TTL, enable flag).
+     */
     struct CachedSensor {
-        uint id;
-        uint logicId;
-        uint moduleId;
-        std::string name;
-        std::string type;
-        nlohmann::json config;
+        uint id; ///< Sensor database identifier
+        uint logicId; ///< Sensor logic identifier within module
+        uint moduleId; ///< Owning module database identifier
+        std::string name; ///< Human-readable sensor name
+        std::string type; ///< Sensor type string
+        nlohmann::json config; ///< Sensor configuration payload
 
+        /**
+         * @brief Check if readings for this sensor should be cached.
+         *
+         * @return true when caching is enabled or not configured.
+         */
         [[nodiscard]] bool useCache() const;
 
+        /**
+         * @brief Get cache time-to-live for this sensor.
+         *
+         * @return TTL duration in seconds, default when not configured.
+         */
         [[nodiscard]] std::chrono::seconds cacheTTL() const;
+
+        /**
+         * @brief Serialize cached sensor into JSON.
+         *
+         * @return JSON object representing sensor state.
+         */
+        nlohmann::json to_json() const;
     };
 
+    /**
+     * @brief Cached sensor reading with freshness flag.
+     */
     struct CachedReading {
-        int sensorId;
-        nlohmann::json value;
-        std::chrono::system_clock::time_point timestamp;
-        bool stale = false;
+        uint sensorId; ///< Owning sensor identifier
+        nlohmann::json value; ///< Last recorded value
+        std::chrono::system_clock::time_point timestamp; ///< Timestamp of last update
+        nlohmann::json metadata; ///< Optional metadata payload
+        bool stale = false; ///< Indicates TTL expiration on access
+
+        /**
+         * @brief Serialize cached reading into JSON.
+         *
+         * @return JSON object representing reading state.
+         */
+        nlohmann::json to_json() const;
     };
 
+    /**
+     * @brief Thread-safe cache for module and sensor configuration.
+     *
+     * @details Maintains fast lookups by id and logic address,
+     *          and supports enumerating modules/sensors for runtime use.
+     */
     class ConfigCache {
     public:
+        /**
+         * @brief Insert or update module configuration.
+         *
+         * @param module Module snapshot to cache.
+         */
         void setModule(const CachedModule &module);
 
-        [[nodiscard]] std::optional<CachedModule> getModule(int moduleId) const;
+        /**
+         * @brief Fetch cached module by module id.
+         *
+         * @param moduleId Module identifier.
+         *
+         * @return Cached module or std::nullopt if missing.
+         */
+        [[nodiscard]] std::optional<CachedModule> getModule(uint moduleId) const;
 
-        void eraseModule(int moduleId);
+        /**
+         * @brief Retrieve all cached modules.
+         *
+         * @return Vector of cached modules.
+         */
+        [[nodiscard]] std::vector<CachedModule> getAllModules() const;
 
-        void updateModuleLastOnline(int moduleId, std::chrono::system_clock::time_point timestamp);
+        /**
+         * @brief Retrieve all cached sensors for a module.
+         *
+         * @param moduleId Module identifier.
+         *
+         * @return Vector of cached sensors for the module.
+         */
+        [[nodiscard]] std::vector<CachedSensor> getModuleSensors(uint moduleId) const;
 
+        /**
+         * @brief Remove cached module and its index entry.
+         *
+         * @param moduleId Module identifier.
+         */
+        void eraseModule(uint moduleId);
+
+        /**
+         * @brief Update last online timestamp for a module.
+         *
+         * @param moduleId Module identifier.
+         * @param timestamp Timestamp to store.
+         */
+        void updateModuleLastOnline(uint moduleId, std::chrono::system_clock::time_point timestamp);
+
+        /**
+         * @brief Insert or update sensor configuration.
+         *
+         * @param sensor Sensor snapshot to cache.
+         */
         void setSensor(const CachedSensor &sensor);
 
-        [[nodiscard]] std::optional<CachedSensor> getSensor(int sensorId) const;
+        /**
+         * @brief Fetch cached sensor by sensor id.
+         *
+         * @param sensorId Sensor identifier.
+         *
+         * @return Cached sensor or std::nullopt if missing.
+         */
+        [[nodiscard]] std::optional<CachedSensor> getSensor(uint sensorId) const;
 
+        /**
+         * @brief Retrieve all cached sensors.
+         *
+         * @return Vector of cached sensors.
+         */
+        [[nodiscard]] std::vector<CachedSensor> getAllSensors() const;
 
-        void eraseSensor(int sensorId);
+        /**
+         * @brief Remove cached sensor and its index entry.
+         *
+         * @param sensorId Sensor identifier.
+         */
+        void eraseSensor(uint sensorId);
 
-        [[nodiscard]] std::optional<int> findModuleId(int logicAddress) const;
+        /**
+         * @brief Lookup module id by logic address.
+         *
+         * @param logicAddress Module logic address.
+         *
+         * @return Module id or std::nullopt if missing.
+         */
+        [[nodiscard]] std::optional<uint> findModuleId(uint logicAddress) const;
 
-        [[nodiscard]] std::optional<int> findSensorId(int moduleId, int logicId) const;
+        /**
+         * @brief Lookup sensor id by module id and sensor logic id.
+         *
+         * @param moduleId Module identifier.
+         * @param logicId Sensor logic identifier.
+         *
+         * @return Sensor id or std::nullopt if missing.
+         */
+        [[nodiscard]] std::optional<uint> findSensorId(uint moduleId, uint logicId) const;
 
-        [[nodiscard]] std::optional<int> findSensorIdByLogicAddress(int moduleLogicAddress, int sensorLogicId) const;
+        /**
+         * @brief Lookup sensor id by module and sensor logic address.
+         *
+         * @param moduleLogicAddress Module logic address.
+         * @param sensorLogicId Sensor logic identifier.
+         *
+         * @return Sensor id or std::nullopt if missing.
+         */
+        [[nodiscard]] std::optional<uint> findSensorIdByLogicAddress(uint moduleLogicAddress, uint sensorLogicId) const;
 
-        [[nodiscard]] std::vector<int> getSensorIdsForModule(int moduleId) const;
+        /**
+         * @brief List sensor ids for a given module.
+         *
+         * @param moduleId Module identifier.
+         *
+         * @return Vector of sensor ids.
+         */
+        [[nodiscard]] std::vector<uint> getSensorIdsForModule(uint moduleId) const;
 
+        /**
+         * @brief Clear all cached modules and related index.
+         */
         void clearModules();
 
+        /**
+         * @brief Clear all cached sensors and related index.
+         */
         void clearSensors();
 
+        /**
+         * @brief Clear modules and sensors together.
+         */
         void clear();
 
+        /**
+         * @brief Number of cached modules.
+         */
         [[nodiscard]] size_t modulesSize() const;
 
+        /**
+         * @brief Number of cached sensors.
+         */
         [[nodiscard]] size_t sensorsSize() const;
 
     private:
         mutable std::shared_mutex mMutex;
 
-        std::unordered_map<int, CachedModule> mModules; ///< moduleId: module
-        std::unordered_map<int, CachedSensor> mSensors; ///< sensorId: sensor
+        std::unordered_map<uint, CachedModule> mModules; ///< moduleId: module
+        std::unordered_map<uint, CachedSensor> mSensors; ///< sensorId: sensor
 
-        std::unordered_map<int, int> mModulesIndex; ///< logicAddress: moduleId
-        std::map<std::pair<int, int>, int> mSensorsIndex; ///< (moduleId, logicId): sensorId
+        std::unordered_map<uint, uint> mModulesIndex; ///< logicAddress: moduleId
+        std::map<std::pair<uint, uint>, uint> mSensorsIndex; ///< (moduleId, logicId): sensorId
 
+        /**
+         * @brief Add module entry to logic address index.
+         *
+         * @param module Module snapshot to index.
+         */
         void addToModulesIndex(const CachedModule &module);
 
-        void removeFromModulesIndex(int logicAddress);
+        /**
+         * @brief Remove module entry from logic address index.
+         *
+         * @param logicAddress Logic address of the module to remove from index.
+         */
+        void removeFromModulesIndex(uint logicAddress);
 
+        /**
+         * @brief Add sensor entry to module/logic index.
+         *
+         * @param sensor Sensor snapshot to index.
+         */
         void addToSensorsIndex(const CachedSensor &sensor);
 
-        void removeFromSensorsIndex(int moduleId, int logicId);
+        /**
+         * @brief Remove sensor entry from module/logic index.
+         *
+         * @param moduleId Module identifier of the sensor to remove from index.
+         * @param logicId Logic identifier of the sensor to remove from index.
+         */
+        void removeFromSensorsIndex(uint moduleId, uint logicId);
     };
 
+    /**
+     * @brief Thread-safe cache for sensor readings with TTL freshness.
+     *
+     * @details Uses ConfigCache to resolve per-sensor caching policy.
+     *          Returned readings can be marked stale when TTL expires.
+     */
     class ReadingsCache {
     public:
+        /**
+         * @brief Construct readings cache with config cache reference.
+         *
+         * @param configCache Configuration cache used for TTL lookup.
+         */
         explicit ReadingsCache(const ConfigCache &configCache);
 
-        [[nodiscard]] std::optional<CachedReading> get(int sensorId) const;
+        /**
+         * @brief Fetch cached reading by sensor id.
+         *
+         * @details Returns cached reading even if stale (flagged via CachedReading::stale).
+         *
+         * @param sensorId Sensor identifier.
+         *
+         * @return Cached reading or std::nullopt if missing.
+         */
+        [[nodiscard]] std::optional<CachedReading> get(uint sensorId) const;
 
-        [[nodiscard]] std::optional<CachedReading> getFresh(int sensorId) const;
+        /**
+         * @brief Fetch only fresh cached reading by sensor id.
+         *
+         * @param sensorId Sensor identifier.
+         *
+         * @return Cached reading if within TTL, std::nullopt otherwise.
+         */
+        [[nodiscard]] std::optional<CachedReading> getFresh(uint sensorId) const;
 
-        void set(int sensorId, const nlohmann::json &value);
+        /**
+         * @brief Retrieve all cached readings for debugging.
+         *
+         * @return Vector of cached readings (no freshness filtering).
+         */
+        [[nodiscard]] std::vector<CachedReading> getDebugAll() const;
 
-        void erase(int sensorId);
+        /**
+         * @brief Insert or update sensor reading.
+         *
+         * @param sensorId Sensor identifier.
+         * @param value Reading value.
+         * @param metadata Reading metadata.
+         */
+        void set(uint sensorId, const nlohmann::json &value, const nlohmann::json &metadata);
 
+        /**
+         * @brief Remove cached reading for a sensor.
+         *
+         * @param sensorId Sensor identifier.
+         */
+        void erase(uint sensorId);
+
+        /**
+         * @brief Clear all cached readings.
+         */
         void clear();
 
+        /**
+         * @brief Number of cached readings.
+         */
         [[nodiscard]] size_t size() const;
 
     private:
@@ -114,10 +346,16 @@ namespace SmartHome {
 
         const ConfigCache &mConfigCache;
 
-        std::unordered_map<int, CachedReading> mReadings;
+        std::unordered_map<uint, CachedReading> mReadings;
 
-        [[nodiscard]] std::chrono::seconds getTTL(int sensorId) const;
+        /**
+         * @brief Resolve TTL for given sensor id using config cache.
+         */
+        [[nodiscard]] std::chrono::seconds getTTL(uint sensorId) const;
 
+        /**
+         * @brief Check if reading is within TTL window.
+         */
         [[nodiscard]] static bool isFresh(const CachedReading &reading, std::chrono::seconds ttl);
     };
 }

--- a/central_unit/src/core/cache.h
+++ b/central_unit/src/core/cache.h
@@ -13,17 +13,17 @@ namespace SmartHome {
     using namespace std::chrono_literals;
 
     struct CachedModule {
-        int id;
-        int logicAddress;
+        uint id;
+        uint logicAddress;
         std::string name;
         nlohmann::json config;
-        std::chrono::steady_clock::time_point lastOnline;
+        std::chrono::system_clock::time_point lastOnline;
     };
 
     struct CachedSensor {
-        int id;
-        int logicId;
-        int moduleId;
+        uint id;
+        uint logicId;
+        uint moduleId;
         std::string name;
         std::string type;
         nlohmann::json config;
@@ -36,7 +36,7 @@ namespace SmartHome {
     struct CachedReading {
         int sensorId;
         nlohmann::json value;
-        std::chrono::steady_clock::time_point timestamp;
+        std::chrono::system_clock::time_point timestamp;
         bool stale = false;
     };
 
@@ -48,7 +48,7 @@ namespace SmartHome {
 
         void eraseModule(int moduleId);
 
-        void updateModuleLastOnline(int moduleId, std::chrono::steady_clock::time_point timestamp);
+        void updateModuleLastOnline(int moduleId, std::chrono::system_clock::time_point timestamp);
 
         void setSensor(const CachedSensor &sensor);
 

--- a/central_unit/src/core/cache.h
+++ b/central_unit/src/core/cache.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <chrono>
+#include <map>
+#include <optional>
+#include <shared_mutex>
+#include <string>
+#include <unordered_map>
+
+#include <nlohmann/json.hpp>
+
+namespace SmartHome {
+    using namespace std::chrono_literals;
+
+    struct CachedModule {
+        int id;
+        int logicAddress;
+        std::string name;
+        nlohmann::json config;
+        std::chrono::steady_clock::time_point lastOnline;
+    };
+
+    struct CachedSensor {
+        int id;
+        int logicId;
+        int moduleId;
+        std::string name;
+        std::string type;
+        nlohmann::json config;
+
+        [[nodiscard]] bool useCache() const;
+
+        [[nodiscard]] std::chrono::seconds cacheTTL() const;
+    };
+
+    struct CachedReading {
+        int sensorId;
+        nlohmann::json value;
+        std::chrono::steady_clock::time_point timestamp;
+        bool stale = false;
+    };
+
+    class ConfigCache {
+    public:
+        void setModule(const CachedModule &module);
+
+        [[nodiscard]] std::optional<CachedModule> getModule(int moduleId) const;
+
+        void eraseModule(int moduleId);
+
+        void updateModuleLastOnline(int moduleId, std::chrono::steady_clock::time_point timestamp);
+
+        void setSensor(const CachedSensor &sensor);
+
+        [[nodiscard]] std::optional<CachedSensor> getSensor(int sensorId) const;
+
+
+        void eraseSensor(int sensorId);
+
+        [[nodiscard]] std::optional<int> findModuleId(int logicAddress) const;
+
+        [[nodiscard]] std::optional<int> findSensorId(int moduleId, int logicId) const;
+
+        [[nodiscard]] std::optional<int> findSensorIdByLogicAddress(int moduleLogicAddress, int sensorLogicId) const;
+
+        [[nodiscard]] std::vector<int> getSensorIdsForModule(int moduleId) const;
+
+        void clear();
+
+        [[nodiscard]] size_t modulesSize() const;
+
+        [[nodiscard]] size_t sensorsSize() const;
+
+    private:
+        mutable std::shared_mutex mMutex;
+
+        std::unordered_map<int, CachedModule> mModules; ///< moduleId: module
+        std::unordered_map<int, CachedSensor> mSensors; ///< sensorId: sensor
+
+        std::unordered_map<int, int> mModulesIndex; ///< logicAddress: moduleId
+        std::map<std::pair<int, int>, int> mSensorsIndex; ///< (moduleId, logicId): sensorId
+
+        void addToModulesIndex(const CachedModule &module);
+
+        void removeFromModulesIndex(int logicAddress);
+
+        void addToSensorsIndex(const CachedSensor &sensor);
+
+        void removeFromSensorsIndex(int moduleId, int logicId);
+    };
+
+    class ReadingsCache {
+    public:
+        explicit ReadingsCache(const ConfigCache &configCache);
+
+        [[nodiscard]] std::optional<CachedReading> get(int sensorId) const;
+
+        [[nodiscard]] std::optional<CachedReading> getFresh(int sensorId) const;
+
+        void set(int sensorId, const nlohmann::json &value);
+
+        void erase(int sensorId);
+
+        void clear();
+
+        [[nodiscard]] size_t size() const;
+
+    private:
+        mutable std::shared_mutex mMutex;
+
+        const ConfigCache &mConfigCache;
+
+        std::unordered_map<int, CachedReading> mReadings;
+
+        [[nodiscard]] std::chrono::seconds getTTL(int sensorId) const;
+
+        [[nodiscard]] static bool isFresh(const CachedReading &reading, std::chrono::seconds ttl);
+    };
+}

--- a/central_unit/src/core/core.cpp
+++ b/central_unit/src/core/core.cpp
@@ -1,12 +1,15 @@
 #include "core.h"
 #include "config_manager/config_manager.h"
 #include "actions/actions.h"
+#include "actions/database_actions.h"
 
 #include <chrono>
 #include <cmath>
 #include <iostream>
 
 #include <boost/asio.hpp>
+
+#include "actions/core_actions.h"
 
 namespace ba = boost::asio;
 namespace bai = boost::asio::ip;
@@ -144,6 +147,26 @@ namespace SmartHome {
             return;
         }
         socketServer.runSocketServer();
+
+        // Fetch initial config from database to populate cache
+        ba::co_spawn(mCoreIoContext, [this]() -> ba::awaitable<void> {
+            const auto target = sai::Target(sai::TargetTypes::DATABASE);
+            ba::steady_timer retryTimer(co_await ba::this_coro::executor);
+
+            if (!CoreActions::findConnections(target.to_string()).has_value()) {
+                mpLogger->warning("[CORE] No database service connection found on startup, entering retry loop...");
+
+                while (mIsRunning && !CoreActions::findConnections(target.to_string()).has_value()) {
+                    mpLogger->debug(
+                        "[CORE] No database service connection found, retrying in 1 second...");
+                    retryTimer.expires_after(1s);
+                    co_await retryTimer.async_wait(ba::use_awaitable);
+                }
+            }
+
+            co_await DatabaseActions::fetchAllConfigs();
+            co_return;
+        }, ba::detached);
 
         //TODO implement watchdog working in CoreThread
         mCoreThreadPool->join();

--- a/central_unit/src/core/core.cpp
+++ b/central_unit/src/core/core.cpp
@@ -2,6 +2,8 @@
 #include "config_manager/config_manager.h"
 #include "actions/actions.h"
 #include "actions/database_actions.h"
+#include "constants.h"
+
 
 #include <chrono>
 #include <cmath>
@@ -30,7 +32,8 @@ namespace SmartHome {
         // Initialize AsyncLogger, using Logger for further initialization
         mpLogger = std::make_shared<Utils::AsyncLogger>(logger, mCoreUtilityIoContext);
 
-        mpService = Utils::ServiceManager::create(logger, ms_ServiceName, Utils::ServiceType::AUTO);
+        mpService = Utils::ServiceManager::create(logger, Constants::DefaultServiceNames::CORE,
+                                                  Utils::ServiceType::AUTO);
         mpService->setIoContext(mCoreIoContext);
 
         if (!mpService->onInitialize()) {

--- a/central_unit/src/core/core.cpp
+++ b/central_unit/src/core/core.cpp
@@ -156,18 +156,28 @@ namespace SmartHome {
             const auto target = sai::Target(sai::TargetTypes::DATABASE);
             ba::steady_timer retryTimer(co_await ba::this_coro::executor);
 
+            // Delay before first check to allow database service to start and register connection
+            retryTimer.expires_after(5s);
+            co_await retryTimer.async_wait(ba::use_awaitable);
+
             if (!CoreActions::findConnections(target.to_string()).has_value()) {
                 mpLogger->warning("[CORE] No database service connection found on startup, entering retry loop...");
 
                 while (mIsRunning && !CoreActions::findConnections(target.to_string()).has_value()) {
                     mpLogger->debug(
-                        "[CORE] No database service connection found, retrying in 1 second...");
-                    retryTimer.expires_after(1s);
+                        "[CORE] No database service connection found, retrying in 5 seconds...");
+                    retryTimer.expires_after(5s);
                     co_await retryTimer.async_wait(ba::use_awaitable);
                 }
             }
 
             co_await DatabaseActions::fetchAllConfigs();
+
+            // Start scheduler after populating cache
+            mpScheduler = std::make_unique<Scheduler>(mCoreIoContext, mConfigCache, mpLogger);
+            mpScheduler->loadFromCache();
+            mpScheduler->start();
+
             co_return;
         }, ba::detached);
 
@@ -188,6 +198,8 @@ namespace SmartHome {
         mIsRunning.store(false);
         auto &ipcServer = IPC::SocketServer::Instance();
         ipcServer.stopAcceptors();
+
+        mpScheduler.reset();
 
         Actions::onCoreShutdown();
 
@@ -245,6 +257,10 @@ namespace SmartHome {
 
     ReadingsCache &Core::readingsCache() {
         return mReadingsCache;
+    }
+
+    Scheduler &Core::scheduler() const {
+        return *mpScheduler;
     }
 
     ba::io_context &Core::coreUtilityIoContext() {

--- a/central_unit/src/core/core.cpp
+++ b/central_unit/src/core/core.cpp
@@ -213,15 +213,15 @@ namespace SmartHome {
         return mIsRunning.load();
     }
 
-    ba::io_context &Core::getCoreUtilityIoContext() {
+    ba::io_context &Core::coreUtilityIoContext() {
         return mCoreUtilityIoContext;
     }
 
-    ba::io_context &Core::getCoreWorkerIoContext() {
+    ba::io_context &Core::coreWorkerIoContext() {
         return mCoreWorkerIoContext;
     }
 
-    ba::io_context &Core::getCoreIoContext() {
+    ba::io_context &Core::coreIoContext() {
         return mCoreIoContext;
     }
 

--- a/central_unit/src/core/core.cpp
+++ b/central_unit/src/core/core.cpp
@@ -181,70 +181,104 @@ namespace SmartHome {
             co_return;
         }, ba::detached);
 
-        //TODO implement watchdog working in CoreThread
-        mCoreThreadPool->join();
-        mCoreThreadPool.reset();
+        mpLogger->info("[CORE] Core running");
 
-        mpLogger->debug("[CORE] Exiting");
-        stopCoreUtilityThread();
-    }
-
-    void Core::shutdown() {
-        // FIXME rework shutdown - implement shutdown from db-service
-        //TODO add is shutting down check
-        mpLogger->debug("[CORE] Starting core shutdown");
-
-        // Signal and initialize shutdown
-        mIsRunning.store(false);
-        auto &ipcServer = IPC::SocketServer::Instance();
-        ipcServer.stopAcceptors();
-
-        mpScheduler.reset();
-
-        Actions::onCoreShutdown();
-
-        // Start shutdown timeout timer
-        auto shutdownTimeout = make_shared<ba::steady_timer>(mCoreUtilityIoContext, ms_SHUTDOWN_TIMEOUT);
-        shutdownTimeout->async_wait([this, shutdownTimeout](const bs::error_code &ec) {
-            if (!ec) {
-                mCoreWorkerThreadPool->stop();
-                mCoreThreadPool->stop();
-                mSocketServerThreadPool->stop();
-            }
-        });
-
-        // Join worker thread
-        mCoreWorkerGuard.reset();
-        mCoreWorkerThreadPool->join();
-
-        // Disable core thread guard for later join
-        mCoreGuard->reset();
-
-        // Stop IPC server
-        if (mConfig.tcp.isEnabled || mConfig.uds.isEnabled) {
-            mpLogger->debug("[CORE] Shutting down IPC socket server");
-            if (ipcServer.isRunning()) {
-                ipcServer.stopSocketServer();
-            }
+        if (mCoreThreadPool) {
+            mCoreThreadPool->join();
+            mCoreThreadPool.reset();
         }
 
-        // Waiting for IPC server threads to finish
-        if (mSocketServerThreadPool.has_value()) {
-            mSocketServerGuard.reset();
+        mpLogger->debug("[CORE] Core main threads finished");
+
+        // Join worker threads
+        if (mCoreWorkerThreadPool) {
+            mCoreWorkerThreadPool->join();
+            mCoreWorkerThreadPool.reset();
+        }
+
+        mpLogger->debug("[CORE] Worker threads finished");
+
+        // Join socket server threads
+        if (mSocketServerThreadPool) {
             mSocketServerThreadPool->join();
             mSocketServerThreadPool.reset();
         }
 
-        mpService->onStop();
-        mpService.reset();
+        mpLogger->debug("[CORE] Socket server threads finished, stopping utilities");
 
-        // Stop handling signals
+        // Stop utility context last (handles logging, timeout timers)
+        if (!mCoreUtilityIoContext.stopped()) {
+            mCoreUtilityIoContext.stop();
+        }
+
+        if (mCoreUtilityThread && mCoreUtilityThread->joinable()) {
+            mCoreUtilityThread->join();
+            mCoreUtilityThread.reset();
+        }
+
+        mpLogger->debug("[CORE] Exiting");
+    }
+
+    void Core::shutdown() {
+        mpLogger->info("[CORE] Shutdown requested");
+
+        bool expected = true;
+        if (!mIsRunning.compare_exchange_strong(expected, false)) {
+            mpLogger->error("[CORE] Shutdown called while core is not running");
+            return;
+        }
+
+        // Stop accepting new connections
+        auto &ipcServer = IPC::SocketServer::Instance();
+        ipcServer.stopAcceptors();
+
+        // Stop scheduler
+        mpScheduler.reset();
+
+        // Cancel active requests/commands
+        Actions::onCoreShutdown();
+
+        // Release all work guards — let io_contexts drain naturally
+        mCoreWorkerGuard.reset();
+        mCoreGuard.reset();
+        mSocketServerGuard.reset();
+
+        // Shutdown timeout as safety net
+        const auto timeoutTimer = std::make_shared<ba::steady_timer>(mCoreUtilityIoContext, ms_SHUTDOWN_TIMEOUT);
+        timeoutTimer->async_wait([this, timeoutTimer](const bs::error_code &ec) {
+            if (!ec) {
+                mpLogger->warning("[CORE] Shutdown timeout - force stopping IO contexts");
+                if (!mCoreWorkerIoContext.stopped()) mCoreWorkerIoContext.stop();
+                if (!mCoreIoContext.stopped()) mCoreIoContext.stop();
+                if (!mSocketServerIoContext.stopped()) mSocketServerIoContext.stop();
+            }
+        });
+
+        // Stop IPC server
+        if (ipcServer.isRunning()) {
+            mpLogger->debug("[CORE] Shutting down IPC socket server");
+            ipcServer.stopSocketServer();
+        }
+
+        // Cancel signals
         if (mSignals.has_value()) {
             mSignals->cancel();
             mSignals.reset();
         }
 
-        mpLogger->debug("[CORE] Shutdown complete");
+        // Stop service manager
+        if (mpService) {
+            mpService->onStop();
+            mpService.reset();
+        }
+
+        // Reset shared objects
+        mpApi.reset();
+
+        mpLogger->debug("[CORE] Shutdown complete - waiting for threads to join in run()");
+
+        // Reset utility guard so timeout timer can also finish
+        mCoreUtilityGuard.reset();
     }
 
     bool Core::isRunning() const {
@@ -279,9 +313,51 @@ namespace SmartHome {
     Core::Core() = default;
 
     Core::~Core() {
-        // FIXME rework shutdown - implement shutdown from db-service
-        if (mIsRunning.load()) {
+        if (isRunning()) {
             shutdown();
+            return;
+        }
+
+        // Cleanup after failed initialization
+        if (!isRunning() && !mIsInitialized.load(std::memory_order_acquire)) {
+            if (mpLogger) mpLogger->warning("[CORE] Running cleanup after failed initialization");
+
+            if (mSignals.has_value()) {
+                mSignals->cancel();
+                mSignals.reset();
+            }
+
+            if (mpService) {
+                mpService->onStop();
+                mpService.reset();
+            }
+
+            mCoreGuard.reset();
+            mCoreWorkerGuard.reset();
+            mSocketServerGuard.reset();
+            mCoreUtilityGuard.reset();
+
+            if (!mCoreIoContext.stopped()) mCoreIoContext.stop();
+            if (!mCoreWorkerIoContext.stopped()) mCoreWorkerIoContext.stop();
+            if (!mSocketServerIoContext.stopped()) mSocketServerIoContext.stop();
+            if (!mCoreUtilityIoContext.stopped()) mCoreUtilityIoContext.stop();
+
+            if (mCoreThreadPool) {
+                mCoreThreadPool->join();
+                mCoreThreadPool.reset();
+            }
+            if (mCoreWorkerThreadPool) {
+                mCoreWorkerThreadPool->join();
+                mCoreWorkerThreadPool.reset();
+            }
+            if (mSocketServerThreadPool) {
+                mSocketServerThreadPool->join();
+                mSocketServerThreadPool.reset();
+            }
+            if (mCoreUtilityThread && mCoreUtilityThread->joinable()) {
+                mCoreUtilityThread->join();
+                mCoreUtilityThread.reset();
+            }
         }
     }
 

--- a/central_unit/src/core/core.cpp
+++ b/central_unit/src/core/core.cpp
@@ -213,6 +213,14 @@ namespace SmartHome {
         return mIsRunning.load();
     }
 
+    ConfigCache &Core::configCache() {
+        return mConfigCache;
+    }
+
+    ReadingsCache &Core::readingsCache() {
+        return mReadingsCache;
+    }
+
     ba::io_context &Core::coreUtilityIoContext() {
         return mCoreUtilityIoContext;
     }

--- a/central_unit/src/core/core.h
+++ b/central_unit/src/core/core.h
@@ -138,6 +138,11 @@ namespace SmartHome {
          */
         ReadingsCache &readingsCache();
 
+        /**
+         * @brief Scheduler getter.
+         *
+         * @return Reference to scheduler instance.
+         */
         Scheduler &scheduler() const;
 
         /**

--- a/central_unit/src/core/core.h
+++ b/central_unit/src/core/core.h
@@ -126,21 +126,21 @@ namespace SmartHome {
          *
          * @return Core utility IO context.
          */
-        ba::io_context &getCoreUtilityIoContext();
+        ba::io_context &coreUtilityIoContext();
 
         /**
          * @brief Core worker IO context getter.
          *
          * @return Core worker IO context.
          */
-        ba::io_context &getCoreWorkerIoContext();
+        ba::io_context &coreWorkerIoContext();
 
         /**
          * @brief Core IO context getter.
          *
          * @return Core IO context.
          */
-        ba::io_context &getCoreIoContext();
+        ba::io_context &coreIoContext();
 
         std::shared_ptr<Utils::AsyncLogger> mpLogger; ///< Logger instance
 

--- a/central_unit/src/core/core.h
+++ b/central_unit/src/core/core.h
@@ -3,6 +3,7 @@
 #include "socket_server.h"
 #include "service_manager/service_manager.h"
 #include "async_logger.h"
+#include "cache.h"
 #include "api/internal_api.h"
 
 #include <atomic>
@@ -121,6 +122,21 @@ namespace SmartHome {
          */
         bool isRunning() const;
 
+
+        /**
+         * @brief Configuration cache getter.
+         *
+         * @return Reference to configuration cache instance.
+         */
+        ConfigCache &configCache();
+
+        /**
+         * @brief Readings cache getter.
+         *
+         * @return Reference to readings cache instance.
+         */
+        ReadingsCache &readingsCache();
+
         /**
          * @brief Core utility IO context getter.
          *
@@ -189,6 +205,10 @@ namespace SmartHome {
 
         std::unique_ptr<Utils::ServiceManager> mpService;
         std::shared_ptr<API::InternalApi> mpApi;
+
+        // Cache
+        ConfigCache mConfigCache;
+        ReadingsCache mReadingsCache{mConfigCache};
 
         // Socket server resources
         ba::io_context mSocketServerIoContext;

--- a/central_unit/src/core/core.h
+++ b/central_unit/src/core/core.h
@@ -5,6 +5,7 @@
 #include "async_logger.h"
 #include "api/internal_api.h"
 #include "cache.h"
+#include "scheduler.h"
 
 #include <atomic>
 #include <memory>
@@ -137,6 +138,8 @@ namespace SmartHome {
          */
         ReadingsCache &readingsCache();
 
+        Scheduler &scheduler() const;
+
         /**
          * @brief Core utility IO context getter.
          *
@@ -207,6 +210,9 @@ namespace SmartHome {
         // Cache
         ConfigCache mConfigCache;
         ReadingsCache mReadingsCache{mConfigCache};
+
+        // Scheduler
+        std::unique_ptr<Scheduler> mpScheduler;
 
         // Socket server resources
         ba::io_context mSocketServerIoContext;

--- a/central_unit/src/core/core.h
+++ b/central_unit/src/core/core.h
@@ -3,8 +3,8 @@
 #include "socket_server.h"
 #include "service_manager/service_manager.h"
 #include "async_logger.h"
-#include "cache.h"
 #include "api/internal_api.h"
+#include "cache.h"
 
 #include <atomic>
 #include <memory>

--- a/central_unit/src/core/core.h
+++ b/central_unit/src/core/core.h
@@ -198,8 +198,6 @@ namespace SmartHome {
          */
         static uint getThreadCount(int threadCountConfigValue);
 
-        static constexpr std::string_view ms_ServiceName = "smarthomed";
-
         // Configuration
         Config mConfig;
 

--- a/central_unit/src/core/main.cpp
+++ b/central_unit/src/core/main.cpp
@@ -134,18 +134,17 @@ namespace SmartHome {
     }
 
     bool runProcess(const std::shared_ptr<Utils::Logger> &logger,
-                    const Utils::ServiceType serviceType,
-                    const std::string_view execPath,
-                    const std::string_view configPath,
-                    const std::string_view processName, bp::child &process) {
+                    const std::string_view processName,
+                    const ProcessConfig &processConfig,
+                    bp::child &process) {
         logger->debugf("[MAIN_CORE] Launching %s", processName.data());
-        switch (serviceType) {
+        switch (processConfig.serviceType) {
             default:
             case Utils::ServiceType::AUTO:
             case Utils::ServiceType::STANDALONE:
-                if (std::filesystem::exists(execPath)) {
+                if (std::filesystem::exists(processConfig.execPath)) {
                     logger->infof("[MAIN_CORE] Starting %s in STANDALONE mode", processName.data());
-                    process = bp::child(execPath.data(), "--config", configPath.data());
+                    process = bp::child(processConfig.execPath.data(), "--config", processConfig.configPath.data());
                     return true;
                 } else {
                     logger->errorf("[MAIN_CORE] Could not find %s executable", processName.data());
@@ -250,11 +249,7 @@ int main(int argc, char *argv[]) {
     // Launch mediator if enabled
     bp::child mediator;
     if (mediatorConfig.isEnabled) {
-        if (runProcess(logger, mediatorConfig.serviceType,
-                       mediatorConfig.execPath,
-                       mediatorConfig.configPath,
-                       "smarthome-radiod",
-                       mediator)) {
+        if (runProcess(logger, "smarthome-radiod", mediatorConfig, mediator)) {
             logger->info("[MAIN_CORE] Mediator launched successfully");
         } else {
             logger->error("[MAIN_CORE] Failed to launch mediator");
@@ -263,11 +258,7 @@ int main(int argc, char *argv[]) {
 
     bp::child dbService;
     if (dbServiceConfig.isEnabled) {
-        if (runProcess(logger, dbServiceConfig.serviceType,
-                       dbServiceConfig.execPath,
-                       dbServiceConfig.configPath,
-                       "smarthome-databased",
-                       dbService)) {
+        if (runProcess(logger, "smarthome-databased", dbServiceConfig, dbService)) {
             logger->info("[MAIN_CORE] Database service launched successfully");
         } else {
             logger->error("[MAIN_CORE] Failed to launch database service");

--- a/central_unit/src/core/main.cpp
+++ b/central_unit/src/core/main.cpp
@@ -102,10 +102,10 @@ namespace SmartHome {
         // Load YAML config
         auto configManager = Utils::ConfigManager(logger);
         Utils::Logger::Config loggerConfig;
-        loggerConfig.logFile.path = s_DEFAULT_LOGFILE_PATH;
+        loggerConfig.logFile.path = std::string{Constants::DefaultPaths::CORE_LOGFILE};
         const std::string configPath = vm.contains("config")
                                            ? vm["config"].as<std::string>()
-                                           : s_DEFAULT_CONFIG_PATH.data();
+                                           : std::string{Constants::DefaultPaths::CORE_CONFIG};
         if (configManager.loadConfig(configPath)) {
             logger->debug("[MAIN_CORE] Loading YAML logger config");
             loadLoggerYamlConfig(configManager, loggerConfig);

--- a/central_unit/src/core/main.cpp
+++ b/central_unit/src/core/main.cpp
@@ -22,8 +22,10 @@ namespace SmartHome {
         configManager.getValue(root + ".path", config.logFile.path);
     }
 
-    void loadYamlConfigs(Utils::ConfigManager &configManager, Core::Config &coreConfig,
-                         MediatorConfig &mediatorConfig) {
+    void loadYamlConfigs(Utils::ConfigManager &configManager,
+                         Core::Config &coreConfig,
+                         MediatorConfig &mediatorConfig,
+                         DbServiceConfig &dbServiceConfig) {
         // Mediator config
         std::string root = "services.mediator";
         configManager.getValue(root + ".enabled", mediatorConfig.isEnabled);
@@ -31,6 +33,14 @@ namespace SmartHome {
             configManager.getValue<std::string>(root + ".service_type").value());
         configManager.getValue(root + ".exec_path", mediatorConfig.execPath);
         configManager.getValue(root + ".config_path", mediatorConfig.configPath);
+
+        // Db-service config
+        root = "services.db-service";
+        configManager.getValue(root + ".enabled", dbServiceConfig.isEnabled);
+        dbServiceConfig.serviceType = Utils::resolveServiceType(
+            configManager.getValue<std::string>(root + ".service_type").value());
+        configManager.getValue(root + ".exec_path", dbServiceConfig.execPath);
+        configManager.getValue(root + ".config_path", dbServiceConfig.configPath);
 
         // Core config
         root = "core";
@@ -72,7 +82,8 @@ namespace SmartHome {
                      const bpo::parsed_options &parsed,
                      const std::shared_ptr<Utils::Logger> &logger,
                      Core::Config &coreConfig,
-                     MediatorConfig &mediatorConfig) {
+                     MediatorConfig &mediatorConfig,
+                     DbServiceConfig &dbServiceConfig) {
         loggerTemporaryOptions logTmpOpt;
 
         // Set temporary logger config based on program options and default values before reading YAML config
@@ -111,7 +122,7 @@ namespace SmartHome {
             loadLoggerYamlConfig(configManager, loggerConfig);
 
             logger->debug("[MAIN_CORE] Loading YAML core config");
-            loadYamlConfigs(configManager, coreConfig, mediatorConfig);
+            loadYamlConfigs(configManager, coreConfig, mediatorConfig, dbServiceConfig);
         } else {
             logger->error("[MAIN_CORE] Could not load YAML config");
         }
@@ -120,6 +131,57 @@ namespace SmartHome {
 
         logger->applyConfig(loggerConfig);
         logger->debug("[MAIN_CORE] Smarthome configured");
+    }
+
+    bool runProcess(const std::shared_ptr<Utils::Logger> &logger,
+                    const Utils::ServiceType serviceType,
+                    const std::string_view execPath,
+                    const std::string_view configPath,
+                    const std::string_view processName, bp::child &process) {
+        logger->debugf("[MAIN_CORE] Launching %s", processName.data());
+        switch (serviceType) {
+            default:
+            case Utils::ServiceType::AUTO:
+            case Utils::ServiceType::STANDALONE:
+                if (std::filesystem::exists(execPath)) {
+                    logger->infof("[MAIN_CORE] Starting %s in STANDALONE mode", processName.data());
+                    process = bp::child(execPath.data(), "--config", configPath.data());
+                    return true;
+                } else {
+                    logger->errorf("[MAIN_CORE] Could not find %s executable", processName.data());
+                    return false;
+                }
+            case Utils::ServiceType::SYSTEMD:
+                logger->infof("[MAIN_CORE] Starting %s in SYSTEMD mode - waiting for service to be ready",
+                              processName.data()); {
+                    bool isRunning = false;
+
+                    for (int attempt = 1; attempt <= s_MAX_RETRIES; ++attempt) {
+                        const int ret = std::system(
+                            ("systemctl is-active --quiet " + std::string(processName) + ".service").c_str());
+                        if (ret == 0) {
+                            logger->infof("[MAIN_CORE] %s service is running", processName.data());
+                            isRunning = true;
+                            break;
+                        }
+
+                        if (attempt < s_MAX_RETRIES) {
+                            logger->debugf("[MAIN_CORE] %s not ready yet, retry %d/%d",
+                                           processName.data(),
+                                           attempt,
+                                           s_MAX_RETRIES);
+                            std::this_thread::sleep_for(s_RETRY_DELAY);
+                        }
+                    }
+
+                    if (!isRunning) {
+                        logger->warningf("[MAIN_CORE] %s service did not start within timeout", processName.data());
+                        logger->infof("[MAIN_CORE] Check status: sudo systemctl status %s.service", processName.data());
+                        return false;
+                    }
+                    return true;
+                }
+        }
     }
 }
 
@@ -165,14 +227,14 @@ int main(int argc, char *argv[]) {
 
     // Define instances
     auto &core = Core::Instance();
-    bp::child mediator;
     auto logger = std::make_shared<Utils::Logger>();
 
     // Define config structs with default values
     Core::Config coreConfig;
     MediatorConfig mediatorConfig;
+    DbServiceConfig dbServiceConfig;
 
-    loadConfigs(vm, parsed, logger, coreConfig, mediatorConfig);
+    loadConfigs(vm, parsed, logger, coreConfig, mediatorConfig, dbServiceConfig);
 
     // Initialize Core
     logger->debug("[MAIN_CORE] Initializing Core...");
@@ -186,44 +248,29 @@ int main(int argc, char *argv[]) {
     // TODO launch gui if in gui mode
 
     // Launch mediator if enabled
+    bp::child mediator;
     if (mediatorConfig.isEnabled) {
-        logger->debug("[MAIN_CORE] Initializing Mediator...");
-        switch (mediatorConfig.serviceType) {
-            default:
-            case Utils::ServiceType::AUTO:
-            case Utils::ServiceType::STANDALONE:
-                if (std::filesystem::exists(mediatorConfig.execPath)) {
-                    logger->info("[MAIN_CORE] Starting Mediator in STANDALONE mode");
-                    mediator = bp::child(mediatorConfig.execPath, "--config", mediatorConfig.configPath);
-                } else {
-                    logger->error("[MAIN_CORE] Could not find mediator executable");
-                }
-                break;
-            case Utils::ServiceType::SYSTEMD:
-                logger->info("[MAIN_CORE] Mediator in SYSTEMD mode - waiting for service to be ready"); {
-                    bool isRunning = false;
+        if (runProcess(logger, mediatorConfig.serviceType,
+                       mediatorConfig.execPath,
+                       mediatorConfig.configPath,
+                       "smarthome-radiod",
+                       mediator)) {
+            logger->info("[MAIN_CORE] Mediator launched successfully");
+        } else {
+            logger->error("[MAIN_CORE] Failed to launch mediator");
+        }
+    }
 
-                    for (int attempt = 1; attempt <= s_MAX_RETRIES; ++attempt) {
-                        int ret = std::system("systemctl is-active --quiet smarthome-mediator.service");
-                        if (ret == 0) {
-                            logger->info("[MAIN_CORE] Mediator service is running");
-                            isRunning = true;
-                            break;
-                        }
-
-                        if (attempt < s_MAX_RETRIES) {
-                            logger->debugf("[MAIN_CORE] Mediator not ready yet, retry %d/%d", attempt, s_MAX_RETRIES);
-                            std::this_thread::sleep_for(s_RETRY_DELAY);
-                        }
-                    }
-
-                    if (!isRunning) {
-                        logger->warning("[MAIN_CORE] Mediator service did not start within timeout");
-                        logger->warning("[MAIN_CORE] RF features will be unavailable");
-                        logger->info("[MAIN_CORE] Check status: sudo systemctl status smarthome-mediator.service");
-                    }
-                    break;
-                }
+    bp::child dbService;
+    if (dbServiceConfig.isEnabled) {
+        if (runProcess(logger, dbServiceConfig.serviceType,
+                       dbServiceConfig.execPath,
+                       dbServiceConfig.configPath,
+                       "smarthome-databased",
+                       dbService)) {
+            logger->info("[MAIN_CORE] Database service launched successfully");
+        } else {
+            logger->error("[MAIN_CORE] Failed to launch database service");
         }
     }
 
@@ -234,7 +281,7 @@ int main(int argc, char *argv[]) {
 
 
     // Wait for mediator to exit if enabled
-    if (mediatorConfig.isEnabled && mediator) {
+    if (mediator) {
         logger->debug("[MAIN_CORE] Waiting for mediator shutdown");
         if (mediatorConfig.serviceType == Utils::ServiceType::STANDALONE) {
             mediator.terminate(); //SIGTERM
@@ -244,6 +291,18 @@ int main(int argc, char *argv[]) {
             }
         } else if (mediatorConfig.serviceType == Utils::ServiceType::SYSTEMD) {
             logger->debug("[MAIN_CORE] Mediator in SYSTEMD mode - not stopping (managed by systemd)");
+        }
+    }
+    if (dbService) {
+        logger->debug("[MAIN_CORE] Waiting for db-service shutdown");
+        if (dbServiceConfig.serviceType == Utils::ServiceType::STANDALONE) {
+            dbService.terminate(); //SIGTERM
+            if (!dbService.wait_for(15s)) {
+                kill(dbService.id(), SIGKILL);
+                dbService.wait();
+            }
+        } else if (dbServiceConfig.serviceType == Utils::ServiceType::SYSTEMD) {
+            logger->debug("[MAIN_CORE] Db-service in SYSTEMD mode - not stopping (managed by systemd)");
         }
     }
 

--- a/central_unit/src/core/main.cpp
+++ b/central_unit/src/core/main.cpp
@@ -141,45 +141,46 @@ namespace SmartHome {
         switch (processConfig.serviceType) {
             default:
             case Utils::ServiceType::AUTO:
-            case Utils::ServiceType::STANDALONE:
+            case Utils::ServiceType::STANDALONE: {
                 if (std::filesystem::exists(processConfig.execPath)) {
                     logger->infof("[MAIN_CORE] Starting %s in STANDALONE mode", processName.data());
                     process = bp::child(processConfig.execPath.data(), "--config", processConfig.configPath.data());
                     return true;
-                } else {
-                    logger->errorf("[MAIN_CORE] Could not find %s executable", processName.data());
+                }
+
+                logger->errorf("[MAIN_CORE] Could not find %s executable", processName.data());
+                return false;
+            }
+            case Utils::ServiceType::SYSTEMD: {
+                logger->infof("[MAIN_CORE] Starting %s in SYSTEMD mode - waiting for service to be ready",
+                              processName.data());
+                bool isRunning = false;
+
+                for (int attempt = 1; attempt <= s_MAX_RETRIES; ++attempt) {
+                    const int ret = std::system(
+                        ("systemctl is-active --quiet " + std::string(processName) + ".service").c_str());
+                    if (ret == 0) {
+                        logger->infof("[MAIN_CORE] %s service is running", processName.data());
+                        isRunning = true;
+                        break;
+                    }
+
+                    if (attempt < s_MAX_RETRIES) {
+                        logger->debugf("[MAIN_CORE] %s not ready yet, retry %d/%d",
+                                       processName.data(),
+                                       attempt,
+                                       s_MAX_RETRIES);
+                        std::this_thread::sleep_for(s_RETRY_DELAY);
+                    }
+                }
+
+                if (!isRunning) {
+                    logger->warningf("[MAIN_CORE] %s service did not start within timeout", processName.data());
+                    logger->infof("[MAIN_CORE] Check status: sudo systemctl status %s.service", processName.data());
                     return false;
                 }
-            case Utils::ServiceType::SYSTEMD:
-                logger->infof("[MAIN_CORE] Starting %s in SYSTEMD mode - waiting for service to be ready",
-                              processName.data()); {
-                    bool isRunning = false;
-
-                    for (int attempt = 1; attempt <= s_MAX_RETRIES; ++attempt) {
-                        const int ret = std::system(
-                            ("systemctl is-active --quiet " + std::string(processName) + ".service").c_str());
-                        if (ret == 0) {
-                            logger->infof("[MAIN_CORE] %s service is running", processName.data());
-                            isRunning = true;
-                            break;
-                        }
-
-                        if (attempt < s_MAX_RETRIES) {
-                            logger->debugf("[MAIN_CORE] %s not ready yet, retry %d/%d",
-                                           processName.data(),
-                                           attempt,
-                                           s_MAX_RETRIES);
-                            std::this_thread::sleep_for(s_RETRY_DELAY);
-                        }
-                    }
-
-                    if (!isRunning) {
-                        logger->warningf("[MAIN_CORE] %s service did not start within timeout", processName.data());
-                        logger->infof("[MAIN_CORE] Check status: sudo systemctl status %s.service", processName.data());
-                        return false;
-                    }
-                    return true;
-                }
+                return true;
+            }
         }
     }
 }

--- a/central_unit/src/core/main.h
+++ b/central_unit/src/core/main.h
@@ -12,7 +12,7 @@ namespace bpo = boost::program_options;
 
 namespace SmartHome {
     /**
-     *@brief Default configuration for launching and managing processes.
+     * @brief Default configuration for launching and managing processes.
      */
     struct ProcessConfig {
         /// Enable/Disable process launch by Core
@@ -26,7 +26,7 @@ namespace SmartHome {
     };
 
     /**
-     *@brief Configuration for launching and managing mediator service.
+     * @brief Configuration for launching and managing mediator service.
      */
     struct MediatorConfig : ProcessConfig {
         MediatorConfig() {
@@ -36,7 +36,7 @@ namespace SmartHome {
     };
 
     /**
-     *@brief Configuration for launching and managing database service.
+     * @brief Configuration for launching and managing database service.
      */
     struct DbServiceConfig : ProcessConfig {
         DbServiceConfig() {

--- a/central_unit/src/core/main.h
+++ b/central_unit/src/core/main.h
@@ -12,31 +12,37 @@ namespace bpo = boost::program_options;
 
 namespace SmartHome {
     /**
+     *@brief Default configuration for launching and managing processes.
+     */
+    struct ProcessConfig {
+        /// Enable/Disable process launch by Core
+        bool isEnabled = false;
+        /// Mode in which process will run
+        Utils::ServiceType serviceType = Utils::ServiceType::AUTO;
+        /// Path to process executable for standalone mode
+        std::string execPath;
+        /// Path to process's own YAML config file
+        std::string configPath;
+    };
+
+    /**
      *@brief Configuration for launching and managing mediator service.
      */
-    struct MediatorConfig {
-        /// Enable/Disable mediator launch by Core
-        bool isEnabled = false;
-        /// Mode in which mediator will run
-        Utils::ServiceType serviceType = Utils::ServiceType::AUTO;
-        /// Path to mediator executable for standalone mode
-        std::string execPath = std::string{Constants::DefaultPaths::MEDIATOR_EXEC};
-        /// Path to mediator's own YAML config file
-        std::string configPath = std::string{Constants::DefaultPaths::MEDIATOR_CONFIG};
+    struct MediatorConfig : ProcessConfig {
+        MediatorConfig() {
+            execPath = Constants::DefaultPaths::MEDIATOR_EXEC;
+            configPath = Constants::DefaultPaths::MEDIATOR_CONFIG;
+        }
     };
 
     /**
      *@brief Configuration for launching and managing database service.
      */
-    struct DbServiceConfig {
-        /// Enable/Disable db-service launch by Core
-        bool isEnabled = false;
-        /// Mode in which db-service will run
-        Utils::ServiceType serviceType = Utils::ServiceType::AUTO;
-        /// Path to db-service executable for standalone mode
-        std::string execPath = std::string{Constants::DefaultPaths::DB_SERVICE_EXEC};
-        /// Path to db-service's own YAML config file
-        std::string configPath = std::string{Constants::DefaultPaths::DB_SERVICE_CONFIG};
+    struct DbServiceConfig : ProcessConfig {
+        DbServiceConfig() {
+            execPath = Constants::DefaultPaths::DB_SERVICE_EXEC;
+            configPath = Constants::DefaultPaths::DB_SERVICE_CONFIG;
+        }
     };
 
     /**
@@ -122,19 +128,15 @@ namespace SmartHome {
      * @brief Runs a process with retry mechanism.
      *
      * @param logger Logger instance for logging process launch attempts and errors.
-     * @param serviceType Service type to determine launch mode (e.g., AUTO, SYSTEMD, STANDALONE).
-     * @param execPath Path to executable for standalone launch mode.
-     * @param configPath Path to configuration file to pass to the process.
      * @param processName Name of the process for logging purposes.
+     * @param processConfig Configuration struct containing process launch parameters.
      * @param process Reference to a boost::process::child object to store the launched process handle.
      *
      * @return true if the process was launched successfully, false otherwise.
      */
     bool runProcess(const std::shared_ptr<Utils::Logger> &logger,
-                    Utils::ServiceType serviceType,
-                    std::string_view execPath,
-                    std::string_view configPath,
                     std::string_view processName,
+                    const ProcessConfig &processConfig,
                     bp::child &process);
 
     static constexpr auto s_MAX_RETRIES = 10;

--- a/central_unit/src/core/main.h
+++ b/central_unit/src/core/main.h
@@ -26,6 +26,20 @@ namespace SmartHome {
     };
 
     /**
+     *@brief Configuration for launching and managing database service.
+     */
+    struct DbServiceConfig {
+        /// Enable/Disable db-service launch by Core
+        bool isEnabled = false;
+        /// Mode in which db-service will run
+        Utils::ServiceType serviceType = Utils::ServiceType::AUTO;
+        /// Path to db-service executable for standalone mode
+        std::string execPath = std::string{Constants::DefaultPaths::DB_SERVICE_EXEC};
+        /// Path to db-service's own YAML config file
+        std::string configPath = std::string{Constants::DefaultPaths::DB_SERVICE_CONFIG};
+    };
+
+    /**
      * @brief Temporary storage for logger command-line options.
      *
      * @details Holds logger settings parsed from program options before they are merged with YAML configuration.
@@ -58,10 +72,11 @@ namespace SmartHome {
      * @param configManager Configuration manager instance for YAML file handling.
      * @param coreConfig Core configuration struct to be updated.
      * @param mediatorConfig Mediator launch configuration struct to be updated.
+     * @param dbServiceConfig
      */
     void loadYamlConfigs(Utils::ConfigManager &configManager,
                          Core::Config &coreConfig,
-                         MediatorConfig &mediatorConfig);
+                         MediatorConfig &mediatorConfig, DbServiceConfig &dbServiceConfig);
 
     /**
      * @brief Overwrites configurations with command-line options.
@@ -93,6 +108,7 @@ namespace SmartHome {
      * @param logger Logger instance to configure and use for loading messages.
      * @param coreConfig Core configuration struct to fill.
      * @param mediatorConfig Mediator configuration struct to fill.
+     * @param dbServiceConfig
      *
      * @note Priority order: defaults -> YAML -> command-line.
      */
@@ -100,9 +116,26 @@ namespace SmartHome {
                      const bpo::parsed_options &parsed,
                      const std::shared_ptr<Utils::Logger> &logger,
                      Core::Config &coreConfig,
-                     MediatorConfig &mediatorConfig);
+                     MediatorConfig &mediatorConfig, DbServiceConfig &dbServiceConfig);
 
-
+    /**
+     * @brief Runs a process with retry mechanism.
+     *
+     * @param logger Logger instance for logging process launch attempts and errors.
+     * @param serviceType Service type to determine launch mode (e.g., AUTO, SYSTEMD, STANDALONE).
+     * @param execPath Path to executable for standalone launch mode.
+     * @param configPath Path to configuration file to pass to the process.
+     * @param processName Name of the process for logging purposes.
+     * @param process Reference to a boost::process::child object to store the launched process handle.
+     *
+     * @return true if the process was launched successfully, false otherwise.
+     */
+    bool runProcess(const std::shared_ptr<Utils::Logger> &logger,
+                    Utils::ServiceType serviceType,
+                    std::string_view execPath,
+                    std::string_view configPath,
+                    std::string_view processName,
+                    bp::child &process);
 
     static constexpr auto s_MAX_RETRIES = 10;
     static constexpr auto s_RETRY_DELAY = 250ms;

--- a/central_unit/src/core/main.h
+++ b/central_unit/src/core/main.h
@@ -82,7 +82,8 @@ namespace SmartHome {
      */
     void loadYamlConfigs(Utils::ConfigManager &configManager,
                          Core::Config &coreConfig,
-                         MediatorConfig &mediatorConfig, DbServiceConfig &dbServiceConfig);
+                         MediatorConfig &mediatorConfig,
+                         DbServiceConfig &dbServiceConfig);
 
     /**
      * @brief Overwrites configurations with command-line options.
@@ -122,7 +123,8 @@ namespace SmartHome {
                      const bpo::parsed_options &parsed,
                      const std::shared_ptr<Utils::Logger> &logger,
                      Core::Config &coreConfig,
-                     MediatorConfig &mediatorConfig, DbServiceConfig &dbServiceConfig);
+                     MediatorConfig &mediatorConfig,
+                     DbServiceConfig &dbServiceConfig);
 
     /**
      * @brief Runs a process with retry mechanism.

--- a/central_unit/src/core/main.h
+++ b/central_unit/src/core/main.h
@@ -72,7 +72,7 @@ namespace SmartHome {
      * @param configManager Configuration manager instance for YAML file handling.
      * @param coreConfig Core configuration struct to be updated.
      * @param mediatorConfig Mediator launch configuration struct to be updated.
-     * @param dbServiceConfig
+     * @param dbServiceConfig Database service launch configuration struct to be updated.
      */
     void loadYamlConfigs(Utils::ConfigManager &configManager,
                          Core::Config &coreConfig,
@@ -108,7 +108,7 @@ namespace SmartHome {
      * @param logger Logger instance to configure and use for loading messages.
      * @param coreConfig Core configuration struct to fill.
      * @param mediatorConfig Mediator configuration struct to fill.
-     * @param dbServiceConfig
+     * @param dbServiceConfig Database service configuration struct to fill.
      *
      * @note Priority order: defaults -> YAML -> command-line.
      */

--- a/central_unit/src/core/main.h
+++ b/central_unit/src/core/main.h
@@ -2,6 +2,7 @@
 
 #include "core.h"
 #include "config_manager/config_manager.h"
+#include "constants.h"
 
 #include <boost/process.hpp>
 #include <boost/program_options.hpp>
@@ -19,9 +20,9 @@ namespace SmartHome {
         /// Mode in which mediator will run
         Utils::ServiceType serviceType = Utils::ServiceType::AUTO;
         /// Path to mediator executable for standalone mode
-        std::string execPath = "/usr/local/bin/smarthome-mediator";
+        std::string execPath = std::string{Constants::DefaultPaths::MEDIATOR_EXEC};
         /// Path to mediator's own YAML config file
-        std::string configPath = "/etc/smarthome/mediator.yaml";
+        std::string configPath = std::string{Constants::DefaultPaths::MEDIATOR_CONFIG};
     };
 
     /**
@@ -102,9 +103,6 @@ namespace SmartHome {
                      MediatorConfig &mediatorConfig);
 
 
-    /// Default path for smarthome YAML config
-    static constexpr std::string_view s_DEFAULT_CONFIG_PATH = "/etc/smarthome/smart_home.yaml";
-    static constexpr std::string_view s_DEFAULT_LOGFILE_PATH = "/var/log/smarthome/core.log";
 
     static constexpr auto s_MAX_RETRIES = 10;
     static constexpr auto s_RETRY_DELAY = 250ms;

--- a/central_unit/src/core/scheduler.cpp
+++ b/central_unit/src/core/scheduler.cpp
@@ -10,10 +10,11 @@ namespace SmartHome {
 
     Scheduler::Scheduler(ba::io_context &ioContext,
                          const ConfigCache &configCache,
-                         const std::shared_ptr<Utils::AsyncLogger> &logger) : mIoContext(ioContext),
-                                                                              mTimer(ioContext),
-                                                                              mConfigCache(configCache),
-                                                                              mpLogger(logger) {
+                         const std::shared_ptr<Utils::AsyncLogger> &logger)
+        : mIoContext(ioContext),
+          mTimer(ioContext),
+          mConfigCache(configCache),
+          mpLogger(logger) {
     }
 
     Scheduler::~Scheduler() {

--- a/central_unit/src/core/scheduler.cpp
+++ b/central_unit/src/core/scheduler.cpp
@@ -102,6 +102,29 @@ namespace SmartHome {
         return mTaskQueue.size();
     }
 
+    std::optional<std::chrono::system_clock::time_point> Scheduler::getNextRunForModule(const uint moduleId) const {
+        std::scoped_lock lock(mMutex);
+
+        auto queueCopy = mTaskQueue;
+        std::optional<std::chrono::system_clock::time_point> earliest;
+
+        while (!queueCopy.empty()) {
+            const auto &task = queueCopy.top();
+
+            if (!task->removed) {
+                const auto sensor = mConfigCache.getSensor(task->sensorId);
+                if (sensor.has_value() && sensor->moduleId == moduleId) {
+                    earliest = task->nextRun;
+                    break;
+                }
+            }
+
+            queueCopy.pop();
+        }
+
+        return earliest;
+    }
+
     bool Scheduler::ScheduledTask::advanceToNext() {
         if (!rruleIterator) return false;
 

--- a/central_unit/src/core/scheduler.cpp
+++ b/central_unit/src/core/scheduler.cpp
@@ -1,0 +1,310 @@
+#include "scheduler.h"
+#include "constants.h"
+#include "api/internal_api.h"
+#include "actions/actions.h"
+#include "actions/database_actions.h"
+
+namespace SmartHome {
+    namespace jrs = JsonRpcStrings;
+    namespace c = Constants;
+
+    Scheduler::Scheduler(ba::io_context &ioContext,
+                         const ConfigCache &configCache,
+                         const std::shared_ptr<Utils::AsyncLogger> &logger) : mIoContext(ioContext),
+                                                                              mTimer(ioContext),
+                                                                              mConfigCache(configCache),
+                                                                              mpLogger(logger) {
+    }
+
+    Scheduler::~Scheduler() {
+        if (mIsStoping.exchange(true, std::memory_order_acq_rel)) return;
+        stop();
+    }
+
+    void Scheduler::loadFromCache() {
+        std::scoped_lock lock(mMutex);
+
+        // Clear existing tasks queue by swapping with an empty queue
+        TaskQueue empty;
+        std::swap(mTaskQueue, empty);
+
+        for (const auto &sensor: mConfigCache.getAllSensors()) {
+            parseSensorSchedule(sensor.id, sensor.config);
+        }
+        mpLogger->infof("[SCHEDULER] Loaded %zu tasks from cache", mTaskQueue.size());
+
+        if (mIsRunning) scheduleNextTimer();
+    }
+
+    void Scheduler::reloadSensor(const uint sensorId) {
+        removeSensor(sensorId);
+
+        std::scoped_lock lock(mMutex);
+
+        // Reparse sensor schedule from current cache state
+        const auto sensorOpt = mConfigCache.getSensor(sensorId);
+        if (sensorOpt.has_value()) {
+            parseSensorSchedule(sensorId, sensorOpt->config);
+        }
+
+        mpLogger->debugf("[SCHEDULER] Reloaded schedule for sensor [%u], queue size: %zu",
+                         sensorId, mTaskQueue.size());
+
+        if (mIsRunning) scheduleNextTimer();
+    }
+
+    void Scheduler::removeSensor(const uint sensorId) {
+        std::scoped_lock lock(mMutex);
+
+        // Clear existing tasks queue by swapping with an empty queue
+        TaskQueue tempQueue;
+        std::swap(mTaskQueue, tempQueue);
+
+        // Filter out tasks for the sensor and keep the rest, flag removed tasks to avoid dispatching them
+        while (!tempQueue.empty()) {
+            auto task = tempQueue.top();
+            tempQueue.pop();
+            if (task->sensorId == sensorId) {
+                task->removed = true;
+            } else {
+                mTaskQueue.push(std::move(task));
+            }
+        }
+
+        mpLogger->debugf("[SCHEDULER] Removed tasks for sensor [%u], queue size: %zu",
+                         sensorId, mTaskQueue.size());
+
+        if (mIsRunning) scheduleNextTimer();
+    }
+
+    void Scheduler::start() {
+        if (mIsRunning.exchange(true, std::memory_order_acq_rel)) return;
+
+        std::scoped_lock lock(mMutex);
+        mpLogger->info("[SCHEDULER] Starting scheduler");
+        scheduleNextTimer();
+    }
+
+    void Scheduler::stop() {
+        if (!mIsRunning.exchange(false, std::memory_order_acq_rel)) return;
+
+        std::scoped_lock lock(mMutex);
+        mpLogger->info("[SCHEDULER] Stopping scheduler");
+        mTimer.cancel();
+    }
+
+    bool Scheduler::isRunning() const {
+        return mIsRunning.load(std::memory_order::acquire);
+    }
+
+    size_t Scheduler::taskCount() const {
+        std::scoped_lock lock(mMutex);
+        return mTaskQueue.size();
+    }
+
+    bool Scheduler::ScheduledTask::advanceToNext() {
+        if (!rruleIterator) return false;
+
+        const icaltimetype next = icalrecur_iterator_next(rruleIterator.get());
+        if (icaltime_is_null_time(next)) return false;
+
+        nextRun = icalToTimePoint(next);
+        return true;
+    }
+
+    Scheduler::IcalIterPtr Scheduler::createRRuleIterator(const std::string &rruleStr, const icaltimetype &dtstart) {
+        // Parse RRULE string
+        icalrecurrencetype recurrence;
+        icalrecurrencetype_clear(&recurrence); // Zero-initialize
+        recurrence = icalrecurrencetype_from_string(rruleStr.c_str());
+
+        if (recurrence.freq == ICAL_NO_RECURRENCE) {
+            return nullptr;
+        }
+
+        const auto iter = icalrecur_iterator_new(recurrence, dtstart);
+        if (!iter) return nullptr;
+
+        return IcalIterPtr(iter);
+    }
+
+    std::chrono::system_clock::time_point Scheduler::icalToTimePoint(const icaltimetype &time) {
+        const time_t timestamp = icaltime_as_timet_with_zone(time, icaltimezone_get_utc_timezone());
+        return std::chrono::system_clock::from_time_t(timestamp);
+    }
+
+    void Scheduler::parseSensorSchedule(const uint sensorId, const nlohmann::json &config) {
+        if (!config.contains(c::SensorConfigKeys::SCHEDULE) || !config[c::SensorConfigKeys::SCHEDULE].is_array()) {
+            return;
+        }
+
+        for (const auto &entry: config[c::SensorConfigKeys::SCHEDULE]) {
+            if (!entry.is_object()) {
+                continue;
+            }
+            if (entry.contains(c::SensorConfigKeys::ENABLED) &&
+                entry[c::SensorConfigKeys::ENABLED].is_boolean() &&
+                !entry[c::SensorConfigKeys::ENABLED].get<bool>()) {
+                continue;
+            }
+            if (!entry.contains(c::SensorConfigKeys::RRULE) || !entry[c::SensorConfigKeys::RRULE].is_string()) {
+                continue;
+            }
+            if (!entry.contains(c::SensorConfigKeys::ACTION) || !entry[c::SensorConfigKeys::ACTION].is_object()) {
+                continue;
+            }
+
+            icaltimetype dtstart;
+            if (entry.contains(c::SensorConfigKeys::DTSTART) && entry[c::SensorConfigKeys::DTSTART].is_string()) {
+                dtstart = icaltime_from_string(entry[c::SensorConfigKeys::DTSTART].get<std::string>().c_str());
+                if (icaltime_is_null_time(dtstart)) {
+                    dtstart = icaltime_current_time_with_zone(icaltimezone_get_utc_timezone());
+                }
+            } else {
+                dtstart = icaltime_current_time_with_zone(icaltimezone_get_utc_timezone());
+            }
+
+            const auto &rruleStr = entry[c::SensorConfigKeys::RRULE].get<std::string>();
+            auto rruleIter = createRRuleIterator(rruleStr, dtstart);
+            if (!rruleIter) {
+                mpLogger->errorf("[SCHEDULER] Failed to parse RRULE '%s' for sensor [%u]", rruleStr.c_str(), sensorId);
+                continue;
+            }
+
+            auto task = std::make_shared<ScheduledTask>();
+            task->sensorId = sensorId;
+            task->action = entry[c::SensorConfigKeys::ACTION];
+            task->rruleIterator = std::move(rruleIter);
+
+            // Advance to first future occurrence
+            if (task->advanceToNext()) {
+                const auto now = std::chrono::system_clock::now();
+                // If nextRun is in the past, advance until it's in the future or recurrence ends
+                while (task->nextRun <= now) {
+                    if (!task->advanceToNext()) break;
+                }
+
+                if (task->nextRun > now) {
+                    mpLogger->debugf("[SCHEDULER] Enqueued task for sensor [%u], next run in %lld s",
+                                     sensorId,
+                                     std::chrono::duration_cast<std::chrono::seconds>(task->nextRun - now).count());
+                    mTaskQueue.push(std::move(task));
+                }
+            }
+        }
+    }
+
+    void Scheduler::scheduleNextTimer() {
+        // Skip removed tasks
+        while (!mTaskQueue.empty() && mTaskQueue.top()->removed) {
+            mTaskQueue.pop();
+        }
+
+        if (mTaskQueue.empty()) {
+            mpLogger->debugf("[SCHEDULER] No task in queue");
+            return;
+        }
+
+        const auto &nextTask = mTaskQueue.top();
+        mTimer.expires_at(nextTask->nextRun);
+        mTimer.async_wait([this](const boost::system::error_code &ec) {
+            onTimerExpired(ec);
+        });
+    }
+
+    void Scheduler::onTimerExpired(const boost::system::error_code &ec) {
+        if (ec || !mIsRunning) return;
+
+        std::scoped_lock lock(mMutex);
+        const auto now = std::chrono::system_clock::now();
+
+        while (!mTaskQueue.empty()) {
+            // Skip and remove tasks that were flagged as removed
+            if (mTaskQueue.top()->removed) {
+                mTaskQueue.pop();
+                continue;
+            }
+
+            // Break if the earliest task is not ready yet
+            if (mTaskQueue.top()->nextRun > now) break;
+
+            auto task = mTaskQueue.top();
+            mTaskQueue.pop();
+
+            // Advance to next occurrence before dispatching current one
+            if (task->advanceToNext()) {
+                mTaskQueue.push(task);
+            }
+
+            dispatchAction(task);
+        }
+
+        // Set timer for next occurrence
+        scheduleNextTimer();
+    }
+
+    void Scheduler::dispatchAction(const TaskPtr &task) const {
+        const auto &action = task->action;
+
+        if (!action.contains(jrs::RequestKeys::METHOD) || !action[jrs::RequestKeys::METHOD].is_string()) {
+            mpLogger->errorf("[SCHEDULER] Invalid action for sensor [%u]: missing or invalid method", task->sensorId);
+            return;
+        }
+
+        if (!action.contains(jrs::RequestKeys::PARAMS) || !action[jrs::RequestKeys::PARAMS].is_object()) {
+            mpLogger->errorf("[SCHEDULER] Invalid action for sensor [%u]: missing or invalid params", task->sensorId);
+            return;
+        }
+
+        const auto &method = action[jrs::RequestKeys::METHOD].get<std::string>();
+        const auto &params = action[jrs::RequestKeys::PARAMS];
+
+        std::pair<std::string, std::string> parsedTargetMethod;
+        try {
+            parsedTargetMethod = API::parseTargetMethodString(method);
+        } catch (const std::exception &e) {
+            mpLogger->errorf("[SCHEDULER] Invalid method format in action for sensor [%u]: %s", task->sensorId,
+                             e.what());
+            return;
+        }
+
+        // Build InternalApi Command and Request
+        API::InternalApi::Command command(params,
+                                          API::ApiId(API::getNextApiId()),
+                                          API::InternalApi::Method(parsedTargetMethod.second),
+                                          API::InternalApi::Target(parsedTargetMethod.first));
+
+
+        API::InternalApi::Request request;
+        request.connectionId = 0; // No real connection
+        request.isResultStructured = true;
+        request.commands.push_back(std::move(command));
+
+        mpLogger->debugf("[SCHEDULER] Dispatching action '%s' for sensor [%u]",
+                         parsedTargetMethod.second.c_str(), task->sensorId);
+
+        Actions::handleIncomingRequest(
+            request, [this, sensorId = task->sensorId](connectionId_t, const std::string &&response) {
+                mpLogger->debugf("[SCHEDULER] Action result for sensor [%u]: %s", sensorId, response.c_str());
+
+                try {
+                    const API::ApiResponse apiResponse(response);
+                    if (apiResponse.error.has_value()) {
+                        mpLogger->errorf("[SCHEDULER] Action error for sensor [%u]: %s",
+                                         sensorId,
+                                         apiResponse.error->data.c_str());
+
+                        const auto sensorOpt = Core::Instance().configCache().getSensor(sensorId);
+                        if (sensorOpt.has_value()) {
+                            DatabaseActions::postLog(sensorOpt.value().moduleId,
+                                                     "error",
+                                                     apiResponse.error->to_string());
+                        }
+                    }
+                } catch (const std::exception &e) {
+                    mpLogger->errorf("[SCHEDULER] Failed to parse action response for sensor [%u]: %s", sensorId,
+                                     e.what());
+                }
+            });
+    }
+}

--- a/central_unit/src/core/scheduler.h
+++ b/central_unit/src/core/scheduler.h
@@ -86,6 +86,13 @@ namespace SmartHome {
          */
         [[nodiscard]] size_t taskCount() const;
 
+        /**
+         * @brief Get the next scheduled run time for any task belonging to a module.
+         *
+         * @return Time point of the next scheduled run for the module, or std::nullopt if no tasks are scheduled for it.
+         */
+        std::optional<std::chrono::system_clock::time_point> getNextRunForModule(uint moduleId) const;
+
     private:
         /**
          * @brief RAII wrapper for icalrecur_iterator lifecycle.

--- a/central_unit/src/core/scheduler.h
+++ b/central_unit/src/core/scheduler.h
@@ -1,0 +1,189 @@
+#pragma once
+#include "cache.h"
+#include "async_logger.h"
+
+#include <queue>
+
+#include <boost/asio.hpp>
+#include <ical.h>
+
+
+namespace SmartHome {
+    /**
+     * @brief Scheduled task execution engine using iCalendar RRULE recurrence.
+     *
+     * @details Maintains a priority queue of scheduled tasks parsed from sensor configurations.
+     *          A single system_timer fires for the nearest task,
+     *          dispatches the action through the existing Actions command pipeline,
+     *          advances the RRULE iterator, and re-enqueues the task.
+     *
+     * @note All public methods are thread-safe.
+     */
+    class Scheduler {
+    public:
+        /**
+         * @brief Construct scheduler bound to an io_context and config cache.
+         *
+         * @param ioContext Boost.Asio context for timer operations.
+         * @param configCache Configuration cache for sensor schedule lookup.
+         * @param logger Logger instance.
+         */
+        Scheduler(ba::io_context &ioContext,
+                  const ConfigCache &configCache,
+                  const std::shared_ptr<Utils::AsyncLogger> &logger);
+
+        ~Scheduler();
+
+        Scheduler(const Scheduler &) = delete;
+
+        Scheduler &operator=(const Scheduler &) = delete;
+
+        /**
+         * @brief Load schedule entries from all sensors in config cache.
+         *
+         * @details Clears existing tasks and rebuilds the queue from current cache state.
+         *
+         * @pre Cache must be populated with sensor configurations containing "schedule" entries.
+         */
+        void loadFromCache();
+
+        // TODO Unused for now, use after db trigger rework (adding payload with changed ids)
+        /**
+         * @brief Reload schedule entries for a specific sensor.
+         *
+         * @details Removes existing tasks for the sensor and reparses its schedule config.
+         *
+         * @note Used after LISTEN/NOTIFY config changes.
+         *
+         * @param sensorId Sensor identifier to reload.
+         */
+        void reloadSensor(uint sensorId);
+
+        /**
+         * @brief Remove all scheduled tasks for a sensor.
+         *
+         * @param sensorId Sensor identifier.
+         */
+        void removeSensor(uint sensorId);
+
+        /**
+         * @brief Start the scheduling timer chain.
+         */
+        void start();
+
+        /**
+         * @brief Stop scheduling and cancel pending timer.
+         */
+        void stop();
+
+        /**
+         * @brief Check if scheduler is currently running.
+         */
+        [[nodiscard]] bool isRunning() const;
+
+        /**
+         * @brief Number of tasks currently in the queue.
+         */
+        [[nodiscard]] size_t taskCount() const;
+
+    private:
+        /**
+         * @brief RAII wrapper for icalrecur_iterator lifecycle.
+         */
+        struct IcalIterDeleter {
+            void operator()(icalrecur_iterator *iter) const {
+                if (iter) icalrecur_iterator_free(iter);
+            }
+        };
+
+        using IcalIterPtr = std::unique_ptr<icalrecur_iterator, IcalIterDeleter>;
+
+        /**
+         * @brief Single scheduled task with RRULE iterator state.
+         */
+        struct ScheduledTask {
+            uint sensorId; ///< Owning sensor
+            nlohmann::json action; ///< Action definition from config
+            std::chrono::system_clock::time_point nextRun; ///< Next scheduled execution time
+            IcalIterPtr rruleIterator; ///< libical recurrence iterator
+            bool removed = false; ///< delete flag for preventing dispatch of removed tasks
+
+            /**
+             * @brief Advance iterator to next occurrence.
+             *
+             * @return true if next occurrence exists, false if recurrence ended.
+             */
+            bool advanceToNext();
+        };
+
+        using TaskPtr = std::shared_ptr<ScheduledTask>;
+
+        /**
+         * @brief Comparator for min-heap ordering by nextRun (earliest first).
+         */
+        struct TaskComparator {
+            bool operator()(const TaskPtr &a, const TaskPtr &b) const {
+                return a->nextRun > b->nextRun;
+            }
+        };
+
+        using TaskQueue = std::priority_queue<TaskPtr, std::vector<TaskPtr>, TaskComparator>;
+
+        /**
+         * @brief Parse RRULE string and create iterator starting from now.
+         *
+         * @param rruleStr RRULE string (e.g. "FREQ=MINUTELY;INTERVAL=5").
+         * @param dtstart Output parameter receiving the start time used.
+         *
+         * @return Iterator pointer or nullptr on parse failure.
+         */
+        static IcalIterPtr createRRuleIterator(const std::string &rruleStr,
+                                               const icaltimetype &dtstart);
+
+        /**
+         * @brief Convert icaltimetype to system_clock time_point.
+         */
+        static std::chrono::system_clock::time_point icalToTimePoint(const icaltimetype &time);
+
+        /**
+         * @brief Parse sensor config \b schedule array and enqueue tasks.
+         *
+         * @param sensorId Sensor identifier.
+         * @param config Sensor configuration JSON containing \b schedule key.
+         */
+        void parseSensorSchedule(uint sensorId, const nlohmann::json &config);
+
+        /**
+         * @brief Set timer to fire at the earliest task's nextRun.
+         *
+         * @note Must be called with mMutex held or from timer handler.
+         */
+        void scheduleNextTimer();
+
+        /**
+         * @brief Timer expiration handler.
+         *
+         * @details Dispatch ready tasks and re-arm.
+         *
+         * @param ec Error code from async_wait.
+         */
+        void onTimerExpired(const boost::system::error_code &ec);
+
+        /**
+         * @brief Dispatch a scheduled action through \c Actions pipeline.
+         *
+         * @param task Task whose action to execute.
+         */
+        void dispatchAction(const TaskPtr &task) const;
+
+        ba::io_context &mIoContext;
+        ba::system_timer mTimer;
+        const ConfigCache &mConfigCache;
+        std::shared_ptr<Utils::AsyncLogger> mpLogger;
+
+        TaskQueue mTaskQueue;
+        mutable std::mutex mMutex;
+        std::atomic_bool mIsRunning{false};
+        std::atomic_bool mIsStoping{false};
+    };
+};

--- a/central_unit/src/db-service/CMakeLists.txt
+++ b/central_unit/src/db-service/CMakeLists.txt
@@ -9,9 +9,9 @@ include(FetchContent)
 
 FetchContent_Declare(
         libpqxx
-        GIT_REPOSITORY  https://github.com/jtv/libpqxx.git
-        GIT_TAG         7.10.5
-        GIT_SHALLOW     ON
+        GIT_REPOSITORY https://github.com/jtv/libpqxx.git
+        GIT_TAG 7.10.5
+        GIT_SHALLOW ON
 )
 
 # Build libpqxx static
@@ -40,6 +40,7 @@ target_link_libraries(smarthome-database PRIVATE
         smarthome::api
         smarthome::utility
         smarthome::logger
+        smarthome::constants
         Boost::program_options
         Boost::system
         pqxx

--- a/central_unit/src/db-service/database_api.cpp
+++ b/central_unit/src/db-service/database_api.cpp
@@ -1,10 +1,13 @@
 #include "database_api.h"
+#include "database_service.h"
+#include "constants.h"
 
 #include <set>
 
-#include "database_service.h"
 
 namespace SmartHomeDB {
+    namespace sc = SmartHome::Constants;
+
     void DatabaseApi::initialize(const std::function<void(const std::string &message)> &callback) {
         mCallback = callback;
     }
@@ -118,27 +121,27 @@ namespace SmartHomeDB {
 
         const auto methodLower = toLower(methodStr);
 
-        if (!params.contains(ak::TABLE_STR) || !params[ak::TABLE_STR].is_string()) {
+        if (!params.contains(sjp::TABLE) || !params[sjp::TABLE].is_string()) {
             throw std::runtime_error("Missing or invalid 'table' field");
         }
 
-        const std::string table = params[ak::TABLE_STR];
+        const std::string table = params[sjp::TABLE];
 
-        if (methodLower == ak::GET_STR) {
+        if (methodLower == sc::Methods::GET) {
             return buildSelectQuery(table, params);
         }
-        if (methodLower == ak::SET_STR) {
-            if (!params.contains(sk::WHERE_STR) && !params.contains(ak::VALUES_STR)) {
+        if (methodLower == sc::Methods::SET) {
+            if (!params.contains(sk::WHERE) && !params.contains(sjp::VALUES)) {
                 throw std::runtime_error("SET requires either 'where' (for UPDATE) or full 'values' (for INSERT)");
             }
 
-            if (params.contains(sk::WHERE_STR)) {
+            if (params.contains(sk::WHERE)) {
                 return buildUpdateQuery(table, params);
             }
 
             return buildInsertQuery(table, params);
         }
-        if (methodLower == ak::DELETE_STR) {
+        if (methodLower == sc::Methods::DELETE) {
             return buildDeleteQuery(table, params);
         }
 
@@ -358,42 +361,42 @@ namespace SmartHomeDB {
     DatabaseClient::DbQuery DatabaseApi::buildSelectQuery(const std::string &table, const nlohmann::json &params) {
         DatabaseClient::DbQuery query;
 
-        query.sql = toUpper(sk::SELECT_STR) + " ";
+        query.sql = toUpper(sk::SELECT) + " ";
 
-        if (params.contains(ak::AGGREGATES_STR) && params.contains(ak::COLUMNS_STR)) {
+        if (params.contains(sjp::AGGREGATES) && params.contains(sjp::COLUMNS)) {
             throw std::runtime_error("Cannot use both 'aggregates' and 'columns'");
         }
 
-        if (params.contains(ak::AGGREGATES_STR)) {
-            query.sql += buildAggregates(params[ak::AGGREGATES_STR]);
-        } else if (params.contains(ak::COLUMNS_STR)) {
-            query.sql += buildColumns(params[ak::COLUMNS_STR]);
+        if (params.contains(sjp::AGGREGATES)) {
+            query.sql += buildAggregates(params[sjp::AGGREGATES]);
+        } else if (params.contains(sjp::COLUMNS)) {
+            query.sql += buildColumns(params[sjp::COLUMNS]);
         } else {
-            query.sql += sk::WILDCARD_STR;
+            query.sql += sk::WILDCARD;
         }
 
-        query.sql += " " + toUpper(sk::FROM_STR) + " " + sqlIdentifier(table);
+        query.sql += " " + toUpper(sk::FROM) + " " + sqlIdentifier(table);
 
-        if (params.contains(ak::WHERE_STR)) {
+        if (params.contains(sjp::WHERE)) {
             int paramIndex = 1;
-            query.sql += " " + toUpper(sk::WHERE_STR);
-            query.sql += " " + buildWhereClause(params[ak::WHERE_STR], query.params, paramIndex);
+            query.sql += " " + toUpper(sk::WHERE);
+            query.sql += " " + buildWhereClause(params[sjp::WHERE], query.params, paramIndex);
         }
 
-        if (params.contains(ak::ORDER_BY_STR)) {
-            query.sql += " " + toUpper(sk::ORDER_BY_STR) + " " + buildOrderBy(params[ak::ORDER_BY_STR]);
+        if (params.contains(sjp::ORDER_BY)) {
+            query.sql += " " + toUpper(sk::ORDER_BY) + " " + buildOrderBy(params[sjp::ORDER_BY]);
         }
 
-        if (params.contains(ak::LIMIT_STR)) {
-            if (!params[ak::LIMIT_STR].is_number_integer()) {
+        if (params.contains(sjp::LIMIT)) {
+            if (!params[sjp::LIMIT].is_number_integer()) {
                 throw std::runtime_error("'limit' must be an integer");
             }
 
-            const int limit = params[ak::LIMIT_STR];
+            const int limit = params[sjp::LIMIT];
             if (limit < 0) {
                 throw std::runtime_error("'limit' must be non-negative");
             }
-            query.sql += " " + toUpper(sk::LIMIT_STR) + " " + std::to_string(limit);
+            query.sql += " " + toUpper(sk::LIMIT) + " " + std::to_string(limit);
         }
 
         const auto pLogger = DatabaseService::Instance().pLogger;
@@ -402,18 +405,18 @@ namespace SmartHomeDB {
     }
 
     DatabaseClient::DbQuery DatabaseApi::buildInsertQuery(const std::string &table, const nlohmann::json &params) {
-        if (!params.contains(ak::VALUES_STR) || !params[ak::VALUES_STR].is_object()) {
+        if (!params.contains(sjp::VALUES) || !params[sjp::VALUES].is_object()) {
             throw std::runtime_error("INSERT requires 'values' object");
         }
 
-        if (params[ak::VALUES_STR].empty()) {
+        if (params[sjp::VALUES].empty()) {
             throw std::runtime_error("'values' cannot be empty");
         }
 
         DatabaseClient::DbQuery query;
         int paramIndex = 1;
 
-        const auto &values = params[ak::VALUES_STR];
+        const auto &values = params[sjp::VALUES];
 
         std::vector<std::string> columns;
         std::vector<std::string> placeholders;
@@ -423,14 +426,14 @@ namespace SmartHomeDB {
             placeholders.push_back(addParam(value, query.params, paramIndex));
         }
 
-        query.sql = toUpper(sk::INSERT_INTO_STR) + " " + sqlIdentifier(table) + " (";
+        query.sql = toUpper(sk::INSERT_INTO) + " " + sqlIdentifier(table) + " (";
         query.sql += joinStrings(columns, ", ");
-        query.sql += ") " + toUpper(sk::VALUES_STR) + " (";
+        query.sql += ") " + toUpper(sk::VALUES) + " (";
         query.sql += joinStrings(placeholders, ", ");
         query.sql += ")";
 
-        if (params.contains(ak::RETURNING_STR)) {
-            query.sql += buildReturning(params[ak::RETURNING_STR]);
+        if (params.contains(sjp::RETURNING)) {
+            query.sql += buildReturning(params[sjp::RETURNING]);
         }
 
         const auto pLogger = DatabaseService::Instance().pLogger;
@@ -439,36 +442,36 @@ namespace SmartHomeDB {
     }
 
     DatabaseClient::DbQuery DatabaseApi::buildUpdateQuery(const std::string &table, const nlohmann::json &params) {
-        if (!params.contains(ak::VALUES_STR) || !params[ak::VALUES_STR].is_object()) {
+        if (!params.contains(sjp::VALUES) || !params[sjp::VALUES].is_object()) {
             throw std::runtime_error("UPDATE requires 'values' object");
         }
 
-        if (params[ak::VALUES_STR].empty()) {
+        if (params[sjp::VALUES].empty()) {
             throw std::runtime_error("'values' cannot be empty");
         }
 
-        if (!params.contains(ak::WHERE_STR)) {
+        if (!params.contains(sjp::WHERE)) {
             throw std::runtime_error("UPDATE requires 'where' object");
         }
 
         DatabaseClient::DbQuery query;
         int paramIndex = 1;
 
-        const auto &values = params[ak::VALUES_STR];
+        const auto &values = params[sjp::VALUES];
 
         std::vector<std::string> setParts;
         for (const auto &[key, value]: values.items()) {
             std::string placeholder = addParam(value, query.params, paramIndex);
-            setParts.push_back(sqlIdentifier(key) + " " + sk::EQUAL_STR.data() + " " + placeholder);
+            setParts.push_back(sqlIdentifier(key) + " " + sk::EQUAL.data() + " " + placeholder);
         }
 
-        query.sql = toUpper(sk::UPDATE_STR) + " " + sqlIdentifier(table) + " " + toUpper(sk::SET_STR) + " ";
+        query.sql = toUpper(sk::UPDATE) + " " + sqlIdentifier(table) + " " + toUpper(sk::SET) + " ";
         query.sql += joinStrings(setParts, ", ");
-        query.sql += " " + toUpper(sk::WHERE_STR);
-        query.sql += " " + buildWhereClause(params[ak::WHERE_STR], query.params, paramIndex);
+        query.sql += " " + toUpper(sk::WHERE);
+        query.sql += " " + buildWhereClause(params[sjp::WHERE], query.params, paramIndex);
 
-        if (params.contains(ak::RETURNING_STR)) {
-            query.sql += " " + buildReturning(params[ak::RETURNING_STR]);
+        if (params.contains(sjp::RETURNING)) {
+            query.sql += " " + buildReturning(params[sjp::RETURNING]);
         }
 
         const auto pLogger = DatabaseService::Instance().pLogger;
@@ -477,19 +480,19 @@ namespace SmartHomeDB {
     }
 
     DatabaseClient::DbQuery DatabaseApi::buildDeleteQuery(const std::string &table, const nlohmann::json &params) {
-        if (!params.contains(ak::WHERE_STR)) {
+        if (!params.contains(sjp::WHERE)) {
             throw std::runtime_error("DELETE requires 'where' object");
         }
 
         DatabaseClient::DbQuery query;
         int paramIndex = 1;
 
-        query.sql = toUpper(sk::DELETE_STR) + " " + toUpper(sk::FROM_STR) + " " + sqlIdentifier(table);
-        query.sql += " " + toUpper(sk::WHERE_STR);
-        query.sql += " " + buildWhereClause(params[ak::WHERE_STR], query.params, paramIndex);
+        query.sql = toUpper(sk::DELETE) + " " + toUpper(sk::FROM) + " " + sqlIdentifier(table);
+        query.sql += " " + toUpper(sk::WHERE);
+        query.sql += " " + buildWhereClause(params[sjp::WHERE], query.params, paramIndex);
 
-        if (params.contains(ak::RETURNING_STR)) {
-            query.sql += " " + buildReturning(params[ak::RETURNING_STR]);
+        if (params.contains(sjp::RETURNING)) {
+            query.sql += " " + buildReturning(params[sjp::RETURNING]);
         }
 
         const auto pLogger = DatabaseService::Instance().pLogger;
@@ -502,36 +505,36 @@ namespace SmartHomeDB {
             throw std::runtime_error("'$subselect' must be an object");
         }
 
-        if (!subSelect.contains(ak::TABLE_STR) || !subSelect[ak::TABLE_STR].is_string()) {
+        if (!subSelect.contains(sjp::TABLE) || !subSelect[sjp::TABLE].is_string()) {
             throw std::runtime_error("Subselect requires 'table' field");
         }
 
-        std::string sql = "(" + toUpper(sk::SELECT_STR) + " ";
+        std::string sql = "(" + toUpper(sk::SELECT) + " ";
 
-        if (subSelect.contains(ak::COLUMNS_STR)) {
-            sql += buildColumns(subSelect[ak::COLUMNS_STR]);
+        if (subSelect.contains(sjp::COLUMNS)) {
+            sql += buildColumns(subSelect[sjp::COLUMNS]);
         } else {
-            sql += sk::WILDCARD_STR;
+            sql += sk::WILDCARD;
         }
 
-        sql += " " + toUpper(sk::FROM_STR) + " " + sqlIdentifier(subSelect[ak::TABLE_STR]);
+        sql += " " + toUpper(sk::FROM) + " " + sqlIdentifier(subSelect[sjp::TABLE]);
 
-        if (subSelect.contains(ak::WHERE_STR)) {
-            sql += " " + toUpper(sk::WHERE_STR) + " " + buildWhereClause(subSelect[ak::WHERE_STR], params, paramIndex);
+        if (subSelect.contains(sjp::WHERE)) {
+            sql += " " + toUpper(sk::WHERE) + " " + buildWhereClause(subSelect[sjp::WHERE], params, paramIndex);
         }
 
-        if (subSelect.contains(ak::ORDER_BY_STR)) {
-            sql += " " + toUpper(sk::ORDER_BY_STR) + " " + buildOrderBy(subSelect[ak::ORDER_BY_STR]);
+        if (subSelect.contains(sjp::ORDER_BY)) {
+            sql += " " + toUpper(sk::ORDER_BY) + " " + buildOrderBy(subSelect[sjp::ORDER_BY]);
         }
 
-        if (subSelect.contains(ak::LIMIT_STR)) {
-            if (!subSelect[ak::LIMIT_STR].is_number_integer()) {
+        if (subSelect.contains(sjp::LIMIT)) {
+            if (!subSelect[sjp::LIMIT].is_number_integer()) {
                 throw std::runtime_error("Subselect 'limit' field must be an integer");
             }
-            sql += " " + toUpper(sk::LIMIT_STR) + " " + std::to_string(subSelect[ak::LIMIT_STR].get<int>());
+            sql += " " + toUpper(sk::LIMIT) + " " + std::to_string(subSelect[sjp::LIMIT].get<int>());
         } else {
             // By default, set limit on subselect to 1
-            sql += " " + toUpper(sk::LIMIT_STR) + " 1";
+            sql += " " + toUpper(sk::LIMIT) + " 1";
         }
 
         sql += ")";
@@ -550,7 +553,7 @@ namespace SmartHomeDB {
             std::string column = sqlIdentifier(key);
 
             if (value.is_null()) {
-                auto isNullStr = joinStrings({sk::IS_STR.data(), sk::NULL_STR.data()}, " ");
+                auto isNullStr = joinStrings({sk::IS.data(), sk::NULL_STR.data()}, " ");
                 conditions.push_back(column + " " + toUpper(isNullStr));
             } else if (value.is_object()) {
                 for (const auto &[op, val]: value.items()) {
@@ -559,9 +562,9 @@ namespace SmartHomeDB {
                     }
 
                     if (val.is_null()) {
-                        if (op == sk::NOT_EQUAL_STR) {
+                        if (op == sk::NOT_EQUAL) {
                             auto isNotNullStr = joinStrings(
-                                {sk::IS_STR.data(), sk::NOT_STR.data(), sk::NULL_STR.data()}, " ");
+                                {sk::IS.data(), sk::NOT.data(), sk::NULL_STR.data()}, " ");
                             conditions.push_back(column + " " + toUpper(isNotNullStr));
                         } else {
                             throw std::runtime_error("Only '!=' operator allowed with NULL");
@@ -580,7 +583,7 @@ namespace SmartHomeDB {
                 const std::string placeholder = addParam(value, params, paramIndex);
                 std::string condition = column;
                 condition += " ";
-                condition += sk::EQUAL_STR.data();
+                condition += sk::EQUAL.data();
                 condition += " ";
                 condition += placeholder;
                 conditions.push_back(std::move(condition));
@@ -588,7 +591,7 @@ namespace SmartHomeDB {
         }
 
         // TODO consider rework to implement OR operator
-        return joinStrings(conditions, " "s + sk::AND_STR.data() + " ");
+        return joinStrings(conditions, " "s + sk::AND.data() + " ");
     }
 
     std::string DatabaseApi::buildColumns(const nlohmann::json &columns) {
@@ -626,8 +629,8 @@ namespace SmartHomeDB {
 
             auto colStr = column.get<std::string>();
 
-            if (colStr == sk::WILDCARD_STR) {
-                if (func != sk::COUNT_STR) {
+            if (colStr == sk::WILDCARD) {
+                if (func != sk::COUNT) {
                     throw std::runtime_error("Only COUNT function can use '*'");
                 }
                 parts.push_back(toUpper(func) + "(*)");
@@ -652,19 +655,19 @@ namespace SmartHomeDB {
                 throw std::runtime_error("'order_by' items must be objects");
             }
 
-            if (!item.contains(ak::COLUMN_STR) || !item[ak::COLUMN_STR].is_string()) {
+            if (!item.contains(sjp::COLUMN) || !item[sjp::COLUMN].is_string()) {
                 throw std::runtime_error("'order_by' items must have 'column' field");
             }
 
-            const std::string column = sqlIdentifier(item[ak::COLUMN_STR].get<std::string>());
-            std::string order = toUpper(sk::ASC_STR); // default ascending
+            const std::string column = sqlIdentifier(item[sjp::COLUMN].get<std::string>());
+            std::string order = toUpper(sk::ASC); // default ascending
 
-            if (item.contains(ak::ORDER_STR)) {
-                if (!item[ak::ORDER_STR].is_string()) {
+            if (item.contains(sjp::ORDER)) {
+                if (!item[sjp::ORDER].is_string()) {
                     throw std::runtime_error("'order' must be a string");
                 }
-                order = toUpper(item[ak::ORDER_STR].get<std::string>());
-                if (order != toUpper(sk::ASC_STR) && order != toUpper(sk::DESC_STR)) {
+                order = toUpper(item[sjp::ORDER].get<std::string>());
+                if (order != toUpper(sk::ASC) && order != toUpper(sk::DESC)) {
                     throw std::runtime_error("'order' must be 'DESC' or 'ASC'");
                 }
             }
@@ -679,10 +682,10 @@ namespace SmartHomeDB {
     }
 
     std::string DatabaseApi::buildReturning(const nlohmann::json &returning) {
-        std::string result = " " + toUpper(sk::RETURNING_STR) + " ";
+        std::string result = " " + toUpper(sk::RETURNING) + " ";
 
-        if (returning.is_string() && returning == sk::WILDCARD_STR) {
-            result += sk::WILDCARD_STR;
+        if (returning.is_string() && returning == sk::WILDCARD) {
+            result += sk::WILDCARD;
         } else if (returning.is_array()) {
             result += buildColumns(returning);
         } else {
@@ -694,8 +697,8 @@ namespace SmartHomeDB {
 
     std::string DatabaseApi::addParam(const nlohmann::json &value, pqxx::params &params, int &paramIndex) {
         // Handle special case - subselect
-        if (value.is_object() && value.contains(ak::SUBSELECT_STR)) {
-            return buildSubSelect(value[ak::SUBSELECT_STR], params, paramIndex);
+        if (value.is_object() && value.contains(sjp::SUBSELECT)) {
+            return buildSubSelect(value[sjp::SUBSELECT], params, paramIndex);
         }
 
         std::string placeholder = "$" + std::to_string(paramIndex++);

--- a/central_unit/src/db-service/database_api.cpp
+++ b/central_unit/src/db-service/database_api.cpp
@@ -331,6 +331,30 @@ namespace SmartHomeDB {
         mCallback(message);
     }
 
+    void DatabaseApi::handleIncomingDbTrigger(std::string &&triggerName, std::string &&triggerData) {
+        const auto pLogger = DatabaseService::Instance().pLogger;
+        pLogger->debugf("[DB_API] [HANDLE_DB_TRIGGER] Message: %s", triggerName.c_str());
+
+        sa::ApiRequest notification;
+        notification.method = "core.notify";
+
+        auto &params = notification.params.emplace(nlohmann::json::object());
+        params[sj::ParamsKeys::TYPE] = triggerName;
+
+        // Try to parse trigger data as JSON
+        if (nlohmann::json::accept(triggerData)) {
+            try {
+                params[sj::ParamsKeys::DATA] = nlohmann::json::parse(triggerData);
+            } catch (const std::exception &e) {
+                pLogger->errorf("[DB_API] Failed to parse trigger data JSON: %s", e.what());
+            }
+        }
+        // Fallback to raw string data
+        if (!params.contains(sj::ParamsKeys::DATA)) params[sj::ParamsKeys::DATA] = triggerData;
+
+        handleOutgoing(0, notification.to_string());
+    }
+
     DatabaseClient::DbQuery DatabaseApi::buildSelectQuery(const std::string &table, const nlohmann::json &params) {
         DatabaseClient::DbQuery query;
 

--- a/central_unit/src/db-service/database_api.h
+++ b/central_unit/src/db-service/database_api.h
@@ -213,7 +213,7 @@ namespace SmartHomeDB {
          *        }
          *      }
          *      \endcode
-         *      
+         *
          * @param triggerName Name of the database trigger event.
          * @param triggerData Associated data payload (e.g. JSON string with details).
          */

--- a/central_unit/src/db-service/database_api.h
+++ b/central_unit/src/db-service/database_api.h
@@ -188,14 +188,36 @@ namespace SmartHomeDB {
         void handleIncoming(SmartHome::connectionId_t connectionId, std::string &&message) override;
 
         /**
-        * @brief Handle outgoing API message.
-        *
-        * @details Forwards serialized message to previously configured callback.
-        *
-        * @param connectionId Destination connection identifier (unused in client).
-        * @param message Message payload to send.
-        */
+         * @brief Handle outgoing API message.
+         *
+         * @details Forwards serialized message to previously configured callback.
+         *
+         * @param connectionId Destination connection identifier (unused in client).
+         * @param message Message payload to send.
+         */
         void handleOutgoing(SmartHome::connectionId_t connectionId, std::string &&message) override;
+
+        /**
+         * @brief Handle incoming database trigger notification.
+         *
+         * @details Converts trigger information into API notification and sends it out.
+         *
+         * @note Notification format example:
+         *      \code{.json}
+         *      {
+         *        "jsonrpc": "2.0",
+         *        "method": "core.notify",
+         *        "params": {
+         *          "type": <triggerName>,
+         *          "data": <triggerData>
+         *        }
+         *      }
+         *      \endcode
+         *      
+         * @param triggerName Name of the database trigger event.
+         * @param triggerData Associated data payload (e.g. JSON string with details).
+         */
+        void handleIncomingDbTrigger(std::string &&triggerName, std::string &&triggerData);
 
     private:
         /**

--- a/central_unit/src/db-service/database_api.h
+++ b/central_unit/src/db-service/database_api.h
@@ -13,75 +13,58 @@ namespace SmartHomeDB {
 
     namespace SqlKeywords {
         // Keys
-        inline constexpr std::string_view SELECT_STR = "select";
-        inline constexpr std::string_view INSERT_INTO_STR = "insert into";
-        inline constexpr std::string_view UPDATE_STR = "update";
-        inline constexpr std::string_view DELETE_STR = "delete";
-        inline constexpr std::string_view FROM_STR = "from";
-        inline constexpr std::string_view WHERE_STR = "where";
-        inline constexpr std::string_view ORDER_BY_STR = "order by";
-        inline constexpr std::string_view LIMIT_STR = "limit";
-        inline constexpr std::string_view RETURNING_STR = "returning";
-        inline constexpr std::string_view VALUES_STR = "values";
-        inline constexpr std::string_view SET_STR = "set";
+        inline constexpr std::string_view SELECT = "select";
+        inline constexpr std::string_view INSERT_INTO = "insert into";
+        inline constexpr std::string_view UPDATE = "update";
+        inline constexpr std::string_view DELETE = "delete";
+        inline constexpr std::string_view FROM = "from";
+        inline constexpr std::string_view WHERE = "where";
+        inline constexpr std::string_view ORDER_BY = "order by";
+        inline constexpr std::string_view LIMIT = "limit";
+        inline constexpr std::string_view RETURNING = "returning";
+        inline constexpr std::string_view VALUES = "values";
+        inline constexpr std::string_view SET = "set";
 
         // Values
-        inline constexpr std::string_view ASC_STR = "asc";
-        inline constexpr std::string_view DESC_STR = "desc";
-        inline constexpr std::string_view IS_STR = "is";
-        inline constexpr std::string_view NOT_STR = "not";
+        inline constexpr std::string_view ASC = "asc";
+        inline constexpr std::string_view DESC = "desc";
+        inline constexpr std::string_view IS = "is";
+        inline constexpr std::string_view NOT = "not";
+        /// \c NULL is a macro in C/C++, \c NULL_STR is used to avoid conflicts
         inline constexpr std::string_view NULL_STR = "null";
-        inline constexpr std::string_view TRUE_STR = "true";
-        inline constexpr std::string_view FALSE_STR = "false";
-        inline constexpr std::string_view WILDCARD_STR = "*";
+        inline constexpr std::string_view TRUE = "true";
+        inline constexpr std::string_view FALSE = "false";
+        inline constexpr std::string_view WILDCARD = "*";
 
         //Aggregates
-        inline constexpr std::string_view COUNT_STR = "count";
-        inline constexpr std::string_view AVG_STR = "avg";
-        inline constexpr std::string_view MAX_STR = "max";
-        inline constexpr std::string_view MIN_STR = "min";
+        inline constexpr std::string_view COUNT = "count";
+        inline constexpr std::string_view AVG = "avg";
+        inline constexpr std::string_view MAX = "max";
+        inline constexpr std::string_view MIN = "min";
 
         inline const std::set AGGREGATES = {
-            COUNT_STR, AVG_STR, MAX_STR, MIN_STR
+            COUNT, AVG, MAX, MIN
         };
 
         // Operators
-        inline constexpr std::string_view EQUAL_STR = "=";
-        inline constexpr std::string_view NOT_EQUAL_STR = "!=";
-        inline constexpr std::string_view GREATER_STR = ">";
-        inline constexpr std::string_view LESS_STR = "<";
-        inline constexpr std::string_view GREATER_OR_EQUAL_STR = ">=";
-        inline constexpr std::string_view LESS_OR_EQUAL_STR = "<=";
-        inline constexpr std::string_view LIKE_STR = "like";
+        inline constexpr std::string_view EQUAL = "=";
+        inline constexpr std::string_view NOT_EQUAL = "!=";
+        inline constexpr std::string_view GREATER = ">";
+        inline constexpr std::string_view LESS = "<";
+        inline constexpr std::string_view GREATER_OR_EQUAL = ">=";
+        inline constexpr std::string_view LESS_OR_EQUAL = "<=";
+        inline constexpr std::string_view LIKE = "like";
 
         inline const std::set OPERATORS = {
-            EQUAL_STR, NOT_EQUAL_STR, GREATER_STR, LESS_STR, GREATER_OR_EQUAL_STR, LESS_OR_EQUAL_STR, LIKE_STR
+            EQUAL, NOT_EQUAL, GREATER, LESS, GREATER_OR_EQUAL, LESS_OR_EQUAL, LIKE
         };
 
         // Reserved operators
-        inline constexpr std::string_view AND_STR = "and";
-        inline constexpr std::string_view OR_STR = "or";
+        inline constexpr std::string_view AND = "and";
+        inline constexpr std::string_view OR = "or";
     }
 
-    namespace ApiKeywords {
-        inline constexpr std::string_view SET_STR = "set";
-        inline constexpr std::string_view GET_STR = "get";
-        inline constexpr std::string_view DELETE_STR = "delete";
-        inline constexpr std::string_view SUBSELECT_STR = "$subselect";
-
-        inline constexpr std::string_view TABLE_STR = "table";
-        inline constexpr std::string_view COLUMNS_STR = "columns";
-        inline constexpr std::string_view COLUMN_STR = "column";
-        inline constexpr std::string_view AGGREGATES_STR = "aggregates";
-        inline constexpr std::string_view WHERE_STR = "where";
-        inline constexpr std::string_view ORDER_BY_STR = "order_by";
-        inline constexpr std::string_view ORDER_STR = "order";
-        inline constexpr std::string_view LIMIT_STR = "limit";
-        inline constexpr std::string_view VALUES_STR = "values";
-        inline constexpr std::string_view RETURNING_STR = "returning";
-    }
-
-    namespace ak = ApiKeywords;
+    namespace sjp = SmartHome::JsonRpcStrings::ParamsKeys;
     namespace sk = SqlKeywords;
 
     /**
@@ -368,8 +351,6 @@ namespace SmartHomeDB {
          * @return Lowercased string.
          */
         static std::string toLower(std::string_view str);
-
-        static constexpr std::string_view msTARGET_STR = "database";
 
 
         std::shared_ptr<DatabaseClient> mpDatabaseClient; ///< Database client used to execute queries

--- a/central_unit/src/db-service/database_client.cpp
+++ b/central_unit/src/db-service/database_client.cpp
@@ -4,6 +4,38 @@
 
 
 namespace SmartHomeDB {
+    DatabaseClient::~DatabaseClient() {
+        if (mIsRunning.load(std::memory_order::acquire)) {
+            stop();
+        }
+    }
+
+    void DatabaseClient::initialize(
+        const std::vector<std::string> &triggersToListen,
+        const std::function<void(const std::string &triggerName, const std::string &triggerData)> &callback) {
+        mCallback = callback;
+
+        mpTriggerTimer = std::make_unique<ba::steady_timer>(mIoContext);
+
+        auto *conn = mpDbConnManager->getTriggerListenerConnection();
+
+        // Listen to specified triggers
+        for (const auto &triggerName: triggersToListen) {
+            DatabaseService::Instance().pLogger->infof(
+                "[DB_CLIENT] Listening to database trigger: %s", triggerName.c_str());
+
+            conn->listen(triggerName, [this](const pqxx::notification &n) {
+                DatabaseService::Instance().pLogger->debug("[DB_CLIENT] Received database trigger notification");
+                if (mCallback) {
+                    mCallback(std::string{n.channel}, std::string{n.payload});
+                }
+            });
+        }
+
+        mIsRunning = true;
+        startPeriodicTriggerCheck();
+    }
+
     void DatabaseClient::handleQuery(const DbQuery &query,
                                      const std::function<void(DbQueryResult &&result)> &callback) const {
         auto isCancelled = std::make_shared<std::atomic_bool>(false);
@@ -115,6 +147,23 @@ namespace SmartHomeDB {
                 }
 
                 callback(std::move(queryResult));
+            }
+        });
+    }
+
+    void DatabaseClient::stop() {
+        mIsRunning = false;
+        if (mpTriggerTimer) {
+            mpTriggerTimer->cancel();
+        }
+    }
+
+    void DatabaseClient::startPeriodicTriggerCheck() {
+        mpTriggerTimer->expires_after(1s);
+        mpTriggerTimer->async_wait([this](const std::error_code &ec) {
+            if (!ec && mIsRunning.load(std::memory_order_acquire)) {
+                mpDbConnManager->getTriggerListenerConnection()->get_notifs();
+                startPeriodicTriggerCheck();
             }
         });
     }

--- a/central_unit/src/db-service/database_client.h
+++ b/central_unit/src/db-service/database_client.h
@@ -70,6 +70,26 @@ namespace SmartHomeDB {
               mpDbConnManager(pDbConnManager) {
         }
 
+
+        /**
+         * @brief Destructor for DatabaseClient, calls stop() to ensure proper cleanup of resources and timers.
+         */
+        ~DatabaseClient();
+
+        /**
+         * @brief Initialize the DatabaseClient.
+         *
+         * @details Sets up the client to listen for specified database triggers and
+         *          starts a periodic timer to check for trigger events.
+         *
+         * @param triggersToListen List of database trigger names to listen for.
+         *                         The client will periodically check for new trigger events matching these names.
+         * @param callback Callback function to invoke when a trigger event is detected.
+         */
+        void initialize(
+            const std::vector<std::string> &triggersToListen,
+            const std::function<void(const std::string &triggerName, const std::string &triggerData)> &callback);
+
         /**
         * @brief Execute a single database query asynchronously.
         *
@@ -96,10 +116,27 @@ namespace SmartHomeDB {
         void handleBatchQuery(const std::vector<DbQuery> &queries,
                               const std::function<void(DbBatchQueryResult &&batchResult)> &callback) const;
 
+
+        /**
+         *  @brief Stop the DatabaseClient, canceling active timers and preventing further trigger checks.
+         */
+        void stop();
+
     private:
+        /**
+         *  @brief Start a periodic timer to check for database trigger events.
+         */
+        void startPeriodicTriggerCheck();
+
         static constexpr auto msTRANSACTION_TIMEOUT = 5s;
 
         ba::io_context &mIoContext;
         std::shared_ptr<DatabaseConnectionManager> mpDbConnManager; ///< Connection manager for acquiring DB connections
+
+        std::unique_ptr<ba::steady_timer> mpTriggerTimer;
+        /// Received DB trigger callback to forward messages to API
+        std::function<void(const std::string &triggerName, const std::string &triggerData)> mCallback;
+
+        std::atomic_bool mIsRunning{false};
     };
 }

--- a/central_unit/src/db-service/database_connection_manager.cpp
+++ b/central_unit/src/db-service/database_connection_manager.cpp
@@ -35,6 +35,7 @@ namespace SmartHomeDB {
 
         mpLogger->debugf("[DB_CONN_MANAGER] [CONSTRUCTOR] Attempting to connect with: %s", config.dbHost.c_str());
 
+        // Initialize connection pool
         for (auto i = 0; i < config.dbConnections; ++i) {
             try {
                 mConnections.push(std::make_unique<pqxx::connection>(mConnectionStr));
@@ -46,6 +47,16 @@ namespace SmartHomeDB {
         if (mConnections.empty()) {
             throw std::runtime_error("No connections available");
         }
+
+        // Initialize separate connection for trigger listener
+        try {
+            mpTriggerListenerConnection = std::make_unique<pqxx::connection>(mConnectionStr);
+        } catch (const std::exception &e) {
+            mpLogger->errorf("[DB_CONN_MANAGER] [CONSTRUCTOR] Failed to initialize trigger listener connection: %s",
+                             e.what());
+            throw std::runtime_error("Failed to initialize trigger listener connection");
+        }
+
         mpLogger->infof("[DB_CONN_MANAGER] [CONSTRUCTOR] Successfully initialized %d of %d connections",
                         mConnections.size(), config.dbConnections);
     }
@@ -60,6 +71,10 @@ namespace SmartHomeDB {
         mConnections.pop();
 
         return {*this, std::move(connection)};
+    }
+
+    pqxx::connection *DatabaseConnectionManager::getTriggerListenerConnection() const {
+        return mpTriggerListenerConnection.get();
     }
 
     void DatabaseConnectionManager::returnConnection(std::unique_ptr<pqxx::connection> connection) {

--- a/central_unit/src/db-service/database_connection_manager.h
+++ b/central_unit/src/db-service/database_connection_manager.h
@@ -14,6 +14,7 @@ namespace SmartHomeDB {
      * @brief Manager of a pool of PostgreSQL connections.
      *
      * @details Initializes a pool of `pqxx::connection` objects using the provided configuration.
+     *          Initializes a dedicated connection for listening to database triggers.
      *          Provides RAII-style acquisition via `DatabaseConnection`
      *          and returns connections to the pool when they are released.
      */
@@ -49,6 +50,7 @@ namespace SmartHomeDB {
          * @details Builds the connection string from \p config and attempts to create up
          *          to \c config.dbConnections connections which are stored in an internal
          *          queue for later acquisition.
+         *          A separate connection is initialized for trigger listening and is not part of the pool.
          *
          * @param pLogger Shared logger used by the manager for diagnostics and errors.
          * @param config Configuration describing connection parameters and pool size.
@@ -67,6 +69,13 @@ namespace SmartHomeDB {
          * @return A \c DatabaseConnection owning the acquired \c pqxx::connection.
          */
         DatabaseConnection acquireConnection();
+
+        /**
+         * @brief Get the dedicated trigger listener connection.
+         *
+         * @return  A pointer to the dedicated trigger listener connection.
+         */
+        pqxx::connection *getTriggerListenerConnection() const;
 
     private:
         friend class DatabaseConnection;
@@ -87,5 +96,8 @@ namespace SmartHomeDB {
         std::queue<std::unique_ptr<pqxx::connection> > mConnections; ///< Pool of available connections
         std::mutex mConnectionsMutex; ///< Protects \c mConnections
         std::condition_variable mConnectionsCond; ///< Signals availability of connections
+
+        /// Connection used for trigger listening
+        std::unique_ptr<pqxx::connection> mpTriggerListenerConnection;
     };
 }

--- a/central_unit/src/db-service/database_connection_manager.h
+++ b/central_unit/src/db-service/database_connection_manager.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "logger.h"
+#include "constants.h"
 
 #include <condition_variable>
 #include <memory>
@@ -38,7 +39,7 @@ namespace SmartHomeDB {
             std::string dbPassword; // No default password
 
             // Additional connection options
-            std::string serviceName = "smarthome-database";
+            std::string serviceName = SmartHome::Constants::DefaultServiceNames::DATABASE.data();
             uint connectionTimeoutSeconds = 10;
             bool isKeepAliveEnabled = true;
             uint keepAliveSeconds = 30;

--- a/central_unit/src/db-service/database_service.cpp
+++ b/central_unit/src/db-service/database_service.cpp
@@ -124,6 +124,12 @@ namespace SmartHomeDB {
             mpDatabaseApi->initialize([this](const std::string &message) {
                 mpSocketClient->handleOutgoing(nullConnection, message.data());
             });
+
+            auto triggerCallback = [this](const std::string &triggerName, const std::string &triggerData) {
+                mpDatabaseApi->handleIncomingDbTrigger(triggerName.data(), triggerData.data());
+            };
+
+            mpDatabaseClient->initialize(mConfig.dbTriggersToListen, triggerCallback);
         });
 
         mSocketClientIoContext.post([this] {
@@ -188,6 +194,10 @@ namespace SmartHomeDB {
             mpService->onStop();
         }
 
+        if (mpDatabaseClient) {
+            mpDatabaseClient->stop();
+        }
+
         // Start shutdown timeout timer
         const auto timeoutTimer = std::make_shared<ba::steady_timer>(mUtilityIoContext, msSHUTDOWN_TIMEOUT);
         timeoutTimer->async_wait([this, timeoutTimer](const bs::error_code &ec) {
@@ -211,6 +221,7 @@ namespace SmartHomeDB {
         mpDatabaseConnectionManager.reset();
         mpSocketClient.reset();
         mpService.reset();
+        mpDatabaseClient.reset();
 
 
         pLogger->debug("[DB_SERVICE] Shutdown complete - waiting for threads to join in run()");

--- a/central_unit/src/db-service/database_service.cpp
+++ b/central_unit/src/db-service/database_service.cpp
@@ -31,7 +31,7 @@ namespace SmartHomeDB {
 
         // Attempt establishing connection with SmartHome daemon
         mpSocketClient = std::make_unique<si::SocketClient>(&mSocketClientIoContext, pLogger,
-                                                            msCLIENT_TARGET_TYPE.data());
+                                                            sc::Targets::DATABASE.data());
         bool isConnectionEstablished = false;
         if (mConfig.uds.isEnabled) {
             isConnectionEstablished = mpSocketClient->connectToServer(mConfig.uds.endpointPath);

--- a/central_unit/src/db-service/database_service.h
+++ b/central_unit/src/db-service/database_service.h
@@ -6,6 +6,7 @@
 #include "socket_server.h"
 #include "service_manager/service_manager.h"
 #include "async_logger.h"
+#include "constants.h"
 
 #include <atomic>
 #include <memory>
@@ -20,21 +21,19 @@ namespace SmartHomeDB {
     namespace bs = boost::system;
     namespace si = SmartHome::IPC;
     namespace su = SmartHome::Utils;
+    namespace sc = SmartHome::Constants;
 
     using namespace std::chrono_literals;
 
     class DatabaseClient;
 
     class DatabaseService {
-        /// Service name
-        static constexpr std::string_view msDEFAULT_SERVICE_NAME = "smarthome-databased";
-
     public:
         /**
          * @brief Configuration structure for DatabaseService initialization.
          */
         struct Config {
-            std::string serviceName = msDEFAULT_SERVICE_NAME.data();
+            std::string serviceName = sc::DefaultServiceNames::DATABASE.data();
 
             DatabaseConnectionManager::Config dbConnConfig{};
 
@@ -46,7 +45,8 @@ namespace SmartHomeDB {
             };
             /// Default UDS config from socket server
             si::SocketServer::Config::Uds uds{
-                .isEnabled = true, .endpointPath = "/var/run/smarthomed.sock"
+                .isEnabled = true, .endpointPath = sc::DefaultPaths::UDS.data()
+
             };
         };
 
@@ -157,8 +157,6 @@ namespace SmartHomeDB {
         static constexpr std::array msSIGNALS_TO_HANDLE = {SIGINT, SIGTERM, SIGHUP};
         /// Maximum time to wait for graceful shutdown
         static constexpr auto msSHUTDOWN_TIMEOUT = 2500ms;
-        /// IPC target type for handshake
-        static constexpr std::string_view msCLIENT_TARGET_TYPE = "database";
 
         Config mConfig;
 

--- a/central_unit/src/db-service/database_service.h
+++ b/central_unit/src/db-service/database_service.h
@@ -38,6 +38,8 @@ namespace SmartHomeDB {
 
             DatabaseConnectionManager::Config dbConnConfig{};
 
+            std::vector<std::string> dbTriggersToListen{};
+
             /// Default TCP config from socket server
             si::SocketServer::Config::Tcp tcp{
                 .isEnabled = true, .endpointAddress = "127.0.0.1", .endpointPort = 43321

--- a/central_unit/src/db-service/main.cpp
+++ b/central_unit/src/db-service/main.cpp
@@ -1,4 +1,5 @@
 #include "main.h"
+#include "constants.h"
 
 #include <iostream>
 #include <string>
@@ -10,6 +11,7 @@
 namespace ba = boost::asio;
 namespace bai = boost::asio::ip;
 namespace bpo = boost::program_options;
+namespace sc = SmartHome::Constants;
 
 namespace SmartHomeDB {
     TerminalPasswordGuard::TerminalPasswordGuard() {
@@ -138,10 +140,10 @@ namespace SmartHomeDB {
         // Load YAML config
         auto configManager = su::ConfigManager(pLogger);
         su::Logger::Config loggerConfig;
-        loggerConfig.logFile.path = sDEFAULT_LOGFILE_PATH;
+        loggerConfig.logFile.path = sc::DefaultPaths::DB_SERVICE_LOGFILE;
         const std::string configPath = vm.contains("config")
                                            ? vm["config"].as<std::string>()
-                                           : sDEFAULT_CONFIG_PATH.data();
+                                           : sc::DefaultPaths::DB_SERVICE_CONFIG.data();
         if (configManager.loadConfig(configPath)) {
             pLogger->debug("[MAIN_DB-SERVICE] Loading YAML logger config");
             loadLoggerYamlConfig(configManager, loggerConfig);

--- a/central_unit/src/db-service/main.cpp
+++ b/central_unit/src/db-service/main.cpp
@@ -41,6 +41,7 @@ namespace SmartHomeDB {
         std::string root = "db_service";
         configManager.getValue(root + ".service_name", databaseServiceConfig.serviceName);
         configManager.getValue(root + ".service_name", databaseServiceConfig.dbConnConfig.serviceName);
+        configManager.getValue(root + ".db_triggers_to_listen", databaseServiceConfig.dbTriggersToListen);
 
         root = "db_service.db_server";
         configManager.getValue(root + ".connections", databaseServiceConfig.dbConnConfig.dbConnections);

--- a/central_unit/src/db-service/main.h
+++ b/central_unit/src/db-service/main.h
@@ -126,9 +126,4 @@ namespace SmartHomeDB {
                      const bpo::parsed_options &parsed,
                      const std::shared_ptr<su::Logger> &pLogger,
                      DatabaseService::Config &databaseServiceConfig);
-
-
-    // Default paths for db-service
-    static constexpr std::string_view sDEFAULT_CONFIG_PATH = "/etc/smarthome/db-service.yaml";
-    static constexpr std::string_view sDEFAULT_LOGFILE_PATH = "/var/log/smarthome/db-service.log";
 }

--- a/central_unit/src/mediator/CMakeLists.txt
+++ b/central_unit/src/mediator/CMakeLists.txt
@@ -27,6 +27,7 @@ target_link_libraries(smarthome-mediator PRIVATE
         smarthome::api
         smarthome::utility
         smarthome::logger
+        smarthome::constants
         Boost::program_options
         Boost::system
         PkgConfig::GPIOD

--- a/central_unit/src/mediator/main.cpp
+++ b/central_unit/src/mediator/main.cpp
@@ -1,4 +1,5 @@
 #include "main.h"
+#include "constants.h"
 
 #include <iostream>
 #include <string>
@@ -10,6 +11,7 @@
 namespace ba = boost::asio;
 namespace bai = boost::asio::ip;
 namespace bpo = boost::program_options;
+namespace sc = SmartHome::Constants;
 
 namespace SmartHomeMediator {
     std::optional<std::array<uint8_t, 6> > parseMacAddress(const std::string &macStr) {
@@ -172,10 +174,10 @@ namespace SmartHomeMediator {
         // Load YAML config
         auto configManager = su::ConfigManager(logger);
         su::Logger::Config loggerConfig;
-        loggerConfig.logFile.path = sDEFAULT_LOGFILE_PATH;
+        loggerConfig.logFile.path = sc::DefaultPaths::MEDIATOR_LOGFILE;
         const std::string configPath = vm.contains("config")
                                            ? vm["config"].as<std::string>()
-                                           : sDEFAULT_CONFIG_PATH.data();
+                                           : sc::DefaultPaths::MEDIATOR_CONFIG.data();
         if (configManager.loadConfig(configPath)) {
             logger->debug("[MAIN_MEDIATOR] Loading YAML logger config");
             loadLoggerYamlConfig(configManager, loggerConfig);

--- a/central_unit/src/mediator/main.h
+++ b/central_unit/src/mediator/main.h
@@ -32,7 +32,7 @@ namespace SmartHomeMediator {
      *
      * @note Whitespace is ignored. String must be exactly 17 characters after stripping whitespace.
      */
-    std::optional<std::array<uint8_t, 6>> parseMacAddress(const std::string& macStr);
+    std::optional<std::array<uint8_t, 6> > parseMacAddress(const std::string &macStr);
 
     /**
      * @brief Read MAC address for network interface from sysfs.
@@ -43,7 +43,7 @@ namespace SmartHomeMediator {
      *
      * @note Reads from /sys/class/net/[interface]/address.
      */
-    std::optional<std::array<uint8_t, 6>> getMacAddressForInterface(const std::string& interface);
+    std::optional<std::array<uint8_t, 6> > getMacAddressForInterface(const std::string &interface);
 
     /**
      * @brief Get MAC address of first available network interface.
@@ -53,7 +53,7 @@ namespace SmartHomeMediator {
      *
      * @return 6-byte MAC address array, or std::nullopt if no valid interface found.
      */
-    std::optional<std::array<uint8_t, 6>> getDefaultMacAddress();
+    std::optional<std::array<uint8_t, 6> > getDefaultMacAddress();
 
     /**
      * @brief Loads logger configuration values from YAML file.
@@ -114,10 +114,5 @@ namespace SmartHomeMediator {
                      const bpo::parsed_options &parsed,
                      const std::shared_ptr<su::Logger> &logger,
                      Mediator::Config &mediatorConfig);
-
-
-    /// Default path for smarthome YAML config
-    static constexpr std::string_view sDEFAULT_CONFIG_PATH = "/etc/smarthome/mediator.yaml";
-    static constexpr std::string_view sDEFAULT_LOGFILE_PATH = "/var/log/smarthome/mediator.log";
 
 }

--- a/central_unit/src/mediator/mediator.cpp
+++ b/central_unit/src/mediator/mediator.cpp
@@ -1,6 +1,5 @@
 #include "mediator.h"
 
-
 namespace SmartHomeMediator {
     Mediator &Mediator::Instance() {
         static Mediator instance;
@@ -17,7 +16,7 @@ namespace SmartHomeMediator {
         mpLogger = std::make_shared<su::AsyncLogger>(logger, mMediatorUtilityIoContext);
 
         // Start service
-        mpService = su::ServiceManager::create(logger, msSERVICE_NAME, su::ServiceType::AUTO);
+        mpService = su::ServiceManager::create(logger, sc::DefaultServiceNames::MEDIATOR, su::ServiceType::AUTO);
         mpService->setIoContext(mMediatorIoContext);
         if (!mpService->onInitialize()) {
             logger->error("[MEDIATOR] Failed to initialize service");
@@ -30,7 +29,9 @@ namespace SmartHomeMediator {
         mConfig = configStruct;
 
         // Attempt establishing connection with SmartHome daemon
-        mpApiClient = std::make_unique<si::SocketClient>(&mApiClientIoContext, mpLogger, msCLIENT_TARGET_TYPE.data());
+        mpApiClient = std::make_unique<si::SocketClient>(&mApiClientIoContext,
+                                                         mpLogger,
+                                                         sc::Targets::MODULE_MEDIATOR.data());
         bool isConnectionEstablished = false;
         if (mConfig.uds.isEnabled) {
             isConnectionEstablished = mpApiClient->connectToServer(mConfig.uds.endpointPath);

--- a/central_unit/src/mediator/mediator.cpp
+++ b/central_unit/src/mediator/mediator.cpp
@@ -88,6 +88,7 @@ namespace SmartHomeMediator {
                 mpLogger->debug("[MEDIATOR] RF initialized");
             } else {
                 mpLogger->errorf("[MEDIATOR] RF initialization failed");
+                // TODO consider implementing retry mechanism with resetting RF module to default
             }
             isRfClientInitialized = isSuccessful;
         });

--- a/central_unit/src/mediator/mediator.h
+++ b/central_unit/src/mediator/mediator.h
@@ -6,6 +6,7 @@
 #include "socket_client.h"
 #include "rf_api/rf_client.h"
 #include "rf_api/rf_api.h"
+#include "constants.h"
 
 #include <memory>
 
@@ -13,6 +14,7 @@
 namespace su = SmartHome::Utils;
 namespace si = SmartHome::IPC;
 namespace bs = boost::system;
+namespace sc = SmartHome::Constants;
 
 
 namespace SmartHomeMediator {
@@ -36,7 +38,7 @@ namespace SmartHomeMediator {
                 .isEnabled = true, .endpointAddress = "127.0.0.1", .endpointPort = 43321
             };
             /// Default UDS config from socket server
-            si::SocketServer::Config::Uds uds{.isEnabled = true, .endpointPath = "/var/run/smarthomed.sock"};
+            si::SocketServer::Config::Uds uds{.isEnabled = true, .endpointPath = sc::DefaultPaths::UDS.data()};
 
             RfClient::Config rfClient{};
         };
@@ -131,9 +133,6 @@ namespace SmartHomeMediator {
         static constexpr std::array msSIGNALS_TO_HANDLE = {SIGINT, SIGTERM, SIGHUP};
         /// Maximum time to wait for graceful shutdown
         static constexpr auto msSHUTDOWN_TIMEOUT = 2500ms;
-        /// Service name
-        static constexpr std::string_view msSERVICE_NAME = "smarthome-radiod";
-        static constexpr std::string_view msCLIENT_TARGET_TYPE = "module_mediator";
 
         Config mConfig;
 

--- a/central_unit/src/mediator/rf_api/rf_api.cpp
+++ b/central_unit/src/mediator/rf_api/rf_api.cpp
@@ -125,7 +125,11 @@ namespace SmartHomeMediator {
             SmartHome::API::ApiError error;
             SmartHome::API::ApiResponse response;
 
+
             if (rfCommand.requestId.has_value()) {
+                // 0 is treated as undefined request id for RF communication protocol
+                // Don't send response for RF notifications (undefined id in RF protocol)
+                if (rfCommand.requestId.value() == 0) return "";
                 response.id = rfCommand.requestId.value();
             } else {
                 // Set response id as null when command id is not set (error response)
@@ -227,7 +231,15 @@ namespace SmartHomeMediator {
         }
 
         if (apiRequest.id.isUndefined()) {
-            parseNotification(pRfCommand.get(), methodLower, pMethodParams.get());
+            // Handle RF notification
+            if (methodLower == sc::Methods::NOTIFY) {
+                parseNotification(pRfCommand.get(), methodLower, pMethodParams.get());
+                return pRfCommand;
+            }
+
+            // Handle JSON-RPC notification (no response expected, used for fire-and-forget commands like sleep)
+            parseRequest(pRfCommand.get(), methodLower, pMethodParams.get());
+            pRfCommand->requestId = 0; // Treat undefined id as 0 for RF communication protocol
             return pRfCommand;
         }
 

--- a/central_unit/src/mediator/rf_api/rf_api.cpp
+++ b/central_unit/src/mediator/rf_api/rf_api.cpp
@@ -1,12 +1,14 @@
 #include "rf_api.h"
 #include "../mediator.h"
 #include "rf_client.h"
+#include "constants.h"
 
 #include <boost/algorithm/string/case_conv.hpp>
 namespace sj = SmartHome::JsonRpcStrings;
 
 namespace SmartHomeMediator {
     using namespace std::string_literals;
+    namespace sc = SmartHome::Constants;
 
     void RfApi::initialize(const std::function<void(const std::string &message)> &messageHandler) {
         mMessageHandler = messageHandler;
@@ -88,6 +90,7 @@ namespace SmartHomeMediator {
 
         try {
             apiRequest(jsonRpcRequest);
+            response.id = apiRequest.id;
         } catch (const std::exception &e) {
             pLogger->errorf("[RF_API] [HANDLE_INCOMING] Failed to parse request message to ApiRequest: %s",
                             e.what());
@@ -176,7 +179,7 @@ namespace SmartHomeMediator {
             notify.params.emplace(nlohmann::json::object());
             auto &params = notify.params.value();
 
-            notify.method = SmartHome::API::getTargetMethodString(RfTypes::CORE_STRING, RfTypes::NOTIFY_STRING);
+            notify.method = SmartHome::API::getTargetMethodString(sc::Targets::CORE, sc::Methods::NOTIFY);
 
             auto notificationType = std::get<RfTypes::NotificationType>(rfCommand.requestType.value());
             params[sj::ParamsKeys::TYPE] = notificationTypeToString(notificationType);
@@ -202,14 +205,14 @@ namespace SmartHomeMediator {
         const auto targetLower = boost::algorithm::to_lower_copy(std::string(targetStr));
         const auto methodLower = boost::algorithm::to_lower_copy(std::string(methodStr));
 
-        if (targetLower != RfTypes::MEDIATOR_STRING) {
+        if (targetLower != sc::Targets::MEDIATOR && targetLower != sc::Targets::MODULE_MEDIATOR) {
             throw std::invalid_argument("Missing or invalid target parameter");
         }
 
         std::unique_ptr<nlohmann::json> pMethodParams;
         if (!params.empty()) {
             pMethodParams = std::make_unique<nlohmann::json>(params);
-        } else if (methodLower != RfTypes::PING_STRING) {
+        } else if (methodLower != sc::Methods::PING) {
             throw std::invalid_argument("Missing method params");
         }
 
@@ -248,12 +251,12 @@ namespace SmartHomeMediator {
 
         bool argsRequired = false;
 
-        if (method == RfTypes::GET_STRING) {
+        if (method == sc::Methods::GET) {
             pConfigCommand->configCommandType = RfTypes::MediatorConfigCommandType::GET;
-        } else if (method == RfTypes::SET_STRING) {
+        } else if (method == sc::Methods::SET) {
             pConfigCommand->configCommandType = RfTypes::MediatorConfigCommandType::SET;
             argsRequired = true;
-        } else if (method == RfTypes::EXECUTE_STRING) {
+        } else if (method == sc::Methods::EXECUTE) {
             pConfigCommand->configCommandType = RfTypes::MediatorConfigCommandType::EXECUTE;
             argsRequired = true;
         } else {
@@ -285,7 +288,7 @@ namespace SmartHomeMediator {
     void RfApi::parseRequest(RfTypes::RfCommand *pCommand,
                              const std::string_view method,
                              nlohmann::json *pMethodParams) {
-        if (method == RfTypes::PING_STRING) {
+        if (method == sc::Methods::PING) {
             pCommand->rfCommandType = RfTypes::RfCommandType::PING;
             return;
         }
@@ -293,10 +296,11 @@ namespace SmartHomeMediator {
         if (!(pMethodParams &&
               pMethodParams->contains(sj::ParamsKeys::TYPE) &&
               pMethodParams->at(sj::ParamsKeys::TYPE).is_string())) {
-            throw std::invalid_argument("Invalid method specified");
+            throw std::invalid_argument(
+                "'type' field is required for get, set and execute commands and must be a string");
         }
 
-        if (method == RfTypes::SET_STRING) {
+        if (method == sc::Methods::SET) {
             // Handle set command
             pCommand->rfCommandType = RfTypes::RfCommandType::SET;
             // Read set type from 'type' field
@@ -306,7 +310,7 @@ namespace SmartHomeMediator {
             } catch (const std::exception &e) {
                 throwParseError("set", e.what(), pMethodParams->dump());
             }
-        } else if (method == RfTypes::GET_STRING) {
+        } else if (method == sc::Methods::GET) {
             // Handle get command
             pCommand->rfCommandType = RfTypes::RfCommandType::GET;
             // Read get type from 'type' field
@@ -316,7 +320,7 @@ namespace SmartHomeMediator {
             } catch (const std::exception &e) {
                 throwParseError("get", e.what(), pMethodParams->dump());
             }
-        } else if (method == RfTypes::EXECUTE_STRING) {
+        } else if (method == sc::Methods::EXECUTE) {
             // Handle execute command
             std::string action;
             try {
@@ -326,12 +330,12 @@ namespace SmartHomeMediator {
             }
 
             // TODO implement function when adding more actions
-            if (action == RfTypes::SLEEP_STRING) {
+            if (action == sc::MediatorTypes::SLEEP) {
                 pCommand->rfCommandType = RfTypes::RfCommandType::SLEEP;
-            } else if (action == RfTypes::DEEP_SLEEP_STRING)
+            } else if (action == sc::MediatorTypes::DEEP_SLEEP)
                 pCommand->rfCommandType = RfTypes::RfCommandType::DEEP_SLEEP;
             else {
-                throw std::invalid_argument("Invalid action parameter specified");
+                throw std::invalid_argument("Invalid 'type' parameter specified");
             }
         } else {
             throw std::invalid_argument("API method not supported: "s + method.data());
@@ -350,7 +354,7 @@ namespace SmartHomeMediator {
     void RfApi::parseNotification(RfTypes::RfCommand *pCommand,
                                   const std::string_view method,
                                   nlohmann::json *pMethodParams) {
-        if (method != RfTypes::NOTIFY_STRING) {
+        if (method != sc::Methods::NOTIFY) {
             throw std::invalid_argument("API notification is not of notify method");
         }
 

--- a/central_unit/src/mediator/rf_api/rf_api.h
+++ b/central_unit/src/mediator/rf_api/rf_api.h
@@ -2,7 +2,6 @@
 
 #include "rf_types.h"
 #include "api.h"
-#include "../../core/api/internal_api.h"
 
 
 namespace sa = SmartHome::API;

--- a/central_unit/src/mediator/rf_api/rf_api.h
+++ b/central_unit/src/mediator/rf_api/rf_api.h
@@ -59,6 +59,20 @@ namespace SmartHomeMediator {
          *         }
          *       }
          *       \endcode
+         *       For request to be directed at mediator itself:
+         *        - \b "module_info" must be omitted
+         *        - \b "type" should contain rf_driver implementation dependent configuration key, or action for execute
+         *
+         * @note Example (set fu_mode to 4 on mediator using HC-12 driver):
+         *       \code{.json}
+         *       {
+         *         "method": "mediator.set",
+         *         "params": {
+         *           "type": "fu_mode",
+         *           "args": [4]
+         *         }
+         *       }
+         *       \endcode
          */
         void handleIncoming(SmartHome::connectionId_t connectionId, std::string &&message) override;
 

--- a/central_unit/src/mediator/rf_api/rf_client.cpp
+++ b/central_unit/src/mediator/rf_api/rf_client.cpp
@@ -72,7 +72,7 @@ namespace SmartHomeMediator {
 
             // Set channel to default
             try {
-                success = co_await mpDriver->setOption(sc::MediatorArgs::CHANNEL.data(),
+                success = co_await mpDriver->setOption(sc::MediatorSpecial::CHANNEL.data(),
                                                        std::to_string(mRfMainChannel));
             } catch (const std::exception &e) {
                 mpLogger->errorf("[RF_CLIENT] Initialization error: %s", e.what());

--- a/central_unit/src/mediator/rf_api/rf_client.cpp
+++ b/central_unit/src/mediator/rf_api/rf_client.cpp
@@ -1,10 +1,13 @@
 #include "rf_client.h"
 #include "../mediator.h"
+#include "constants.h"
 
 #include <boost/format.hpp>
 #include <boost/algorithm/string/join.hpp>
 
 namespace SmartHomeMediator {
+    namespace sc = SmartHome::Constants;
+
     RfClient::RfClient(ba::io_context &ioContext,
                        const std::shared_ptr<su::Logger> &logger,
                        const Config &config)
@@ -28,7 +31,7 @@ namespace SmartHomeMediator {
         std::vector<std::string> hexBytes;
         hexBytes.reserve(mUniqueNetworkId.size());
 
-        for (const auto &byte : mUniqueNetworkId) {
+        for (const auto &byte: mUniqueNetworkId) {
             hexBytes.push_back((boost::format("%02X") % static_cast<int>(byte)).str());
         }
         const std::string macStr = boost::algorithm::join(hexBytes, ":");
@@ -69,7 +72,7 @@ namespace SmartHomeMediator {
 
             // Set channel to default
             try {
-                success = co_await mpDriver->setOption(RfDriver::msCHANNEL_OPTION_STRING.data(),
+                success = co_await mpDriver->setOption(sc::MediatorArgs::CHANNEL.data(),
                                                        std::to_string(mRfMainChannel));
             } catch (const std::exception &e) {
                 mpLogger->errorf("[RF_CLIENT] Initialization error: %s", e.what());

--- a/central_unit/src/mediator/rf_api/rf_types.cpp
+++ b/central_unit/src/mediator/rf_api/rf_types.cpp
@@ -425,7 +425,7 @@ namespace SmartHomeMediator::RfTypes {
             {sc::MediatorTypes::SENSOR_VALUE, GetType::SENSOR_VALUE},
             {sc::MediatorTypes::CONFIG_OPTION, GetType::CONFIG_OPTION},
             {sc::MediatorTypes::SENSOR_LIST, GetType::SENSOR_LIST},
-            {sc::MediatorTypes::LOGS, GetType::LOGS},
+            {sc::MediatorTypes::MODULE_LOGS, GetType::LOGS},
             {sc::MediatorTypes::BATTERY_LEVEL, GetType::BATTERY_LEVEL},
             {sc::MediatorTypes::FORCE_READ_SENSOR_VALUE, GetType::FORCE_READ_SENSOR_VALUE}
         };

--- a/central_unit/src/mediator/rf_api/rf_types.cpp
+++ b/central_unit/src/mediator/rf_api/rf_types.cpp
@@ -1,9 +1,11 @@
 #include "rf_types.h"
+#include "constants.h"
 
 #include <boost/algorithm/string/case_conv.hpp>
 
 namespace SmartHomeMediator::RfTypes {
     namespace sj = SmartHome::JsonRpcStrings;
+    namespace sc = SmartHome::Constants;
 
 
     Packet Packet::from_bytes(const std::span<const uint8_t> data) {
@@ -402,30 +404,30 @@ namespace SmartHomeMediator::RfTypes {
     std::string_view getStringFromRfErrorCode(const RfErrorCode code) {
         switch (code) {
             case RfErrorCode::UNKNOWN:
-                return "Unknown error";
+                return sc::HumanReadableErrors::UNKNOWN_ERROR;
             case RfErrorCode::BAD_COMMAND:
-                return "Bad command";
+                return sc::HumanReadableErrors::BAD_COMMAND;
             case RfErrorCode::UNKNOWN_COMMAND:
-                return "Unknown command";
+                return sc::HumanReadableErrors::UNKNOWN_COMMAND;
             case RfErrorCode::BAD_ARGUMENT:
-                return "Bad argument";
+                return sc::HumanReadableErrors::BAD_ARGUMENT;
             case RfErrorCode::NOT_IMPLEMENTED:
-                return "Not implemented";
+                return sc::HumanReadableErrors::NOT_IMPLEMENTED;
             case RfErrorCode::INTERNAL_ERROR:
-                return "Internal error";
+                return sc::HumanReadableErrors::INTERNAL_ERROR;
             default:
-                return "Undefined error";
+                return sc::HumanReadableErrors::UNDEFINED_ERROR;
         }
     }
 
     GetType getTypeFromString(const std::string_view value) {
         static const std::unordered_map<std::string_view, GetType> strToGetMap{
-            {SENSOR_VALUE_STRING, GetType::SENSOR_VALUE},
-            {CONFIG_OPTION_STRING, GetType::CONFIG_OPTION},
-            {SENSOR_LIST_STRING, GetType::SENSOR_LIST},
-            {LOGS_STRING, GetType::LOGS},
-            {BATTERY_LEVEL_STRING, GetType::BATTERY_LEVEL},
-            {FORCE_READ_SENSOR_VALUE_STRING, GetType::FORCE_READ_SENSOR_VALUE}
+            {sc::MediatorTypes::SENSOR_VALUE, GetType::SENSOR_VALUE},
+            {sc::MediatorTypes::CONFIG_OPTION, GetType::CONFIG_OPTION},
+            {sc::MediatorTypes::SENSOR_LIST, GetType::SENSOR_LIST},
+            {sc::MediatorTypes::LOGS, GetType::LOGS},
+            {sc::MediatorTypes::BATTERY_LEVEL, GetType::BATTERY_LEVEL},
+            {sc::MediatorTypes::FORCE_READ_SENSOR_VALUE, GetType::FORCE_READ_SENSOR_VALUE}
         };
 
         const auto iter = strToGetMap.find(boost::algorithm::to_lower_copy(std::string(value)));
@@ -434,9 +436,9 @@ namespace SmartHomeMediator::RfTypes {
 
     SetType setTypeFromString(const std::string_view value) {
         static const std::unordered_map<std::string_view, SetType> strToSetMap{
-            {CONFIG_OPTION_STRING, SetType::CONFIG_OPTION},
-            {TOGGLE_ACTUATOR_STRING, SetType::TOGGLE_ACTUATOR},
-            {SET_ACTUATOR_VALUE_STRING, SetType::SET_ACTUATOR_VALUE}
+            {sc::MediatorTypes::CONFIG_OPTION, SetType::CONFIG_OPTION},
+            {sc::MediatorTypes::TOGGLE_ACTUATOR, SetType::TOGGLE_ACTUATOR},
+            {sc::MediatorTypes::SET_ACTUATOR_VALUE, SetType::SET_ACTUATOR_VALUE}
         };
 
         const auto iter = strToSetMap.find(boost::algorithm::to_lower_copy(std::string(value)));
@@ -445,10 +447,10 @@ namespace SmartHomeMediator::RfTypes {
 
     NotificationType notificationTypeFromString(const std::string_view value) {
         static const std::unordered_map<std::string_view, NotificationType> strToNotifMap{
-            {MANUAL_TRIGGER_STRING, NotificationType::MANUAL_TRIGGER},
-            {POWER_LOSS_STRING, NotificationType::POWER_LOSS},
-            {ALERT_STRING, NotificationType::ALERT},
-            {WAKE_STRING, NotificationType::WAKE}
+            {sc::MediatorTypes::MANUAL_TRIGGER, NotificationType::MANUAL_TRIGGER},
+            {sc::MediatorTypes::POWER_LOSS, NotificationType::POWER_LOSS},
+            {sc::MediatorTypes::ALERT, NotificationType::ALERT},
+            {sc::MediatorTypes::WAKE, NotificationType::WAKE}
         };
 
         const auto iter = strToNotifMap.find(boost::algorithm::to_lower_copy(std::string(value)));
@@ -458,15 +460,15 @@ namespace SmartHomeMediator::RfTypes {
     std::string_view notificationTypeToString(const NotificationType value) {
         switch (value) {
             case NotificationType::MANUAL_TRIGGER:
-                return MANUAL_TRIGGER_STRING;
+                return sc::MediatorTypes::MANUAL_TRIGGER;
             case NotificationType::POWER_LOSS:
-                return POWER_LOSS_STRING;
+                return sc::MediatorTypes::POWER_LOSS;
             case NotificationType::ALERT:
-                return ALERT_STRING;
+                return sc::MediatorTypes::ALERT;
             case NotificationType::WAKE:
-                return WAKE_STRING;
+                return sc::MediatorTypes::WAKE;
             default:
-                return UNDEFINED_STRING;
+                return sc::Common::UNDEFINED;
         }
     }
 

--- a/central_unit/src/mediator/rf_api/rf_types.h
+++ b/central_unit/src/mediator/rf_api/rf_types.h
@@ -9,7 +9,6 @@
 
 
 namespace SmartHomeMediator::RfTypes {
-
     /**
      * @brief Error codes returned in RF protocol error responses.
      */
@@ -583,41 +582,6 @@ namespace SmartHomeMediator::RfTypes {
      */
     template<typename T>
     void assignRawDataToParameter(Parameter &param, const std::span<uint8_t> &rawData);
-
-
-    // Target string
-    inline constexpr std::string_view MEDIATOR_STRING = "module_mediator";
-    inline constexpr std::string_view CORE_STRING = "core";
-
-    // Commands strings
-    inline constexpr std::string_view GET_STRING = "get";
-    inline constexpr std::string_view SET_STRING = "set";
-    inline constexpr std::string_view NOTIFY_STRING = "notify";
-    inline constexpr std::string_view EXECUTE_STRING = "execute";
-    inline constexpr std::string_view PING_STRING = "ping";
-
-    // Set/Get/Notify type strings
-    inline constexpr std::string_view CONFIG_OPTION_STRING = "config_option";
-    inline constexpr std::string_view TOGGLE_ACTUATOR_STRING = "toggle_actuator";
-    inline constexpr std::string_view SET_ACTUATOR_VALUE_STRING = "set_actuator_value";
-    inline constexpr std::string_view SENSOR_VALUE_STRING = "sensor_value";
-    inline constexpr std::string_view SENSOR_LIST_STRING = "sensor_list";
-    inline constexpr std::string_view LOGS_STRING = "logs";
-    inline constexpr std::string_view BATTERY_LEVEL_STRING = "battery_level";
-    inline constexpr std::string_view FORCE_READ_SENSOR_VALUE_STRING = "force_read_sensor_value";
-    inline constexpr std::string_view MANUAL_TRIGGER_STRING = "manual_trigger";
-    inline constexpr std::string_view POWER_LOSS_STRING = "power_loss";
-    inline constexpr std::string_view ALERT_STRING = "alert";
-    inline constexpr std::string_view WAKE_STRING = "wake";
-
-    // Action types strings
-    inline constexpr std::string_view SLEEP_STRING = "sleep";
-    inline constexpr std::string_view DEEP_SLEEP_STRING = "deep_sleep";
-
-    // Special strings
-    inline constexpr std::string_view ALL_OPTIONS_STRING = "all_options";
-    inline constexpr std::string_view DEFAULT_STRING = "DEFAULT";
-    inline constexpr std::string_view UNDEFINED_STRING = "undefined";
 }
 
 #include "rf_types.tpp"

--- a/central_unit/src/mediator/rf_driver/hc12_driver.cpp
+++ b/central_unit/src/mediator/rf_driver/hc12_driver.cpp
@@ -1,11 +1,14 @@
 #include "hc12_driver.h"
 #include "../rf_api/rf_types.h"
+#include "constants.h"
 
 #include <algorithm>
 #include <boost/algorithm/string/find.hpp>
 
 
 namespace SmartHomeMediator {
+    namespace sc = SmartHome::Constants;
+
     HC12Driver::HC12Driver(ba::io_context &ioContext,
                            const std::shared_ptr<su::Logger> &logger,
                            const Config &config)
@@ -181,7 +184,7 @@ namespace SmartHomeMediator {
 
             // Validate response, with spacial case for resetting to default
             if (value == responseValueStr ||
-                (parsedOption == Hc12Option::DEFAULT && responseStr == RfTypes::DEFAULT_STRING)) {
+                (parsedOption == Hc12Option::DEFAULT && responseStr == sc::Common::DEFAULT_UPPER)) {
                 success = true;
                 mpLogger->debugf("[HC12_DRIVER] [SET_OPTION] option set: %s=%s",
                                  option.data(), responseValueStr.c_str());
@@ -400,7 +403,7 @@ namespace SmartHomeMediator {
                 commandStr = "AT+P" + std::string(value);
                 break;
             case Hc12Option::DEFAULT:
-                if (value != RfTypes::ALL_OPTIONS_STRING) break;
+                if (value != sc::MediatorArgs::ALL_OPTIONS) break;
                 commandStr = "AT+DEFAULT";
                 break;
             default:
@@ -480,7 +483,7 @@ namespace SmartHomeMediator {
         std::string valuePart(responseStr.substr(plusPos + 1));
 
         // Handle reset to default settings
-        if (valuePart == RfTypes::DEFAULT_STRING) {
+        if (valuePart == sc::Common::DEFAULT_UPPER) {
             return {valuePart.begin(), valuePart.end()};
         }
 

--- a/central_unit/src/mediator/rf_driver/hc12_driver.cpp
+++ b/central_unit/src/mediator/rf_driver/hc12_driver.cpp
@@ -184,7 +184,7 @@ namespace SmartHomeMediator {
 
             // Validate response, with spacial case for resetting to default
             if (value == responseValueStr ||
-                (parsedOption == Hc12Option::DEFAULT && responseStr == sc::Common::DEFAULT_UPPER)) {
+                (parsedOption == Hc12Option::DEFAULT && responseValueStr == sc::Common::DEFAULT_UPPER)) {
                 success = true;
                 mpLogger->debugf("[HC12_DRIVER] [SET_OPTION] option set: %s=%s",
                                  option.data(), responseValueStr.c_str());

--- a/central_unit/src/mediator/rf_driver/hc12_driver.cpp
+++ b/central_unit/src/mediator/rf_driver/hc12_driver.cpp
@@ -403,7 +403,7 @@ namespace SmartHomeMediator {
                 commandStr = "AT+P" + std::string(value);
                 break;
             case Hc12Option::DEFAULT:
-                if (value != sc::MediatorArgs::ALL_OPTIONS) break;
+                if (value != sc::MediatorSpecial::ALL_OPTIONS) break;
                 commandStr = "AT+DEFAULT";
                 break;
             default:

--- a/central_unit/src/mediator/rf_driver/hc12_driver.h
+++ b/central_unit/src/mediator/rf_driver/hc12_driver.h
@@ -13,6 +13,7 @@
 #include <vector>
 #include <set>
 
+// TODO Setting FU_MODE can change HC-12 baudrate, implement automatic baudrate change in UART port to handle this case
 
 namespace ba = boost::asio;
 
@@ -31,7 +32,7 @@ namespace SmartHomeMediator {
             BAUDRATE, // AT+B (1200/2400/.../115200)
             FU_MODE, // AT+FU (1-4)
             POWER, // AT+P (1-8)
-            DEFAULT // Reset to default
+            DEFAULT // Reset to default, requires value "all_options"
         };
 
         struct Config {

--- a/central_unit/src/mediator/rf_driver/rf_driver.h
+++ b/central_unit/src/mediator/rf_driver/rf_driver.h
@@ -3,7 +3,6 @@
 #include "async_logger.h"
 
 #include <string>
-#include <string_view>
 #include <vector>
 #include <memory>
 
@@ -37,7 +36,7 @@ namespace SmartHomeMediator {
          *
          * @return Awaitable with received data string.
          */
-        virtual ba::awaitable<std::vector<uint8_t>> read() = 0;
+        virtual ba::awaitable<std::vector<uint8_t> > read() = 0;
 
         /**
          * @brief Set RF transceiver configuration option.
@@ -56,7 +55,7 @@ namespace SmartHomeMediator {
          *
          * @return Awaitable with option value, or empty string on error.
          */
-        virtual ba::awaitable<std::vector<uint8_t>> getOption(std::string option) = 0;
+        virtual ba::awaitable<std::vector<uint8_t> > getOption(std::string option) = 0;
 
         /**
          * @brief Get all RF transceiver configuration options.
@@ -79,11 +78,7 @@ namespace SmartHomeMediator {
          */
         virtual bool isMultiChannel() = 0;
 
-        /// String used by setOption when changing channels if transceiver supports it
-        static constexpr std::string_view msCHANNEL_OPTION_STRING = "channel";
-
     protected:
         std::shared_ptr<su::Logger> mpLogger;
     };
-
 }

--- a/central_unit/src/mediator/session.cpp
+++ b/central_unit/src/mediator/session.cpp
@@ -201,7 +201,7 @@ namespace SmartHomeMediator {
                     break;
                 case RfTypes::MediatorConfigCommandType::GET:
                     // Get all options
-                    if (key == sc::MediatorArgs::ALL_OPTIONS) {
+                    if (key == sc::MediatorSpecial::ALL_OPTIONS) {
                         try {
                             apiResponse.result = co_await mpRfDriver->getAllOptions();
                         } catch (const std::exception &e) {
@@ -572,7 +572,7 @@ namespace SmartHomeMediator {
         constexpr int retries = 3;
         for (int i = 0; i < retries; i++) {
             try {
-                isSuccessful = co_await mpRfDriver->setOption(sc::MediatorArgs::CHANNEL.data(),
+                isSuccessful = co_await mpRfDriver->setOption(sc::MediatorSpecial::CHANNEL.data(),
                                                               std::to_string(channel));
             } catch (const std::exception &e) {
                 mpLogger->errorf("[SESSION] [CHANGE_CHANNEL] Failed to change RF channel. Attempt %d/%d. Cause: %s",

--- a/central_unit/src/mediator/session.cpp
+++ b/central_unit/src/mediator/session.cpp
@@ -299,7 +299,8 @@ namespace SmartHomeMediator {
 
                 // Parse RF response to SmartHome::API format
                 try {
-                    ctx.resultsVector.push_back(RfApi::toApiString(*ctx.pCommandResponse));
+                    const auto apiString = RfApi::toApiString(*ctx.pCommandResponse);
+                    if (!apiString.empty()) ctx.resultsVector.push_back(apiString);
                 } catch (const std::exception &e) {
                     mpLogger->debugf("[SESSION] [EXECUTE] [AWAIT_RESPONSE] parse to api response failed: %s",
                                      e.what());
@@ -415,7 +416,8 @@ namespace SmartHomeMediator {
 
                 // Try parsing to SmartHome::API format
                 try {
-                    ctx.resultsVector.push_back(RfApi::toApiString(*ctx.pCommandResponse));
+                    const auto apiString = RfApi::toApiString(*ctx.pCommandResponse);
+                    if (!apiString.empty()) ctx.resultsVector.push_back(apiString);
                 } catch (const std::exception &e) {
                     mpLogger->debugf("[SESSION] [EXECUTE] [AWAIT_NOTIFICATION] parse to api response failed: %s",
                                      e.what());

--- a/central_unit/src/mediator/session.cpp
+++ b/central_unit/src/mediator/session.cpp
@@ -2,6 +2,7 @@
 #include "rf_api/rf_client.h"
 #include "rf_driver/hc12_driver.h"
 #include "rf_api/rf_api.h"
+#include "constants.h"
 
 #include <cmath>
 #include <utility>
@@ -9,6 +10,7 @@
 
 namespace SmartHomeMediator {
     using namespace std::string_literals;
+    namespace sc = SmartHome::Constants;
 
     Session::Session(RfTypes::SessionMetadata &&metadata,
                      const std::shared_ptr<HC12Driver> &pRfDriver,
@@ -199,7 +201,7 @@ namespace SmartHomeMediator {
                     break;
                 case RfTypes::MediatorConfigCommandType::GET:
                     // Get all options
-                    if (key == RfTypes::ALL_OPTIONS_STRING) {
+                    if (key == sc::MediatorArgs::ALL_OPTIONS) {
                         try {
                             apiResponse.result = co_await mpRfDriver->getAllOptions();
                         } catch (const std::exception &e) {
@@ -570,7 +572,7 @@ namespace SmartHomeMediator {
         constexpr int retries = 3;
         for (int i = 0; i < retries; i++) {
             try {
-                isSuccessful = co_await mpRfDriver->setOption(RfDriver::msCHANNEL_OPTION_STRING.data(),
+                isSuccessful = co_await mpRfDriver->setOption(sc::MediatorArgs::CHANNEL.data(),
                                                               std::to_string(channel));
             } catch (const std::exception &e) {
                 mpLogger->errorf("[SESSION] [CHANGE_CHANNEL] Failed to change RF channel. Attempt %d/%d. Cause: %s",


### PR DESCRIPTION
## Implement caching, scheduling and improve Core lifecycle

### Caching:
- Added ConfigCache for modules and sensors with index-based lookups.
- Added ReadingsCache with per-sensor TTL freshness tracking.
- Integrated cache population from db-service on startup via fetchAllConfigs.
- Added PostgreSQL LISTEN/NOTIFY handling for real-time cache invalidation.

### Scheduler:
 - Added RRULE-based scheduler using libical for recurring sensor actions.
- Scheduler uses priority queue with single system_timer, dispatches through existing Actions pipeline.
- Supports configurable dtstart for aligned scheduling (e.g. full hours).

### Core Lifecycle:
- Reworked Core shutdown to match db-service pattern.
- Added destructor cleanup for failed initialization scenario.
- Added launching db-service and mediator as child processes from smarthomed.

### Core Actions:
- Expanded CoreActions GET handlers: modules, sensors, readings, logs, debug cache.
- Added sensor ID resolution from module_id + sensor_logic_id.

### Common/Shared:
- Added constants.h in Common, centralized shared constants across targets.
- Moved ApiKeys from db-api to JsonRpcStrings::ParamsKeys.
- Added parseTimestampTz and timePointToTimestampTz utility functions.
