### PR TITLE
Central unit/feature/sh 221 cache unit tests

### DIFF
--- a/central_unit/docs/namespaces.h
+++ b/central_unit/docs/namespaces.h
@@ -88,6 +88,15 @@ namespace SmartHome::Exceptions {
 }
 
 /**
+ * @namespace SmartHome::Tests
+ * @brief Namespace containing unit tests.
+ *
+ * @details Contains unit tests and mocks for classes and structs in \c SmartHome namespace.
+ */
+namespace SmartHome::Tests {
+}
+
+/**
  * @namespace SmartHomeCLI
  * @brief Command Line Interface for Smart Home system.
  *

--- a/central_unit/src/common/CMakeLists.txt
+++ b/central_unit/src/common/CMakeLists.txt
@@ -38,6 +38,8 @@ add_library(smarthome_logger STATIC
         logger/logger.cpp
         logger/async_logger.cpp
 )
+set_target_properties(smarthome_logger PROPERTIES FOLDER "lib")
+
 
 add_library(smarthome::logger ALIAS smarthome_logger)
 
@@ -54,6 +56,7 @@ target_link_libraries(smarthome_logger PRIVATE
 add_library(smarthome_api STATIC
         api/api.cpp
 )
+set_target_properties(smarthome_api PROPERTIES FOLDER "lib")
 
 add_library(smarthome::api ALIAS smarthome_api)
 
@@ -72,6 +75,7 @@ add_library(smarthome_ipc STATIC
         ipc/socket_server_connection.cpp
         ipc/socket_server.cpp
 )
+set_target_properties(smarthome_ipc PROPERTIES FOLDER "lib")
 
 add_library(smarthome::ipc ALIAS smarthome_ipc)
 
@@ -97,6 +101,8 @@ add_library(smarthome_utility STATIC
         utils/service_manager/standalone_service.cpp
         utils/service_manager/systemd_service.cpp
 )
+set_target_properties(smarthome_utility PROPERTIES FOLDER "lib")
+
 
 add_library(smarthome::utility ALIAS smarthome_utility)
 

--- a/central_unit/src/common/constants/constants.h
+++ b/central_unit/src/common/constants/constants.h
@@ -11,6 +11,7 @@ namespace SmartHome::Constants {
         inline constexpr std::string_view VALUE = "value";
         inline constexpr std::string_view ERROR = "error";
         inline constexpr std::string_view STATUS = "status";
+        inline constexpr std::string_view STALE = "stale";
 
         // Special
         inline constexpr std::string_view UNDEFINED_BRACKETS = "<undefined>";

--- a/central_unit/src/core/CMakeLists.txt
+++ b/central_unit/src/core/CMakeLists.txt
@@ -29,6 +29,9 @@ set(ICAL_GLIB OFF CACHE BOOL "" FORCE)
 set(CMAKE_DISABLE_FIND_PACKAGE_ICU ON CACHE BOOL "" FORCE)
 
 FetchContent_MakeAvailable(libical)
+set_target_properties(ical ical-header ical_cxx icalss icalss-header icalss_cxx icalvcal
+        PROPERTIES FOLDER "third_party")
+
 
 # Core library
 add_library(smarthome_core_lib STATIC
@@ -43,6 +46,7 @@ add_library(smarthome_core_lib STATIC
         actions/mediator_actions.cpp
         actions/database_actions.cpp
 )
+set_target_properties(smarthome_core_lib PROPERTIES FOLDER "lib")
 
 add_library(smarthome::core_lib ALIAS smarthome_core_lib)
 

--- a/central_unit/src/core/actions/database_actions.cpp
+++ b/central_unit/src/core/actions/database_actions.cpp
@@ -6,6 +6,7 @@ namespace SmartHome {
 
     namespace jmik = JsonRpcStrings::ModuleInfoKeys;
     namespace jp = JsonRpcStrings::ParamsKeys;
+    namespace cdbi = Constants::DatabaseIdentifiers;
 
     awaitOptApiResponse DatabaseActions::databaseRequestHandler(cmdMetaPtr commandMetadata) {
         Core::Instance().mpLogger->debug("[DATABASE_ACTIONS] [REQUEST_HANDLER] called");
@@ -32,6 +33,8 @@ namespace SmartHome {
 
         co_return commandResult;
     }
+
+    // TODO replace literals with constants
 
     ba::awaitable<nlohmann::json> DatabaseActions::getModuleAddressingInfo(uint moduleId) {
         API::ApiRequest request;
@@ -78,15 +81,10 @@ namespace SmartHome {
 
                 // Update config cache with retrieved info
                 try {
-                    auto module = CachedModule{
-                        .id = moduleId,
-                        .logicAddress = row[jmik::LOGIC_ADDRESS],
-                        .name = row["name"],
-                        .config = row["config"],
-                    };
+                    auto module = CachedModule(moduleId, row[cdbi::LOGIC_ADDRESS], row[cdbi::NAME], row[cdbi::CONFIG]);
 
-                    if (!row["last_online"].is_null()) {
-                        module.lastOnline = Utils::parseTimestampTz(row["last_online"]);
+                    if (!row[cdbi::LAST_ONLINE].is_null()) {
+                        module.lastOnline = Utils::parseTimestampTz(row[cdbi::LAST_ONLINE]);
                     }
 
                     Core::Instance().configCache().setModule(module);
@@ -203,20 +201,9 @@ namespace SmartHome {
 
             if (responseResultJson.contains(jp::AFFECTED_ROWS) &&
                 responseResultJson.contains(jp::ROWS)) {
-                for (const auto &row: responseResultJson[jp::ROWS]) {
+                for (const auto &moduleData: responseResultJson[jp::ROWS]) {
                     try {
-                        CachedModule module{
-                            .id = row["id"],
-                            .logicAddress = row["logic_address"],
-                            .name = row["name"],
-                            .config = row["config"],
-                        };
-
-                        if (!row["last_online"].is_null()) {
-                            module.lastOnline = Utils::parseTimestampTz(row["last_online"]);
-                        }
-
-                        cache.setModule(module);
+                        cache.setModule(CachedModule(moduleData));
                     } catch (const std::exception &e) {
                         Core::Instance().mpLogger->errorf(
                             "[DATABASE_ACTIONS] [FETCH_MODULE_CONFIGS] Failed to parse db response: %s", e.what());
@@ -268,17 +255,9 @@ namespace SmartHome {
 
             if (responseResultJson.contains(jp::AFFECTED_ROWS) &&
                 responseResultJson.contains(jp::ROWS)) {
-                for (const auto &row: responseResultJson[jp::ROWS]) {
+                for (const auto &deviceData: responseResultJson[jp::ROWS]) {
                     try {
-                        CachedDevice device{
-                            .id = row["id"],
-                            .logicId = row["logic_id"],
-                            .moduleId = row["module_id"],
-                            .name = row["name"],
-                            .type = row["type"],
-                            .config = row["config"]
-                        };
-                        cache.setDevice(device);
+                        cache.setDevice(CachedDevice(deviceData));
                     } catch (const std::exception &e) {
                         Core::Instance().mpLogger->errorf(
                             "[DATABASE_ACTIONS] [FETCH_DEVICES_CONFIGS] Failed to parse db response: %s", e.what());

--- a/central_unit/src/core/cache.cpp
+++ b/central_unit/src/core/cache.cpp
@@ -256,6 +256,11 @@ namespace SmartHome {
         const auto iter = mModules.find(moduleId);
         if (iter == mModules.end()) return;
 
+        const auto deviceIds = getDeviceIdsForModuleUnlocked(moduleId);
+        for (const auto id: deviceIds) {
+            eraseDeviceUnlocked(id);
+        }
+
         removeFromModulesIndex(iter->second.logicAddress);
         mModules.erase(iter);
     }
@@ -323,12 +328,7 @@ namespace SmartHome {
 
     void ConfigCache::eraseDevice(const uint deviceId) {
         std::unique_lock lock(mMutex);
-
-        const auto iter = mDevices.find(deviceId);
-        if (iter == mDevices.end()) return;
-
-        removeFromDevicesIndex(iter->second.moduleId, iter->second.logicId);
-        mDevices.erase(iter);
+        eraseDeviceUnlocked(deviceId);
     }
 
     std::optional<uint> ConfigCache::findModuleId(const uint logicAddress) const {
@@ -363,15 +363,7 @@ namespace SmartHome {
 
     std::vector<uint> ConfigCache::getDeviceIdsForModule(const uint moduleId) const {
         std::shared_lock lock(mMutex);
-
-        std::vector<uint> deviceIds;
-
-        for (const auto &[key, deviceId]: mDevicesIndex) {
-            if (key.first == moduleId) {
-                deviceIds.push_back(deviceId);
-            }
-        }
-        return deviceIds;
+        return getDeviceIdsForModuleUnlocked(moduleId);
     }
 
     void ConfigCache::clearModules() {
@@ -421,6 +413,24 @@ namespace SmartHome {
         mDevicesIndex.erase({moduleId, logicId});
     }
 
+    std::vector<uint> ConfigCache::getDeviceIdsForModuleUnlocked(const uint moduleId) const {
+        std::vector<uint> deviceIds;
+
+        for (const auto &[key, deviceId]: mDevicesIndex) {
+            if (key.first == moduleId) {
+                deviceIds.push_back(deviceId);
+            }
+        }
+        return deviceIds;
+    }
+
+    void ConfigCache::eraseDeviceUnlocked(const uint deviceId) {
+        const auto iter = mDevices.find(deviceId);
+        if (iter == mDevices.end()) return;
+
+        removeFromDevicesIndex(iter->second.moduleId, iter->second.logicId);
+        mDevices.erase(iter);
+    }
 
     ReadingsCache::ReadingsCache(const ConfigCache &configCache) : mConfigCache(configCache) {
     }

--- a/central_unit/src/core/cache.cpp
+++ b/central_unit/src/core/cache.cpp
@@ -173,6 +173,13 @@ namespace SmartHome {
         return json;
     }
 
+    CachedReading::CachedReading(const uint deviceId,
+                                 nlohmann::json value,
+                                 const std::chrono::system_clock::time_point timestamp,
+                                 nlohmann::json metadata)
+        : deviceId(deviceId), value(std::move(value)), timestamp(timestamp), metadata(std::move(metadata)) {
+    }
+
     nlohmann::json CachedReading::to_json() const {
         nlohmann::json json;
         json[cdbi::DEVICE_ID] = deviceId;
@@ -438,8 +445,8 @@ namespace SmartHome {
         return device;
     }
 
-
-    ReadingsCache::ReadingsCache(const ConfigCache &configCache) : mConfigCache(configCache) {
+    ReadingsCache::ReadingsCache(const ConfigCache &configCache, Clock clock)
+        : mConfigCache(configCache), mClock(std::move(clock)) {
     }
 
     std::optional<CachedReading> ReadingsCache::get(const uint deviceId) const {
@@ -468,7 +475,7 @@ namespace SmartHome {
         if (iter == mReadings.end()) return std::nullopt;
 
         // Copy reading before releasing lock
-        const auto reading = iter->second;
+        auto reading = iter->second;
         lock.unlock();
 
         // Check if reading is fresh based on device's TTL
@@ -490,13 +497,7 @@ namespace SmartHome {
     }
 
     void ReadingsCache::set(const uint deviceId, const nlohmann::json &value, const nlohmann::json &metadata) {
-        CachedReading reading{
-            .deviceId = deviceId,
-            .value = value,
-            .timestamp = std::chrono::system_clock::now(),
-            .metadata = metadata,
-            .stale = false
-        };
+        auto reading = CachedReading(deviceId, value, mClock(), metadata);
         std::unique_lock lock(mMutex);
         mReadings.insert_or_assign(deviceId, std::move(reading));
     }
@@ -524,8 +525,8 @@ namespace SmartHome {
         return 0s; // 0 TTL if device not found or caching disabled
     }
 
-    bool ReadingsCache::isFresh(const CachedReading &reading, const std::chrono::seconds ttl) {
-        const auto age = std::chrono::system_clock::now() - reading.timestamp;
+    bool ReadingsCache::isFresh(const CachedReading &reading, const std::chrono::seconds ttl) const {
+        const auto age = mClock() - reading.timestamp;
         return age < ttl;
     }
 }

--- a/central_unit/src/core/cache.cpp
+++ b/central_unit/src/core/cache.cpp
@@ -3,6 +3,7 @@
 #include "constants.h"
 
 #include <mutex>
+#include <utility>
 
 
 namespace SmartHome {
@@ -14,10 +15,10 @@ namespace SmartHome {
 
     CachedModule::CachedModule(const uint id,
                                const uint logicAddress,
-                               const std::string &name,
-                               const nlohmann::json &config,
+                               std::string name,
+                               nlohmann::json config,
                                const std::optional<std::chrono::system_clock::time_point> lastOnline)
-        : id(id), logicAddress(logicAddress), name(name), config(config), lastOnline(lastOnline) {
+        : id(id), logicAddress(logicAddress), name(std::move(name)), config(std::move(config)), lastOnline(lastOnline) {
     }
 
     CachedModule::CachedModule(const nlohmann::json &moduleData) {
@@ -78,10 +79,10 @@ namespace SmartHome {
     CachedDevice::CachedDevice(const uint id,
                                const uint logicId,
                                const uint moduleId,
-                               const std::string &name,
+                               std::string name,
                                const std::string &type,
-                               const nlohmann::json &config)
-        : id(id), logicId(logicId), moduleId(moduleId), name(name), type(type), config(config) {
+                               nlohmann::json config)
+        : id(id), logicId(logicId), moduleId(moduleId), name(std::move(name)), type(type), config(std::move(config)) {
         verifyTypeValue(type); // Throws if invalid
     }
 
@@ -149,7 +150,7 @@ namespace SmartHome {
     void CachedDevice::verifyTypeValue(const std::string_view type) {
         if (Constants::DeviceTypes::TYPES.contains(type)) return; // Return on valid
 
-        std::string validTypes = "";
+        std::string validTypes;
         bool isFirst = true;
         for (const auto &validType: Constants::DeviceTypes::TYPES) {
             if (!isFirst) validTypes += ", ";
@@ -431,7 +432,7 @@ namespace SmartHome {
     std::optional<CachedDevice> ConfigCache::getDeviceUnlocked(const uint deviceId, const bool isFresh) const {
         const auto iter = mDevices.find(deviceId);
         if (iter == mDevices.end()) return std::nullopt;
-        auto device = iter->second;
+        auto &device = iter->second;
 
         if (isFresh && !device.isFresh()) return std::nullopt;
         return device;

--- a/central_unit/src/core/cache.cpp
+++ b/central_unit/src/core/cache.cpp
@@ -82,6 +82,7 @@ namespace SmartHome {
                                const std::string &type,
                                const nlohmann::json &config)
         : id(id), logicId(logicId), moduleId(moduleId), name(name), type(type), config(config) {
+        verifyTypeValue(type); // Throws if invalid
     }
 
     CachedDevice::CachedDevice(const nlohmann::json &deviceData) {
@@ -116,6 +117,7 @@ namespace SmartHome {
             !deviceData[cdbi::TYPE].is_string()) {
             throw std::invalid_argument("Invalid or missing '"s + cdbi::TYPE.data() + "' field, it must be a string");
         }
+        verifyTypeValue(deviceData[cdbi::TYPE].get<std::string_view>()); // Throws if invalid
         type = deviceData[cdbi::TYPE];
 
         if (!deviceData.contains(cdbi::CONFIG) ||
@@ -142,6 +144,21 @@ namespace SmartHome {
 
     bool CachedDevice::isFresh() const {
         return !stale;
+    }
+
+    void CachedDevice::verifyTypeValue(const std::string_view type) {
+        if (Constants::DeviceTypes::TYPES.contains(type)) return; // Return on valid
+
+        std::string validTypes = "";
+        bool isFirst = true;
+        for (const auto &validType: Constants::DeviceTypes::TYPES) {
+            if (!isFirst) validTypes += ", ";
+            validTypes += validType.data();
+            isFirst = false;
+        }
+
+        throw std::invalid_argument(
+            "Invalid '"s + cdbi::TYPE.data() + "' field value, valid values: " + validTypes);
     }
 
     nlohmann::json CachedDevice::to_json() const {

--- a/central_unit/src/core/cache.cpp
+++ b/central_unit/src/core/cache.cpp
@@ -215,10 +215,12 @@ namespace SmartHome {
         if (iter == mModules.end()) return std::nullopt;
         auto &module = iter->second;
 
-        const bool result = expected == module.isFresh();
-        module.stale = !desired; // Inverses isFresh and stale logic - desired isFresh = false means module is stale
+        if (expected != module.isFresh()) return false;
 
-        return result;
+        // Inverses isFresh and stale logic - desired isFresh = false means module is stale
+        module.stale = !desired;
+
+        return true;
     }
 
 
@@ -300,10 +302,12 @@ namespace SmartHome {
         if (iter == mDevices.end()) return std::nullopt;
         auto &device = iter->second;
 
-        const bool result = expected == device.isFresh();
-        device.stale = !desired; // Inverses isFresh and stale logic - desired (isFresh) = false means module is stale
+        if (expected != device.isFresh()) return false;
 
-        return result;
+        // Inverses isFresh and stale logic - desired (isFresh) = false means module is stale
+        device.stale = !desired;
+
+        return true;
     }
 
     std::vector<CachedDevice> ConfigCache::getAllDevices() const {

--- a/central_unit/src/core/cache.cpp
+++ b/central_unit/src/core/cache.cpp
@@ -451,7 +451,7 @@ namespace SmartHome {
         if (iter == mReadings.end()) return std::nullopt;
 
         // Copy reading before releasing lock
-        const auto &reading = iter->second;
+        const auto reading = iter->second;
         lock.unlock();
 
         // Check if reading is fresh based on device's TTL

--- a/central_unit/src/core/cache.cpp
+++ b/central_unit/src/core/cache.cpp
@@ -6,9 +6,56 @@
 
 
 namespace SmartHome {
+    using namespace std::string_literals;
+
     namespace cdbi = Constants::DatabaseIdentifiers;
     namespace cdck = Constants::DeviceConfigKeys;
     namespace cc = Constants::Common;
+
+    CachedModule::CachedModule(const uint id,
+                               const uint logicAddress,
+                               const std::string &name,
+                               const nlohmann::json &config,
+                               const std::optional<std::chrono::system_clock::time_point> lastOnline)
+        : id(id), logicAddress(logicAddress), name(name), config(config), lastOnline(lastOnline) {
+    }
+
+    CachedModule::CachedModule(const nlohmann::json &moduleData) {
+        if (!moduleData.contains(cdbi::ID) ||
+            !moduleData[cdbi::ID].is_number_integer()) {
+            throw std::invalid_argument("Invalid or missing '"s + cdbi::ID.data() + "' field, it must be an integer");
+        }
+        id = moduleData[cdbi::ID];
+
+
+        if (!moduleData.contains(cdbi::LOGIC_ADDRESS) ||
+            !moduleData[cdbi::LOGIC_ADDRESS].is_number_integer()) {
+            throw std::invalid_argument(
+                "Invalid or missing '"s + cdbi::LOGIC_ADDRESS.data() + "' field, it must be an integer");
+        }
+        logicAddress = moduleData[cdbi::LOGIC_ADDRESS];
+
+        if (!moduleData.contains(cdbi::NAME) ||
+            !moduleData[cdbi::NAME].is_string()) {
+            throw std::invalid_argument("Invalid or missing '"s + cdbi::NAME.data() + "' field, it must be a string");
+        }
+        name = moduleData[cdbi::NAME];
+
+        if (!moduleData.contains(cdbi::CONFIG) ||
+            !moduleData[cdbi::CONFIG].is_object()) {
+            throw std::invalid_argument(
+                "Invalid or missing '"s + cdbi::CONFIG.data() + "' field, it must be an object");
+        }
+        config = moduleData[cdbi::CONFIG];
+
+        // LAST_ONLINE field is optional, return early if missing or null
+        if (!moduleData.contains(cdbi::LAST_ONLINE) || moduleData[cdbi::LAST_ONLINE].is_null()) return;
+
+        if (!moduleData[cdbi::LAST_ONLINE].is_string()) {
+            throw std::invalid_argument("Invalid '"s + cdbi::LAST_ONLINE.data() + "' field, it must be a string");
+        }
+        lastOnline = Utils::parseTimestampTz(moduleData[cdbi::LAST_ONLINE]);
+    }
 
     bool CachedModule::isFresh() const {
         return !stale;
@@ -26,6 +73,57 @@ namespace SmartHome {
             json[cdbi::LAST_ONLINE] = nullptr;
         }
         return json;
+    }
+
+    CachedDevice::CachedDevice(const uint id,
+                               const uint logicId,
+                               const uint moduleId,
+                               const std::string &name,
+                               const std::string &type,
+                               const nlohmann::json &config)
+        : id(id), logicId(logicId), moduleId(moduleId), name(name), type(type), config(config) {
+    }
+
+    CachedDevice::CachedDevice(const nlohmann::json &deviceData) {
+        if (!deviceData.contains(cdbi::ID) ||
+            !deviceData[cdbi::ID].is_number_integer()) {
+            throw std::invalid_argument("Invalid or missing '"s + cdbi::ID.data() + "' field, it must be an integer");
+        }
+        id = deviceData[cdbi::ID];
+
+
+        if (!deviceData.contains(cdbi::LOGIC_ID) ||
+            !deviceData[cdbi::LOGIC_ID].is_number_integer()) {
+            throw std::invalid_argument(
+                "Invalid or missing '"s + cdbi::LOGIC_ID.data() + "' field, it must be an integer");
+        }
+        logicId = deviceData[cdbi::LOGIC_ID];
+
+        if (!deviceData.contains(cdbi::MODULE_ID) ||
+            !deviceData[cdbi::MODULE_ID].is_number_integer()) {
+            throw std::invalid_argument(
+                "Invalid or missing '"s + cdbi::MODULE_ID.data() + "' field, it must be an integer");
+        }
+        moduleId = deviceData[cdbi::MODULE_ID];
+
+        if (!deviceData.contains(cdbi::NAME) ||
+            !deviceData[cdbi::NAME].is_string()) {
+            throw std::invalid_argument("Invalid or missing '"s + cdbi::NAME.data() + "' field, it must be a string");
+        }
+        name = deviceData[cdbi::NAME];
+
+        if (!deviceData.contains(cdbi::TYPE) ||
+            !deviceData[cdbi::TYPE].is_string()) {
+            throw std::invalid_argument("Invalid or missing '"s + cdbi::TYPE.data() + "' field, it must be a string");
+        }
+        type = deviceData[cdbi::TYPE];
+
+        if (!deviceData.contains(cdbi::CONFIG) ||
+            !deviceData[cdbi::CONFIG].is_object()) {
+            throw std::invalid_argument(
+                "Invalid or missing '"s + cdbi::CONFIG.data() + "' field, it must be an object");
+        }
+        config = deviceData[cdbi::CONFIG];
     }
 
     bool CachedDevice::useCache() const {

--- a/central_unit/src/core/cache.cpp
+++ b/central_unit/src/core/cache.cpp
@@ -236,12 +236,14 @@ namespace SmartHome {
     }
 
     std::vector<CachedDevice> ConfigCache::getModuleDevices(const uint moduleId) const {
-        const auto devicesIds = getDeviceIdsForModule(moduleId);
+        std::shared_lock lock(mMutex);
+
+        const auto devicesIds = getDeviceIdsForModuleUnlocked(moduleId);
 
         std::vector<CachedDevice> devices;
         devices.reserve(devicesIds.size());
         for (const auto deviceId: devicesIds) {
-            const auto deviceOpt = getDevice(deviceId);
+            const auto deviceOpt = getDeviceUnlocked(deviceId);
             if (deviceOpt.has_value()) {
                 devices.push_back(deviceOpt.value());
             }
@@ -289,13 +291,7 @@ namespace SmartHome {
 
     std::optional<CachedDevice> ConfigCache::getDevice(const uint deviceId, const bool isFresh) const {
         std::shared_lock lock(mMutex);
-
-        const auto iter = mDevices.find(deviceId);
-        if (iter == mDevices.end()) return std::nullopt;
-        auto device = iter->second;
-
-        if (isFresh && !device.isFresh()) return std::nullopt;
-        return device;
+        return getDeviceUnlocked(deviceId, isFresh);
     }
 
     std::optional<bool> ConfigCache::compareExchangeIsDeviceFresh(const uint deviceId,
@@ -431,6 +427,16 @@ namespace SmartHome {
         removeFromDevicesIndex(iter->second.moduleId, iter->second.logicId);
         mDevices.erase(iter);
     }
+
+    std::optional<CachedDevice> ConfigCache::getDeviceUnlocked(const uint deviceId, const bool isFresh) const {
+        const auto iter = mDevices.find(deviceId);
+        if (iter == mDevices.end()) return std::nullopt;
+        auto device = iter->second;
+
+        if (isFresh && !device.isFresh()) return std::nullopt;
+        return device;
+    }
+
 
     ReadingsCache::ReadingsCache(const ConfigCache &configCache) : mConfigCache(configCache) {
     }

--- a/central_unit/src/core/cache.cpp
+++ b/central_unit/src/core/cache.cpp
@@ -1,40 +1,45 @@
 #include "cache.h"
 #include "utils.h"
+#include "constants.h"
 
 #include <mutex>
 
 
 namespace SmartHome {
+    namespace cdbi = Constants::DatabaseIdentifiers;
+    namespace cdck = Constants::DeviceConfigKeys;
+    namespace cc = Constants::Common;
+
     bool CachedModule::isFresh() const {
         return !stale;
     }
 
     nlohmann::json CachedModule::to_json() const {
         nlohmann::json json;
-        json["id"] = id;
-        json["logic_address"] = logicAddress;
-        json["name"] = name;
-        json["config"] = config;
+        json[cdbi::ID] = id;
+        json[cdbi::LOGIC_ADDRESS] = logicAddress;
+        json[cdbi::NAME] = name;
+        json[cdbi::CONFIG] = config;
         if (lastOnline.has_value()) {
-            json["last_online"] = Utils::timePointToTimestampTz(lastOnline.value());
+            json[cdbi::LAST_ONLINE] = Utils::timePointToTimestampTz(lastOnline.value());
         } else {
-            json["last_online"] = nullptr;
+            json[cdbi::LAST_ONLINE] = nullptr;
         }
         return json;
     }
 
     bool CachedDevice::useCache() const {
-        if (config.contains("use_cache") && config["use_cache"].is_boolean()) {
-            return config["use_cache"].get<bool>();
+        if (config.contains(cdck::USE_CACHE) && config[cdck::USE_CACHE].is_boolean()) {
+            return config[cdck::USE_CACHE].get<bool>();
         }
         return true; // Default to using cache if not specified
     }
 
     std::chrono::seconds CachedDevice::cacheTTL() const {
-        if (config.contains("cache_ttl") && config["cache_ttl"].is_number_unsigned()) {
-            return std::chrono::seconds(config["cache_ttl"].get<uint64_t>());
+        if (config.contains(cdck::CACHE_TTL) && config[cdck::CACHE_TTL].is_number_unsigned()) {
+            return std::chrono::seconds(config[cdck::CACHE_TTL].get<uint64_t>());
         }
-        return 60s; // Default TTL of 60 seconds
+        return msDEFAULT_TTL;
     }
 
     bool CachedDevice::isFresh() const {
@@ -43,22 +48,22 @@ namespace SmartHome {
 
     nlohmann::json CachedDevice::to_json() const {
         nlohmann::json json;
-        json["id"] = id;
-        json["logic_id"] = logicId;
-        json["module_id"] = moduleId;
-        json["name"] = name;
-        json["type"] = type;
-        json["config"] = config;
+        json[cdbi::ID] = id;
+        json[cdbi::LOGIC_ID] = logicId;
+        json[cdbi::MODULE_ID] = moduleId;
+        json[cdbi::NAME] = name;
+        json[cdbi::TYPE] = type;
+        json[cdbi::CONFIG] = config;
         return json;
     }
 
     nlohmann::json CachedReading::to_json() const {
         nlohmann::json json;
-        json["device_id"] = deviceId;
-        json["value"] = value;
-        json["timestamp"] = Utils::timePointToTimestampTz(timestamp);
-        json["metadata"] = metadata;
-        json["stale"] = stale;
+        json[cdbi::DEVICE_ID] = deviceId;
+        json[cc::VALUE] = value;
+        json[cdbi::TIMESTAMP] = Utils::timePointToTimestampTz(timestamp);
+        json[cdbi::METADATA] = metadata;
+        json[cc::STALE] = stale;
         return json;
     }
 

--- a/central_unit/src/core/cache.h
+++ b/central_unit/src/core/cache.h
@@ -8,7 +8,6 @@
 #include <unordered_map>
 
 #include <nlohmann/json.hpp>
-#include <nlohmann/json_fwd.hpp>
 
 namespace SmartHome {
     using namespace std::chrono_literals;
@@ -40,8 +39,8 @@ namespace SmartHome {
          */
         CachedModule(uint id,
                      uint logicAddress,
-                     const std::string &name,
-                     const nlohmann::json &config,
+                     std::string name,
+                     nlohmann::json config,
                      std::optional<std::chrono::system_clock::time_point> lastOnline = std::nullopt);
 
         /**
@@ -50,6 +49,8 @@ namespace SmartHome {
          * @param moduleData
          */
         explicit CachedModule(const nlohmann::json &moduleData);
+
+        bool operator==(const CachedModule &) const = default;
 
         /**
          * @brief Check if the module configuration is up to date.
@@ -93,9 +94,9 @@ namespace SmartHome {
         CachedDevice(uint id,
                      uint logicId,
                      uint moduleId,
-                     const std::string &name,
+                     std::string name,
                      const std::string &type,
-                     const nlohmann::json &config);
+                     nlohmann::json config);
 
         /**
          * TODO !pr
@@ -103,6 +104,8 @@ namespace SmartHome {
          * @param deviceData
          */
         explicit CachedDevice(const nlohmann::json &deviceData);
+
+        bool operator==(const CachedDevice &) const = default;
 
         /**
          * @brief Check if readings for this device should be cached.

--- a/central_unit/src/core/cache.h
+++ b/central_unit/src/core/cache.h
@@ -156,6 +156,12 @@ namespace SmartHome {
         nlohmann::json metadata; ///< Optional metadata payload
         bool stale = false; ///< Indicates TTL expiration on access
 
+
+        CachedReading(uint deviceId,
+                      nlohmann::json value,
+                      std::chrono::system_clock::time_point timestamp,
+                      nlohmann::json metadata);
+
         /**
          * @brief Serialize cached reading into JSON.
          *
@@ -420,12 +426,16 @@ namespace SmartHome {
      */
     class ReadingsCache {
     public:
+        using Clock = std::function<std::chrono::system_clock::time_point()>;
+
         /**
          * @brief Construct readings cache with config cache reference.
          *
          * @param configCache Configuration cache used for TTL lookup.
+         * @param clock Time source used for freshness checks, defaults to system_clock::now().
          */
-        explicit ReadingsCache(const ConfigCache &configCache);
+        explicit ReadingsCache(const ConfigCache &configCache,
+                               Clock clock = [] { return std::chrono::system_clock::now(); });
 
         /**
          * @brief Fetch cached reading by device id.
@@ -484,6 +494,7 @@ namespace SmartHome {
         mutable std::shared_mutex mMutex;
 
         const ConfigCache &mConfigCache;
+        Clock mClock; ///< Clock used for freshness checks. Can be mocked in tests.
 
         std::unordered_map<uint, CachedReading> mReadings;
 
@@ -495,6 +506,6 @@ namespace SmartHome {
         /**
          * @brief Check if reading is within TTL window.
          */
-        [[nodiscard]] static bool isFresh(const CachedReading &reading, std::chrono::seconds ttl);
+        [[nodiscard]] bool isFresh(const CachedReading &reading, std::chrono::seconds ttl) const;
     };
 }

--- a/central_unit/src/core/cache.h
+++ b/central_unit/src/core/cache.h
@@ -133,6 +133,13 @@ namespace SmartHome {
         [[nodiscard]] nlohmann::json to_json() const;
 
     private:
+        /**
+         * TODO !pr
+         *
+         * @param type
+         */
+        static void verifyTypeValue(std::string_view type);
+
         static constexpr auto msDEFAULT_TTL = 60s;
     };
 

--- a/central_unit/src/core/cache.h
+++ b/central_unit/src/core/cache.h
@@ -85,6 +85,9 @@ namespace SmartHome {
          * @return JSON object representing device state.
          */
         nlohmann::json to_json() const;
+
+    private:
+        static constexpr auto msDEFAULT_TTL = 60s;
     };
 
     /**

--- a/central_unit/src/core/cache.h
+++ b/central_unit/src/core/cache.h
@@ -29,13 +29,13 @@ namespace SmartHome {
         bool stale = false; ///< Module object has changed, update pending
 
         /**
-         * TODO !pr
+         * @brief Construct a new Cached Module object.
          *
-         * @param id
-         * @param logicAddress
-         * @param name
-         * @param config
-         * @param lastOnline
+         * @param id Module ID.
+         * @param logicAddress Module logic address.
+         * @param name Module name.
+         * @param config Module configuration in JSON object format.
+         * @param lastOnline Optional last online timestamp.
          */
         CachedModule(uint id,
                      uint logicAddress,
@@ -44,9 +44,9 @@ namespace SmartHome {
                      std::optional<std::chrono::system_clock::time_point> lastOnline = std::nullopt);
 
         /**
-         * TODO !pr
+         * @brief Construct a new Cached Module object from JSON. Used for deserialization from DB query result.
          *
-         * @param moduleData
+         * @param moduleData Module data in JSON format. Expected keys: id, logic_address, name, config, last_online.
          */
         explicit CachedModule(const nlohmann::json &moduleData);
 
@@ -82,14 +82,16 @@ namespace SmartHome {
         bool stale = false; ///< Device object has changed, update pending
 
         /**
-         * TODO !pr
+         * @brief Construct a new Cached Device object.
          *
-         * @param id
-         * @param logicId
-         * @param moduleId
-         * @param name
-         * @param type
-         * @param config
+         * @param id Device ID.
+         * @param logicId Device logical identifier within module.
+         * @param moduleId Owning module ID.
+         * @param name Device name.
+         * @param type Device type string.
+         * @param config Device configuration in JSON object format.
+         *
+         * @throws std::invalid_argument If type is invalid.
          */
         CachedDevice(uint id,
                      uint logicId,
@@ -99,9 +101,11 @@ namespace SmartHome {
                      nlohmann::json config);
 
         /**
-         * TODO !pr
+         * @brief Construct a new Cached Device object from JSON data. Used for deserialization from DB query result.
          *
-         * @param deviceData
+         * @param deviceData Device data in JSON format. Expected fields: id, logicId, moduleId, name, type, config.
+         *
+         * @throws std::invalid_argument When required fields are missing or invalid.
          */
         explicit CachedDevice(const nlohmann::json &deviceData);
 
@@ -137,9 +141,11 @@ namespace SmartHome {
 
     private:
         /**
-         * TODO !pr
+         * @brief Verifies that device type is valid.
          *
-         * @param type
+         * @param type Type string to verify.
+         *
+         * @throws std::invalid_argument When type is not recognized.
          */
         static void verifyTypeValue(std::string_view type);
 
@@ -196,12 +202,13 @@ namespace SmartHome {
         [[nodiscard]] std::optional<CachedModule> getModule(uint moduleId, bool isFresh = false) const;
 
         /**
-         * TODO !pr
+         * @brief Compare and exchange freshness state of a module.
          *
-         * @param moduleId
-         * @param expected
-         * @param desired
-         * @return
+         * @param moduleId Module ID.
+         * @param expected Expected value.
+         * @param desired Desired value to set if current matches expected.
+         *
+         * @return \c true if exchange was successful, \c false otherwise, \c std::nullopt if module was not found.
          */
         std::optional<bool> compareExchangeIsModuleFresh(uint moduleId, bool expected, bool desired);
 
@@ -255,12 +262,13 @@ namespace SmartHome {
 
 
         /**
-         * TODO !pr
+         * @brief Atomically compare-and-exchange device freshness flag.
          *
-         * @param deviceId
-         * @param expected
-         * @param desired
-         * @return
+         * @param deviceId Device ID.
+         * @param expected Expected value.
+         * @param desired Desired value to set if current matches expected.
+         *
+         * @return \c true if exchange was successful, \c false otherwise, \c std::nullopt if device was not found.
          */
         std::optional<bool> compareExchangeIsDeviceFresh(uint deviceId, bool expected, bool desired);
 

--- a/central_unit/src/core/cache.h
+++ b/central_unit/src/core/cache.h
@@ -444,7 +444,11 @@ namespace SmartHome {
          */
         explicit ReadingsCache(const ConfigCache &configCache,
                                Clock clock = [] { return std::chrono::system_clock::now(); });
+~ReadingsCache() = default;
 
+ReadingsCache(const ReadingsCache &) = delete;
+
+ReadingsCache &operator=(const ReadingsCache &) = delete;
         /**
          * @brief Fetch cached reading by device id.
          *

--- a/central_unit/src/core/cache.h
+++ b/central_unit/src/core/cache.h
@@ -213,7 +213,7 @@ namespace SmartHome {
         [[nodiscard]] std::vector<CachedDevice> getModuleDevices(uint moduleId) const;
 
         /**
-         * @brief Remove cached module and its index entry.
+         * @brief Remove cached module, its index entry and all related devices.
          *
          * @param moduleId Module identifier.
          */
@@ -345,6 +345,8 @@ namespace SmartHome {
          * @brief Add module entry to logic address index.
          *
          * @param module Module snapshot to index.
+         *
+         * @pre Lock on \c mMutex (exclusive).
          */
         void addToModulesIndex(const CachedModule &module);
 
@@ -352,6 +354,8 @@ namespace SmartHome {
          * @brief Remove module entry from logic address index.
          *
          * @param logicAddress Logic address of the module to remove from index.
+         *
+         * @pre Lock on \c mMutex (exclusive).
          */
         void removeFromModulesIndex(uint logicAddress);
 
@@ -359,6 +363,8 @@ namespace SmartHome {
          * @brief Add device entry to module/logic index.
          *
          * @param device Device snapshot to index.
+         *
+         * @pre Lock on \c mMutex (exclusive).
          */
         void addToDevicesIndex(const CachedDevice &device);
 
@@ -367,8 +373,31 @@ namespace SmartHome {
          *
          * @param moduleId Module identifier of the device to remove from index.
          * @param logicId Logic identifier of the device to remove from index.
+         *
+         * @pre Lock on \c mMutex (exclusive).
          */
         void removeFromDevicesIndex(uint moduleId, uint logicId);
+
+        /**
+         * @brief List device ids for a given module.
+         *
+         * @param moduleId Module identifier.
+         *
+         * @return Vector of device ids.
+         *
+         * @pre Lock on \c mMutex.
+         */
+        [[nodiscard]] std::vector<uint> getDeviceIdsForModuleUnlocked(uint moduleId) const;
+
+        /**
+         * @brief Remove cached device and its index entry.
+         *
+         * @param deviceId Device identifier.
+         *
+         * @pre Lock on \c mMutex (exclusive).
+         */
+        void eraseDeviceUnlocked(uint deviceId);
+
     };
 
     /**

--- a/central_unit/src/core/cache.h
+++ b/central_unit/src/core/cache.h
@@ -398,6 +398,15 @@ namespace SmartHome {
          */
         void eraseDeviceUnlocked(uint deviceId);
 
+        /**
+         * @brief Fetch cached device by device id.
+         *
+         * @param deviceId Device identifier.
+         * @param isFresh When true, returns std::nullopt if device is stale.
+         *
+         * @return Cached device or std::nullopt if missing or stale.
+         */
+        [[nodiscard]] std::optional<CachedDevice> getDeviceUnlocked(uint deviceId, bool isFresh = false) const;
     };
 
     /**

--- a/central_unit/src/core/cache.h
+++ b/central_unit/src/core/cache.h
@@ -30,6 +30,28 @@ namespace SmartHome {
         bool stale = false; ///< Module object has changed, update pending
 
         /**
+         * TODO !pr
+         *
+         * @param id
+         * @param logicAddress
+         * @param name
+         * @param config
+         * @param lastOnline
+         */
+        CachedModule(uint id,
+                     uint logicAddress,
+                     const std::string &name,
+                     const nlohmann::json &config,
+                     std::optional<std::chrono::system_clock::time_point> lastOnline = std::nullopt);
+
+        /**
+         * TODO !pr
+         *
+         * @param moduleData
+         */
+        explicit CachedModule(const nlohmann::json &moduleData);
+
+        /**
          * @brief Check if the module configuration is up to date.
          *
          * @return true when module is not marked stale.
@@ -41,7 +63,7 @@ namespace SmartHome {
          *
          * @return JSON object representing module state.
          */
-        nlohmann::json to_json() const;
+        [[nodiscard]] nlohmann::json to_json() const;
     };
 
     /**
@@ -57,6 +79,30 @@ namespace SmartHome {
         std::string type; ///< Device type string
         nlohmann::json config; ///< Device configuration payload
         bool stale = false; ///< Device object has changed, update pending
+
+        /**
+         * TODO !pr
+         *
+         * @param id
+         * @param logicId
+         * @param moduleId
+         * @param name
+         * @param type
+         * @param config
+         */
+        CachedDevice(uint id,
+                     uint logicId,
+                     uint moduleId,
+                     const std::string &name,
+                     const std::string &type,
+                     const nlohmann::json &config);
+
+        /**
+         * TODO !pr
+         *
+         * @param deviceData
+         */
+        explicit CachedDevice(const nlohmann::json &deviceData);
 
         /**
          * @brief Check if readings for this device should be cached.
@@ -84,7 +130,7 @@ namespace SmartHome {
          *
          * @return JSON object representing device state.
          */
-        nlohmann::json to_json() const;
+        [[nodiscard]] nlohmann::json to_json() const;
 
     private:
         static constexpr auto msDEFAULT_TTL = 60s;
@@ -105,7 +151,7 @@ namespace SmartHome {
          *
          * @return JSON object representing reading state.
          */
-        nlohmann::json to_json() const;
+        [[nodiscard]] nlohmann::json to_json() const;
     };
 
     /**
@@ -133,6 +179,14 @@ namespace SmartHome {
          */
         [[nodiscard]] std::optional<CachedModule> getModule(uint moduleId, bool isFresh = false) const;
 
+        /**
+         * TODO !pr
+         *
+         * @param moduleId
+         * @param expected
+         * @param desired
+         * @return
+         */
         std::optional<bool> compareExchangeIsModuleFresh(uint moduleId, bool expected, bool desired);
 
         /**
@@ -184,6 +238,14 @@ namespace SmartHome {
         [[nodiscard]] std::optional<CachedDevice> getDevice(uint deviceId, bool isFresh = false) const;
 
 
+        /**
+         * TODO !pr
+         *
+         * @param deviceId
+         * @param expected
+         * @param desired
+         * @return
+         */
         std::optional<bool> compareExchangeIsDeviceFresh(uint deviceId, bool expected, bool desired);
 
         /**

--- a/central_unit/src/core/event_handler.h
+++ b/central_unit/src/core/event_handler.h
@@ -7,6 +7,11 @@
 
 #include <nlohmann/json.hpp>
 
+// TODO consider reworking/refactoring EventHandler and its unit tests to remove need for friend class usage.
+namespace SmartHome::Tests {
+    class EventHandlerTest;
+}
+
 namespace SmartHome {
     /**
      * @brief Reacts to device reading changes and module notifications by dispatching configured actions.
@@ -18,7 +23,7 @@ namespace SmartHome {
      * @note All public methods are thread-safe.
      */
     class EventHandler : public std::enable_shared_from_this<EventHandler> {
-        friend class EventHandlerTest;
+        friend class Tests::EventHandlerTest;
         using ActionDispatcher =
         std::function<void(std::string_view actionName, uint id, const nlohmann::json &action)>;
 
@@ -51,9 +56,10 @@ namespace SmartHome {
          * @brief Deconstruct the EventHandler instance. Stops handling new or pending events.
          */
         ~EventHandler();
-        
-        EventHandler (const EventHandler&) = delete;
-        EventHandler& operator= (const EventHandler&) = delete;
+
+        EventHandler(const EventHandler &) = delete;
+
+        EventHandler &operator=(const EventHandler &) = delete;
 
         /**
          * @brief Reload all device events and module notification rules from the config cache.

--- a/central_unit/src/db-service/CMakeLists.txt
+++ b/central_unit/src/db-service/CMakeLists.txt
@@ -22,6 +22,8 @@ set(SKIP_BUILD_TEST ON CACHE INTERNAL "")
 set(BUILD_DOC OFF CACHE INTERNAL "")
 
 FetchContent_MakeAvailable(libpqxx)
+set_target_properties(pqxx PROPERTIES FOLDER "third_party")
+
 
 # Target
 add_executable(smarthome-database

--- a/central_unit/tests/CMakeLists.txt
+++ b/central_unit/tests/CMakeLists.txt
@@ -7,10 +7,10 @@ FetchContent_Declare(googletest
         EXCLUDE_FROM_ALL)
 
 set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
-set(BUILD_GMOCK OFF CACHE BOOL "" FORCE)
+set(BUILD_GMOCK ON CACHE BOOL "" FORCE)
 
 FetchContent_MakeAvailable(googletest)
-set_target_properties(gtest gtest_main PROPERTIES FOLDER "third_party")
+set_target_properties(gtest gtest_main gmock gmock_main PROPERTIES FOLDER "third_party")
 
 include(GoogleTest)
 
@@ -34,6 +34,7 @@ function(smarthome_add_test_group GROUP)
     target_link_libraries(${GROUP}_tests
             PUBLIC
             GTest::gtest
+            GTest::gmock
             ${ARG_LIBS}
             PRIVATE
             GTest::gtest_main
@@ -62,6 +63,7 @@ set_target_properties(all_tests PROPERTIES FOLDER "tests")
 target_link_libraries(all_tests
         PUBLIC
         GTest::gtest
+        GTest::gmock
         ${all_libs}
         PRIVATE
         GTest::gtest_main

--- a/central_unit/tests/CMakeLists.txt
+++ b/central_unit/tests/CMakeLists.txt
@@ -14,4 +14,56 @@ set_target_properties(gtest gtest_main PROPERTIES FOLDER "third_party")
 
 include(GoogleTest)
 
+# Add list of tests to global all_tests target and group target
+function(smarthome_add_test_group GROUP)
+    cmake_parse_arguments(
+            ARG
+            ""
+            ""
+            "TESTS;LIBS"
+            ${ARGN}
+    )
+
+    set(sources "")
+    foreach (name IN LISTS ARG_TESTS)
+        list(APPEND sources "${CMAKE_CURRENT_SOURCE_DIR}/${name}.cpp")
+    endforeach ()
+
+    add_executable(${GROUP}_tests ${sources})
+    set_target_properties(${GROUP}_tests PROPERTIES FOLDER "tests")
+    target_link_libraries(${GROUP}_tests
+            PUBLIC
+            GTest::gtest
+            ${ARG_LIBS}
+            PRIVATE
+            GTest::gtest_main
+            project_warnings
+    )
+
+    gtest_discover_tests(${GROUP}_tests
+            TEST_PREFIX "${GROUP}."
+            PROPERTIES LABELS "${GROUP}"
+    )
+
+    set_property(GLOBAL APPEND PROPERTY SMARTHOME_TEST_SOURCES ${sources})
+    set_property(GLOBAL APPEND PROPERTY SMARTHOME_TEST_LIBS ${ARG_LIBS})
+endfunction()
+
+# Tests subdirectories
 add_subdirectory(core)
+
+
+# All tests in one target
+get_property(all_sources GLOBAL PROPERTY SMARTHOME_TEST_SOURCES)
+get_property(all_libs GLOBAL PROPERTY SMARTHOME_TEST_LIBS)
+
+add_executable(all_tests ${all_sources})
+set_target_properties(all_tests PROPERTIES FOLDER "tests")
+target_link_libraries(all_tests
+        PUBLIC
+        GTest::gtest
+        ${all_libs}
+        PRIVATE
+        GTest::gtest_main
+        project_warnings
+)

--- a/central_unit/tests/CMakeLists.txt
+++ b/central_unit/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
 set(BUILD_GMOCK OFF CACHE BOOL "" FORCE)
 
 FetchContent_MakeAvailable(googletest)
+set_target_properties(gtest gtest_main PROPERTIES FOLDER "third_party")
 
 include(GoogleTest)
 

--- a/central_unit/tests/core/CMakeLists.txt
+++ b/central_unit/tests/core/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(test_names
         event_handler_test
         config_cache_test
+        readings_cache_test
 )
 
 smarthome_add_test_group(core TESTS ${test_names} LIBS smarthome::core_lib)

--- a/central_unit/tests/core/CMakeLists.txt
+++ b/central_unit/tests/core/CMakeLists.txt
@@ -1,8 +1,5 @@
-add_executable(event_handler_test event_handler_test.cpp)
+set(test_names
+        event_handler_test
+)
 
-target_link_libraries(event_handler_test PRIVATE
-        smarthome::core_lib
-        GTest::gtest_main
-        project_warnings)
-
-gtest_discover_tests(event_handler_test TEST_PREFIX "core.")
+smarthome_add_test_group(core TESTS ${test_names} LIBS smarthome::core_lib)

--- a/central_unit/tests/core/CMakeLists.txt
+++ b/central_unit/tests/core/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(test_names
         event_handler_test
+        config_cache_test
 )
 
 smarthome_add_test_group(core TESTS ${test_names} LIBS smarthome::core_lib)

--- a/central_unit/tests/core/config_cache_test.cpp
+++ b/central_unit/tests/core/config_cache_test.cpp
@@ -1,0 +1,578 @@
+#include "config_cache_test.h"
+#include "utils.h"
+
+#include <gmock/gmock.h>
+
+namespace SmartHome {
+    //region helpers
+    nlohmann::json ConfigCacheTest::validModuleConfigJson(const bool withLastOnline) {
+        nlohmann::json json = {
+            {"id", 1},
+            {"logic_address", 11},
+            {"name", "testModule"},
+            {"config", nlohmann::json::object()},
+        };
+
+        if (withLastOnline) {
+            json["last_online"] = "2026-07-15 18:15:02+02";
+        }
+        return json;
+    }
+
+    nlohmann::json ConfigCacheTest::validDeviceConfigJson() {
+        return {
+            {"id", 1},
+            {"logic_id", 11},
+            {"module_id", 2},
+            {"name", "testModule"},
+            {"type", "sensor"},
+            {
+                "config", {
+                    {"use_cache", true},
+                    {"cache_ttl", 300u}
+                }
+            },
+        };
+    }
+
+    std::vector<CachedModule> ConfigCacheTest::populateConfigCacheWithModules(const uint numberOfModules) {
+        std::vector<CachedModule> result;
+        result.reserve(numberOfModules);
+
+        auto cachedModule = CachedModule(validModuleConfigJson());
+
+        for (uint i = 0; i < numberOfModules; i++) {
+            cachedModule.id = i + 1;
+            cachedModule.logicAddress = cachedModule.id + 10;
+            mConfigCache.setModule(cachedModule);
+            result.push_back(cachedModule);
+        }
+
+        return result;
+    }
+
+    std::vector<CachedDevice> ConfigCacheTest::populateConfigCacheWithDevices(const uint numberOfDevices,
+                                                                              const uint moduleId) {
+        std::vector<CachedDevice> result;
+        result.reserve(numberOfDevices);
+
+        auto cachedDevice = CachedDevice(validDeviceConfigJson());
+
+        for (uint i = 0; i < numberOfDevices; i++) {
+            cachedDevice.id = moduleId * 10 + i + 1;
+            cachedDevice.logicId = i + 1;
+            cachedDevice.moduleId = moduleId;
+
+            mConfigCache.setDevice(cachedDevice);
+            result.push_back(cachedDevice);
+        }
+
+        return result;
+    }
+
+
+    //endregion
+
+    //region CachedModule
+    TEST_F(ConfigCacheTest, CachedModuleValidFormat) {
+        auto moduleData = validModuleConfigJson(true);
+
+        // Tests with last online
+        EXPECT_NO_THROW(CachedModule{moduleData});
+        EXPECT_NO_THROW(CachedModule(moduleData["id"],
+            moduleData["logic_address"],
+            moduleData["name"],
+            moduleData["config"],
+            SmartHome::Utils::parseTimestampTz(moduleData["last_online"])));
+
+
+        // Test with null last online
+        moduleData["last_online"] = nullptr;
+        EXPECT_NO_THROW(CachedModule{moduleData});
+
+        // Tests with no last online
+        moduleData.erase("last_online");
+        EXPECT_NO_THROW(CachedModule{moduleData});
+        EXPECT_NO_THROW(CachedModule(moduleData["id"],
+            moduleData["logic_address"],
+            moduleData["name"],
+            moduleData["config"]));
+    }
+
+    TEST_F(ConfigCacheTest, CachedModuleMissingOrWrongId) {
+        auto moduleData = validModuleConfigJson();
+
+        moduleData.erase("id");
+        EXPECT_THAT([&] { CachedModule{moduleData}; },
+                    ::testing::ThrowsMessage<std::invalid_argument>(::testing::HasSubstr("id")));
+
+        moduleData["id"] = "1";
+        EXPECT_THAT([&] { CachedModule{moduleData}; },
+                    ::testing::ThrowsMessage<std::invalid_argument>(::testing::HasSubstr("id")));
+    }
+
+    TEST_F(ConfigCacheTest, CachedModuleMissingOrWrongLogicAddress) {
+        auto moduleData = validModuleConfigJson();
+
+        moduleData.erase("logic_address");
+        EXPECT_THAT([&] { CachedModule{moduleData}; },
+                    ::testing::ThrowsMessage<std::invalid_argument>(::testing::HasSubstr("logic_address")));
+
+        moduleData["logic_address"] = "1";
+        EXPECT_THAT([&] { CachedModule{moduleData}; },
+                    ::testing::ThrowsMessage<std::invalid_argument>(::testing::HasSubstr("logic_address")));
+    }
+
+    TEST_F(ConfigCacheTest, CachedModuleMissingOrWrongName) {
+        auto moduleData = validModuleConfigJson();
+
+        moduleData.erase("name");
+        EXPECT_THAT([&] { CachedModule{moduleData}; },
+                    ::testing::ThrowsMessage<std::invalid_argument>(::testing::HasSubstr("name")));
+
+        moduleData["name"] = 1;
+        EXPECT_THAT([&] { CachedModule{moduleData}; },
+                    ::testing::ThrowsMessage<std::invalid_argument>(::testing::HasSubstr("name")));
+    }
+
+    TEST_F(ConfigCacheTest, CachedModuleMissingOrWrongConfig) {
+        auto moduleData = validModuleConfigJson();
+
+        moduleData.erase("config");
+        EXPECT_THAT([&] { CachedModule{moduleData}; },
+                    ::testing::ThrowsMessage<std::invalid_argument>(::testing::HasSubstr("config")));
+
+        moduleData["config"] = nlohmann::json::array();
+        EXPECT_THAT([&] { CachedModule{moduleData}; },
+                    ::testing::ThrowsMessage<std::invalid_argument>(::testing::HasSubstr("config")));
+    }
+
+    TEST_F(ConfigCacheTest, CachedModuleWrongLastOnline) {
+        auto moduleData = validModuleConfigJson(true);
+
+        moduleData["last_online"] = 123456789;
+        EXPECT_THAT([&] { CachedModule{moduleData}; },
+                    ::testing::ThrowsMessage<std::invalid_argument>(::testing::HasSubstr("last_online")));
+    }
+
+    TEST_F(ConfigCacheTest, CachedModuleToJSON) {
+        auto jsonRaw = validModuleConfigJson(true);
+        auto jsonParsed = CachedModule(jsonRaw).to_json();
+
+        auto lastOnlineRawStr = jsonRaw["last_online"].get<std::string>();
+        jsonRaw.erase("last_online");
+
+        auto lastOnlineParsedStr = jsonParsed["last_online"].get<std::string>();
+        jsonParsed.erase("last_online");
+
+        EXPECT_EQ(jsonRaw, jsonParsed); // Compare without last_online
+
+        // Parse lastOnlineRawStr before comparing
+        const auto timePoint = Utils::parseTimestampTz(lastOnlineRawStr);
+        lastOnlineRawStr = Utils::timePointToTimestampTz(timePoint);
+
+        EXPECT_EQ(lastOnlineRawStr, lastOnlineParsedStr);
+    }
+
+    TEST_F(ConfigCacheTest, CachedModuleToJSONNullLastOnline) {
+        const auto json = CachedModule(validModuleConfigJson()).to_json();
+
+        ASSERT_TRUE(json.contains("last_online"));
+        EXPECT_TRUE(json["last_online"].is_null());
+    }
+
+    //endregion
+
+    //region CachedDevice
+    TEST_F(ConfigCacheTest, CachedDeviceValidFormat) {
+        auto deviceData = validDeviceConfigJson();
+
+        EXPECT_NO_THROW(CachedDevice{deviceData});
+        EXPECT_NO_THROW(CachedDevice(deviceData["id"],
+            deviceData["logic_id"],
+            deviceData["module_id"],
+            deviceData["name"],
+            deviceData["type"],
+            deviceData["config"]));
+    }
+
+    TEST_F(ConfigCacheTest, CachedDeviceMissingOrWrongId) {
+        auto deviceData = validDeviceConfigJson();
+
+        deviceData.erase("id");
+        EXPECT_THAT([&] { CachedDevice{deviceData}; },
+                    ::testing::ThrowsMessage<std::invalid_argument>(::testing::HasSubstr("id")));
+
+        deviceData["id"] = "1";
+        EXPECT_THAT([&] { CachedDevice{deviceData}; },
+                    ::testing::ThrowsMessage<std::invalid_argument>(::testing::HasSubstr("id")));
+    }
+
+    TEST_F(ConfigCacheTest, CachedDeviceMissingOrWrongLogicId) {
+        auto deviceData = validDeviceConfigJson();
+
+        deviceData.erase("logic_id");
+        EXPECT_THAT([&] { CachedDevice{deviceData}; },
+                    ::testing::ThrowsMessage<std::invalid_argument>(::testing::HasSubstr("logic_id")));
+
+        deviceData["logic_id"] = "1";
+        EXPECT_THAT([&] { CachedDevice{deviceData}; },
+                    ::testing::ThrowsMessage<std::invalid_argument>(::testing::HasSubstr("logic_id")));
+    }
+
+    TEST_F(ConfigCacheTest, CachedDeviceMissingOrWrongModuleId) {
+        auto deviceData = validDeviceConfigJson();
+
+        deviceData.erase("module_id");
+        EXPECT_THAT([&] { CachedDevice{deviceData}; },
+                    ::testing::ThrowsMessage<std::invalid_argument>(::testing::HasSubstr("module_id")));
+
+        deviceData["module_id"] = "1";
+        EXPECT_THAT([&] { CachedDevice{deviceData}; },
+                    ::testing::ThrowsMessage<std::invalid_argument>(::testing::HasSubstr("module_id")));
+    }
+
+    TEST_F(ConfigCacheTest, CachedDeviceMissingOrWrongName) {
+        auto deviceData = validDeviceConfigJson();
+
+        deviceData.erase("name");
+        EXPECT_THAT([&] { CachedDevice{deviceData}; },
+                    ::testing::ThrowsMessage<std::invalid_argument>(::testing::HasSubstr("name")));
+
+        deviceData["name"] = 1;
+        EXPECT_THAT([&] { CachedDevice{deviceData}; },
+                    ::testing::ThrowsMessage<std::invalid_argument>(::testing::HasSubstr("name")));
+    }
+
+    TEST_F(ConfigCacheTest, CachedDeviceMissingOrWrongType) {
+        auto deviceData = validDeviceConfigJson();
+
+        deviceData.erase("type");
+        EXPECT_THAT([&] { CachedDevice{deviceData}; },
+                    ::testing::ThrowsMessage<std::invalid_argument>(::testing::HasSubstr("missing 'type'")));
+
+        deviceData["type"] = 1;
+        EXPECT_THAT([&] { CachedDevice{deviceData}; },
+                    ::testing::ThrowsMessage<std::invalid_argument>(::testing::HasSubstr("Invalid or missing 'type'")));
+
+        deviceData["type"] = "invalid_type";
+        EXPECT_THAT([&] { CachedDevice{deviceData}; },
+                    ::testing::ThrowsMessage<std::invalid_argument>(::testing::HasSubstr("Invalid 'type'")));
+
+        EXPECT_THAT([&] { CachedDevice(deviceData["id"],
+                        deviceData["logic_id"],
+                        deviceData["module_id"],
+                        deviceData["name"],
+                        deviceData["type"],
+                        deviceData["config"]); },
+                    ::testing::ThrowsMessage<std::invalid_argument>(::testing::HasSubstr("Invalid 'type'")));
+    }
+
+    TEST_F(ConfigCacheTest, CachedDeviceMissingOrWrongConfig) {
+        auto deviceData = validDeviceConfigJson();
+
+        deviceData.erase("config");
+        EXPECT_THAT([&] { CachedDevice{deviceData}; },
+                    ::testing::ThrowsMessage<std::invalid_argument>(::testing::HasSubstr("config")));
+
+        deviceData["config"] = nlohmann::json::array();
+        EXPECT_THAT([&] { CachedDevice{deviceData}; },
+                    ::testing::ThrowsMessage<std::invalid_argument>(::testing::HasSubstr("config")));
+    }
+
+    TEST_F(ConfigCacheTest, CachedDeviceUseCache) {
+        auto cachedDevice = CachedDevice(validDeviceConfigJson());
+
+        EXPECT_TRUE(cachedDevice.useCache());
+
+        cachedDevice.config["use_cache"] = false;
+        EXPECT_FALSE(cachedDevice.useCache());
+
+        cachedDevice.config.erase("use_cache");
+        EXPECT_TRUE(cachedDevice.useCache());
+    }
+
+    TEST_F(ConfigCacheTest, CachedDeviceCacheTTL) {
+        auto cachedDevice = CachedDevice(validDeviceConfigJson());
+
+        EXPECT_EQ(cachedDevice.cacheTTL().count(), 300);
+
+        cachedDevice.config.erase("cache_ttl");
+        EXPECT_EQ(cachedDevice.cacheTTL().count(), 60);
+    }
+
+    TEST_F(ConfigCacheTest, CachedDeviceToJSON) {
+        const auto json = CachedDevice(validDeviceConfigJson()).to_json();
+        EXPECT_EQ(validDeviceConfigJson(), json);
+    }
+
+    //endregion
+
+    //region ConfigCache
+
+    TEST_F(ConfigCacheTest, ConfigCacheSetAndGetModule) {
+        const auto modules = populateConfigCacheWithModules(2);
+
+        EXPECT_EQ(mConfigCache.modulesSize(), 2);
+
+        EXPECT_TRUE(mConfigCache.getModule(modules[0].id).has_value());
+        EXPECT_TRUE(mConfigCache.getModule(modules[1].id).has_value());
+
+        EXPECT_EQ(modules[0], mConfigCache.getModule(modules[0].id).value());
+        EXPECT_EQ(modules[1], mConfigCache.getModule(modules[1].id).value());
+    }
+
+    TEST_F(ConfigCacheTest, ConfigCacheGetMissingModule) {
+        EXPECT_EQ(mConfigCache.getModule(1), std::nullopt);
+    }
+
+    TEST_F(ConfigCacheTest, ConfigCacheGetFreshModule) {
+        const auto modules = populateConfigCacheWithModules(2);
+
+        ASSERT_THAT(mConfigCache.compareExchangeIsModuleFresh(2, true, false), ::testing::Optional(true));
+
+        EXPECT_TRUE(mConfigCache.getModule(1, true).has_value());
+        EXPECT_FALSE(mConfigCache.getModule(2, true).has_value());
+    }
+
+    TEST_F(ConfigCacheTest, ConfigCacheCompareExchangeIsModuleFresh) {
+        populateConfigCacheWithModules(1);
+        constexpr uint moduleId = 1;
+
+        EXPECT_TRUE(mConfigCache.getModule(moduleId, true).has_value());
+        EXPECT_THAT(mConfigCache.compareExchangeIsModuleFresh(moduleId, true, false), ::testing::Optional(true));
+
+        // Successfully set as stale
+        EXPECT_FALSE(mConfigCache.getModule(moduleId, true).has_value());
+        EXPECT_THAT(mConfigCache.compareExchangeIsModuleFresh(moduleId, true, true), ::testing::Optional(false));
+
+        // Failed to set as fresh, expected value not matched
+        EXPECT_FALSE(mConfigCache.getModule(moduleId, true).has_value());
+    }
+
+    TEST_F(ConfigCacheTest, ConfigCacheCompareExchangeIsModuleFreshMissingModule) {
+        EXPECT_EQ(mConfigCache.compareExchangeIsModuleFresh( 1, true, false), std::nullopt);
+    }
+
+    TEST_F(ConfigCacheTest, ConfigCacheGetAllModules) {
+        const auto modules = populateConfigCacheWithModules(2);
+        EXPECT_THAT(mConfigCache.getAllModules(), ::testing::UnorderedElementsAreArray(modules));
+    }
+
+    TEST_F(ConfigCacheTest, ConfigCacheEraseModule) {
+        populateConfigCacheWithModules(2);
+        populateConfigCacheWithDevices(1, 1);
+        constexpr uint moduleId = 1;
+
+        EXPECT_TRUE(mConfigCache.getModule(moduleId).has_value());
+        EXPECT_EQ(mConfigCache.getModuleDevices(moduleId).size(), 1);
+
+        mConfigCache.eraseModule(moduleId);
+
+        EXPECT_EQ(mConfigCache.modulesSize(), 1);
+        EXPECT_FALSE(mConfigCache.getModule(moduleId).has_value());
+        EXPECT_THAT(mConfigCache.getModuleDevices(moduleId), ::testing::IsEmpty());
+    }
+
+    TEST_F(ConfigCacheTest, ConfigCacheUpdateModuleLastOnline) {
+        populateConfigCacheWithModules(1);
+        constexpr uint moduleId = 1;
+
+        const auto timestamp = std::chrono::system_clock::now();
+        mConfigCache.updateModuleLastOnline(moduleId, timestamp);
+
+        EXPECT_EQ(mConfigCache.getModule(moduleId).value().lastOnline, timestamp);
+    }
+
+    TEST_F(ConfigCacheTest, ConfigCacheUpdateModule) {
+        const auto modules = populateConfigCacheWithModules(1);
+
+        EXPECT_EQ(mConfigCache.modulesSize(), 1);
+
+        auto updatedCachedModule = modules[0];
+        updatedCachedModule.logicAddress += 1;
+        mConfigCache.setModule(updatedCachedModule);
+
+        EXPECT_EQ(mConfigCache.modulesSize(), 1);
+        EXPECT_EQ(mConfigCache.findModuleId(modules[0].logicAddress), std::nullopt);
+        EXPECT_EQ(mConfigCache.getModule(modules[0].id).value().logicAddress, modules[0].logicAddress + 1);
+    }
+
+    TEST_F(ConfigCacheTest, ConfigCacheGetModuleDevices) {
+        const auto modules = populateConfigCacheWithModules(3);
+        const auto module1Devices = populateConfigCacheWithDevices(2, 1);
+        const auto module3Devices = populateConfigCacheWithDevices(4, 3);
+
+        EXPECT_THAT(mConfigCache.getModuleDevices(1), ::testing::UnorderedElementsAreArray(module1Devices));
+        EXPECT_THAT(mConfigCache.getModuleDevices(3), ::testing::UnorderedElementsAreArray(module3Devices));
+
+        EXPECT_THAT(mConfigCache.getModuleDevices(2), ::testing::IsEmpty());
+        EXPECT_THAT(mConfigCache.getModuleDevices(4), ::testing::IsEmpty());
+    }
+
+    TEST_F(ConfigCacheTest, ConfigCacheGetDeviceIdsForModule) {
+        const auto modules = populateConfigCacheWithModules(1);
+        const auto devices = populateConfigCacheWithDevices(2);
+
+        EXPECT_THAT(mConfigCache.getDeviceIdsForModule(1),
+                    ::testing::UnorderedElementsAre(devices[0].id, devices[1].id));
+    }
+
+    TEST_F(ConfigCacheTest, ConfigCacheFindModuleId) {
+        const auto modules = populateConfigCacheWithModules(2);
+
+        EXPECT_EQ(mConfigCache.findModuleId(modules[1].logicAddress).value(), modules[1].id);
+    }
+
+    TEST_F(ConfigCacheTest, ConfigCacheFindModuleIdMissingModule) {
+        const auto modules = populateConfigCacheWithModules(1);
+
+        EXPECT_FALSE(mConfigCache.findModuleId(modules[0].logicAddress+1).has_value());
+    }
+
+    TEST_F(ConfigCacheTest, ConfigCacheSetAndGetDevice) {
+        populateConfigCacheWithModules(1);
+        const auto devices = populateConfigCacheWithDevices(2, 1);
+
+        EXPECT_EQ(mConfigCache.devicesSize(), 2);
+
+        EXPECT_TRUE(mConfigCache.getDevice(devices[0].id).has_value());
+        EXPECT_TRUE(mConfigCache.getDevice(devices[1].id).has_value());
+    }
+
+    TEST_F(ConfigCacheTest, ConfigCacheCompareExchangeIsDeviceFresh) {
+        populateConfigCacheWithModules(1);
+        const auto devices = populateConfigCacheWithDevices(2, 1);
+        const auto deviceId = devices[0].id;
+
+        EXPECT_TRUE(mConfigCache.getDevice(deviceId, true).has_value());
+        EXPECT_THAT(mConfigCache.compareExchangeIsDeviceFresh(deviceId, true, false), ::testing::Optional(true));
+
+        // Successfully set as stale
+        EXPECT_FALSE(mConfigCache.getDevice(deviceId, true).has_value());
+        EXPECT_THAT(mConfigCache.compareExchangeIsDeviceFresh(deviceId, true, true), ::testing::Optional(false));
+
+        // Failed to set as fresh, expected value not matched
+        EXPECT_FALSE(mConfigCache.getDevice(deviceId, true).has_value());
+    }
+
+    TEST_F(ConfigCacheTest, ConfigCacheGetMissingDevice) {
+        EXPECT_EQ(mConfigCache.getDevice(1), std::nullopt);
+    }
+
+    TEST_F(ConfigCacheTest, ConfigCacheCompareExchangeIsDeviceFreshMissingDevice) {
+        EXPECT_EQ(mConfigCache.compareExchangeIsDeviceFresh(1, true, false), std::nullopt);
+    }
+
+    TEST_F(ConfigCacheTest, ConfigCacheGetAllDevices) {
+        populateConfigCacheWithModules(3);
+        const auto devices1 = populateConfigCacheWithDevices(6, 1);
+        const auto devices2 = populateConfigCacheWithDevices(4, 2);
+        const auto devices3 = populateConfigCacheWithDevices(8, 3);
+
+        std::vector<CachedDevice> allDevices;
+        allDevices.insert(allDevices.end(), devices1.begin(), devices1.end());
+        allDevices.insert(allDevices.end(), devices2.begin(), devices2.end());
+        allDevices.insert(allDevices.end(), devices3.begin(), devices3.end());
+
+        EXPECT_EQ(mConfigCache.devicesSize(), 18);
+
+        EXPECT_THAT(allDevices, ::testing::UnorderedElementsAreArray(mConfigCache.getAllDevices()));
+    }
+
+    TEST_F(ConfigCacheTest, ConfigCacheEraseDevice) {
+        populateConfigCacheWithModules(1);
+        const auto devices = populateConfigCacheWithDevices(2, 1);
+
+        EXPECT_EQ(mConfigCache.devicesSize(), 2);
+        EXPECT_TRUE(mConfigCache.getDevice(devices[0].id).has_value());
+
+        mConfigCache.eraseDevice(devices[0].id);
+
+        EXPECT_EQ(mConfigCache.devicesSize(), 1);
+        EXPECT_FALSE(mConfigCache.getDevice(devices[0].id).has_value());
+    }
+
+    TEST_F(ConfigCacheTest, ConfigCacheUpdateDevice) {
+        const auto modules = populateConfigCacheWithModules(1);
+        const auto devices = populateConfigCacheWithDevices(2);
+
+        EXPECT_EQ(mConfigCache.devicesSize(), 2);
+
+        auto updatedCachedDevice = devices[0];
+        updatedCachedDevice.logicId += 1;
+        mConfigCache.setDevice(updatedCachedDevice);
+
+        EXPECT_EQ(mConfigCache.devicesSize(), 2);
+        EXPECT_EQ(mConfigCache.findDeviceId(1, devices[0].logicId), std::nullopt);
+        EXPECT_EQ(mConfigCache.getDevice(devices[0].id).value().logicId, devices[0].logicId + 1);
+    }
+
+    TEST_F(ConfigCacheTest, ConfigCacheFindDeviceId) {
+        const auto modules = populateConfigCacheWithModules(3);
+        const auto devices = populateConfigCacheWithDevices(3, 2);
+
+        EXPECT_THAT(mConfigCache.findDeviceId(modules[1].id, devices[1].logicId), ::testing::Optional(devices[1].id));
+    }
+
+    TEST_F(ConfigCacheTest, ConfigCacheFindDeviceIdByLogicAddress) {
+        const auto modules = populateConfigCacheWithModules(3);
+        const auto devices = populateConfigCacheWithDevices(3, 2);
+
+        EXPECT_THAT(mConfigCache.findDeviceIdByLogicAddress(modules[1].logicAddress, devices[1].logicId),
+                    ::testing::Optional(devices[1].id));
+    }
+
+    TEST_F(ConfigCacheTest, ConfigCacheFindDeviceIdMissingDevice) {
+        const auto modules = populateConfigCacheWithModules(1);
+        const auto devices = populateConfigCacheWithDevices(1);
+
+        EXPECT_EQ(mConfigCache.findDeviceId(modules[0].id, devices[0].logicId + 1), std::nullopt);
+    }
+
+    TEST_F(ConfigCacheTest, ConfigCacheFindDeviceIdByLogicAddressMissingModule) {
+        const auto modules = populateConfigCacheWithModules(1);
+        const auto devices = populateConfigCacheWithDevices(1);
+
+        EXPECT_EQ(mConfigCache.findDeviceIdByLogicAddress(modules[0].logicAddress + 1, devices[0].logicId),
+                  std::nullopt);
+    }
+
+    TEST_F(ConfigCacheTest, ConfigCacheFindDeviceIdByLogicAddressMissingDevice) {
+        const auto modules = populateConfigCacheWithModules(1);
+        const auto devices = populateConfigCacheWithDevices(1);
+
+        EXPECT_EQ(mConfigCache.findDeviceIdByLogicAddress(modules[0].logicAddress, devices[0].logicId + 1),
+                  std::nullopt);
+    }
+
+    TEST_F(ConfigCacheTest, ConfigCacheClearModules) {
+        const auto modules = populateConfigCacheWithModules(2);
+        const auto devices = populateConfigCacheWithDevices(2);
+
+        mConfigCache.clearModules();
+
+        EXPECT_EQ(mConfigCache.modulesSize(), 0);
+        EXPECT_EQ(mConfigCache.findModuleId(modules[0].logicAddress), std::nullopt);
+
+        // Devices remain untouched
+        EXPECT_EQ(mConfigCache.devicesSize(), 2);
+        EXPECT_TRUE(mConfigCache.getDevice(devices[0].id).has_value());
+    }
+
+    TEST_F(ConfigCacheTest, ConfigCacheClearDevices) {
+        const auto modules = populateConfigCacheWithModules(2);
+        const auto devices = populateConfigCacheWithDevices(2);
+
+        mConfigCache.clearDevices();
+
+        EXPECT_EQ(mConfigCache.devicesSize(), 0);
+        EXPECT_EQ(mConfigCache.findDeviceId(devices[0].moduleId, devices[0].logicId), std::nullopt);
+
+        // Modules remain untouched
+        EXPECT_EQ(mConfigCache.modulesSize(), 2);
+        EXPECT_TRUE(mConfigCache.getModule(modules[0].id).has_value());
+    }
+
+    //endregion
+}

--- a/central_unit/tests/core/config_cache_test.cpp
+++ b/central_unit/tests/core/config_cache_test.cpp
@@ -3,7 +3,7 @@
 
 #include <gmock/gmock.h>
 
-namespace SmartHome {
+namespace SmartHome::Tests {
     //region helpers
     nlohmann::json ConfigCacheTest::validModuleConfigJson(const bool withLastOnline) {
         nlohmann::json json = {

--- a/central_unit/tests/core/config_cache_test.h
+++ b/central_unit/tests/core/config_cache_test.h
@@ -1,0 +1,29 @@
+#pragma once
+#include "cache.h"
+
+#include <gtest/gtest.h>
+
+namespace SmartHome {
+    inline void PrintTo(const CachedModule &m, std::ostream *os) {
+        *os << m.to_json().dump();
+    }
+
+    inline void PrintTo(const CachedDevice &m, std::ostream *os) {
+        *os << m.to_json().dump();
+    }
+
+    class ConfigCacheTest : public ::testing::Test {
+    protected:
+        // Helpers
+
+        static nlohmann::json validModuleConfigJson(bool withLastOnline = false);
+
+        static nlohmann::json validDeviceConfigJson();
+
+        std::vector<CachedModule> populateConfigCacheWithModules(uint numberOfModules);
+
+        std::vector<CachedDevice> populateConfigCacheWithDevices(uint numberOfDevices, uint moduleId = 1);
+
+        ConfigCache mConfigCache;
+    };
+}

--- a/central_unit/tests/core/config_cache_test.h
+++ b/central_unit/tests/core/config_cache_test.h
@@ -3,7 +3,7 @@
 
 #include <gtest/gtest.h>
 
-namespace SmartHome {
+namespace SmartHome::Tests {
     inline void PrintTo(const CachedModule &m, std::ostream *os) {
         *os << m.to_json().dump();
     }

--- a/central_unit/tests/core/event_handler_test.cpp
+++ b/central_unit/tests/core/event_handler_test.cpp
@@ -87,14 +87,7 @@ namespace SmartHome {
     }
 
     void EventHandlerTest::seedDevice(const uint id, const nlohmann::json &config) {
-        CachedDevice device;
-        device.id = id;
-        device.logicId = id;
-        device.moduleId = 1;
-        device.name = "name";
-        device.type = "sensor";
-        device.config = config;
-        mConfigCache.setDevice(device);
+        mConfigCache.setDevice(CachedDevice(id, id, 1, "name", "sensor", config));
     }
 
     void EventHandlerTest::seedDeviceWithEventsField(const uint id, const nlohmann::json &eventsValue) {
@@ -137,12 +130,7 @@ namespace SmartHome {
     }
 
     void EventHandlerTest::seedModule(const uint moduleId, const uint logicAddress, const nlohmann::json &config) {
-        CachedModule module;
-        module.id = moduleId;
-        module.logicAddress = logicAddress;
-        module.name = "name";
-        module.config = config;
-        mConfigCache.setModule(module);
+        mConfigCache.setModule(CachedModule(moduleId, logicAddress, "name", config));
     }
 
     nlohmann::json EventHandlerTest::validValuesFormat(const size_t count) {

--- a/central_unit/tests/core/event_handler_test.cpp
+++ b/central_unit/tests/core/event_handler_test.cpp
@@ -1,6 +1,6 @@
 #include "event_handler_test.h"
 
-namespace SmartHome {
+namespace SmartHome::Tests {
     // Setup method for the test fixture
     void EventHandlerTest::SetUp() {
         auto logger = std::make_shared<Utils::Logger>();

--- a/central_unit/tests/core/event_handler_test.h
+++ b/central_unit/tests/core/event_handler_test.h
@@ -5,7 +5,7 @@
 #include "cache.h"
 #include "async_logger.h"
 
-namespace SmartHome {
+namespace SmartHome::Tests {
     class EventHandlerTest : public ::testing::Test {
     protected:
         struct CapturedDispatch {

--- a/central_unit/tests/core/readings_cache_test.cpp
+++ b/central_unit/tests/core/readings_cache_test.cpp
@@ -1,0 +1,153 @@
+#include "readings_cache_test.h"
+#include "utils.h"
+
+namespace SmartHome::Tests {
+    void ReadingsCacheTest::populateDevices(const uint id, bool useCache, uint cacheTTL) {
+        const auto device = CachedDevice(id, id, 1, "test", "sensor", {
+                                             {"use_cache", useCache},
+                                             {"cache_ttl", cacheTTL}
+                                         });
+
+        mConfigCache.setDevice(device);
+    }
+
+    void ReadingsCacheTest::populateReadings(const uint id, const nlohmann::json &value,
+                                             const nlohmann::json &metadata) {
+        mReadingsCache.set(id, value, metadata);
+    }
+
+    TEST_F(ReadingsCacheTest, CachedReadingToJson) {
+        constexpr uint id = 1;
+        const nlohmann::json value = 12.34;
+        const auto timestamp = std::chrono::system_clock::now();
+        const nlohmann::json metadata = {{"type", "sensor_value"}};
+
+        const auto reading = CachedReading(id, value, timestamp, metadata);
+
+        const auto readingJson = reading.to_json();
+
+        EXPECT_EQ(readingJson["device_id"], id);
+        EXPECT_EQ(readingJson["value"], value);
+        EXPECT_EQ(readingJson["timestamp"], Utils::timePointToTimestampTz(timestamp));
+        EXPECT_EQ(readingJson["metadata"], metadata);
+        EXPECT_FALSE(readingJson["stale"]);
+    }
+
+    TEST_F(ReadingsCacheTest, ReadingsCacheSetAndGetReading) {
+        populateDevices();
+        populateReadings(1, 12.34, {{"type", "sensor_value"}});
+
+        const auto cachedReading = mReadingsCache.get(1);
+
+        ASSERT_TRUE(cachedReading.has_value());
+
+        EXPECT_EQ(cachedReading.value().value, 12.34);
+        EXPECT_EQ(cachedReading.value().metadata, nlohmann::json({{"type", "sensor_value"}}));
+        EXPECT_FALSE(cachedReading.value().stale);
+    }
+
+    TEST_F(ReadingsCacheTest, ReadingsCacheGetMissingReading) {
+        populateReadings(1);
+
+        ASSERT_EQ(mReadingsCache.size(), 1);
+        const auto cachedReading = mReadingsCache.get(2);
+
+        EXPECT_FALSE(cachedReading.has_value());
+    }
+
+    TEST_F(ReadingsCacheTest, ReadingsCacheEraseReading) {
+        populateReadings();
+        EXPECT_TRUE( mReadingsCache.get(1).has_value());
+
+        mReadingsCache.erase(1);
+        EXPECT_FALSE(mReadingsCache.get(1).has_value());
+    }
+
+    TEST_F(ReadingsCacheTest, ReadingsCacheClearReadings) {
+        populateReadings(1);
+        populateReadings(2);
+        populateReadings(3);
+
+        EXPECT_EQ(mReadingsCache.size(), 3);
+
+        mReadingsCache.clear();
+        EXPECT_EQ(mReadingsCache.size(), 0);
+    }
+
+    TEST_F(ReadingsCacheTest, ReadingsCacheOverrideReading) {
+        populateReadings(1, 12.34);
+        EXPECT_EQ(mReadingsCache.get(1).value().value, 12.34);
+
+        populateReadings(1, 0);
+        EXPECT_EQ(mReadingsCache.get(1).value().value, 0);
+    }
+
+    TEST_F(ReadingsCacheTest, ReadingsCacheGetFreshReading) {
+        populateDevices();
+        populateReadings();
+
+        EXPECT_TRUE(mReadingsCache.getFresh(1).has_value());
+    }
+
+    TEST_F(ReadingsCacheTest, ReadingsCacheGetFreshMissingReading) {
+        populateDevices();
+
+        EXPECT_FALSE(mReadingsCache.getFresh(1).has_value());
+    }
+
+    TEST_F(ReadingsCacheTest, ReadingsCacheGetFreshReadingStaleNoCache) {
+        populateDevices(1,false);
+        populateReadings();
+
+        EXPECT_FALSE(mReadingsCache.getFresh(1).has_value());
+    }
+
+    TEST_F(ReadingsCacheTest, ReadingsCacheGetFreshReadingStaleZeroTime) {
+        populateDevices(1,true, 0);
+        populateReadings();
+
+        EXPECT_FALSE(mReadingsCache.getFresh(1).has_value());
+    }
+
+    TEST_F(ReadingsCacheTest, ReadingsCacheGetFreshReadingTurnedStale) {
+        populateDevices(1,true);
+        populateReadings();
+
+        EXPECT_TRUE(mReadingsCache.getFresh(1).has_value());
+
+        mNow += 59s;
+
+        EXPECT_TRUE(mReadingsCache.getFresh(1).has_value());
+
+        mNow += 2s;
+
+        EXPECT_FALSE(mReadingsCache.getFresh(1).has_value());
+    }
+
+    TEST_F(ReadingsCacheTest, ReadingsCacheGetStaleReading) {
+        populateDevices(1, false);
+        populateReadings(1, 12.34);
+
+        const auto cachedReading = mReadingsCache.get(1);
+
+        ASSERT_TRUE(cachedReading.has_value());
+        EXPECT_TRUE(cachedReading.value().stale);
+        EXPECT_EQ(cachedReading.value().value, 12.34);
+    }
+
+    TEST_F(ReadingsCacheTest, ReadingsCacheGetFreshReadingUnknownDevice) {
+        populateReadings(1); // No device in ConfigCache
+
+        EXPECT_FALSE(mReadingsCache.getFresh(1).has_value());
+    }
+
+    TEST_F(ReadingsCacheTest, ReadingsCacheOverrideRefreshesTimestamp) {
+        populateDevices(1, true);
+        populateReadings(1);
+        mNow += 61s;
+        ASSERT_FALSE(mReadingsCache.getFresh(1).has_value());
+
+        populateReadings(1); // Overwrite resets timestamp
+        EXPECT_TRUE(mReadingsCache.getFresh(1).has_value());
+    }
+}

--- a/central_unit/tests/core/readings_cache_test.h
+++ b/central_unit/tests/core/readings_cache_test.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "cache.h"
+
+#include <gtest/gtest.h>
+
+namespace SmartHome::Tests {
+    inline void PrintTo(const CachedReading &m, std::ostream *os) {
+        *os << m.to_json().dump();
+    }
+
+    class ReadingsCacheTest : public ::testing::Test {
+    protected:
+        void populateDevices(uint id = 1, bool useCache = true, uint cacheTTL = 60);
+
+        void populateReadings(uint id = 1, const nlohmann::json &value = 12.34, const nlohmann::json &metadata = {});
+
+        // Controllable time source injected into ReadingsCache via the Clock lambda
+        std::chrono::system_clock::time_point mNow = std::chrono::system_clock::now();
+
+        ConfigCache mConfigCache;
+        ReadingsCache mReadingsCache{mConfigCache, [this] { return mNow; }};
+    };
+}


### PR DESCRIPTION
# Cache unit tests + bugfixes found while testing
## Bug fixes
- Fixed CAS logic in `CompareExchange...` methods - was not following proper compare-and-swap semantics
- Fixed `getModuleDevices` - was non-atomic
- Fixed `getFresh` - was returning/passing by reference instead of copy
- Fixed `eraseModule` - did not erase related devices, leaving orphaned device entries

## Tests
- Added unit tests for `ConfigCache` and `ReadingsCache`
- Moved test classes to `SmartHome::Tests` namespace

## CMake
- Added function to auto-register gtest targets and aggregate "all tests" target
- Added target segregation into folders (lib, third_party, tests)

## Other
- Changed cache related literals to constants
- Added cache constructors
- Added type verification in `CachedDevice`
- Added missing docstrings in cache.h