### PR TITLE
Central unit/feature/sh 222 scheduler unit tests

### DIFF
--- a/central_unit/CMakeLists.txt
+++ b/central_unit/CMakeLists.txt
@@ -11,6 +11,12 @@ if (POLICY CMP0167)
     cmake_policy(SET CMP0167 OLD)
 endif ()
 
+# Define folders for target organization
+set(LIBRARIES_TARGETS_FOLDER "Libs" CACHE STRING "Folder where libraries targets are placed")
+set(THIRD_PARTY_TARGETS_FOLDER "ThirdParty" CACHE STRING
+        "Folder where third party libraries and tools targets are placed")
+set(TESTS_TARGETS_FOLDER "Tests" CACHE STRING "Folder where tests targets are placed")
+
 # Define defaults for build variables
 set(TARGET_DEVICE "NATIVE" CACHE STRING "Target device type")
 set_property(CACHE TARGET_DEVICE PROPERTY STRINGS "NATIVE" "RPI_ZERO_2W")
@@ -145,7 +151,7 @@ target_compile_options(project_warnings INTERFACE
 )
 
 # warnings GCC only 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_compile_options(project_warnings INTERFACE
             -Wshadow=local
             -Warith-conversion
@@ -154,7 +160,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
             -Wduplicated-branches
             -Wlogical-op
     )
-endif()
+endif ()
 
 # Add subdirectories
 add_subdirectory(src/common)

--- a/central_unit/CMakeLists.txt
+++ b/central_unit/CMakeLists.txt
@@ -168,6 +168,12 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     )
 endif ()
 
+set(SMARTHOME_INCLUDE_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+# Add cmake files
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+include(smarthome_targets) # Target helpers
+
 # Add subdirectories
 add_subdirectory(src/common)
 

--- a/central_unit/CMakeLists.txt
+++ b/central_unit/CMakeLists.txt
@@ -1,11 +1,13 @@
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.28...4.3)
 project(SmartHome)
 
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD 23) # TODO delete after refactoring targets definitions using helpers
+set(CMAKE_CXX_STANDARD_REQUIRED ON) # TODO delete after refactoring targets definitions using helpers
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-
+# TODO delete after dependencies update
 # Policy for boost compatibility
 if (POLICY CMP0167)
     cmake_policy(SET CMP0167 OLD)
@@ -61,6 +63,7 @@ endif ()
 
 # Config info
 message(STATUS "==================[ Build Configuration ]=====================")
+message(STATUS "CMAKE_VERSION: ${CMAKE_VERSION}")
 message(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 message(STATUS "CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
 message(STATUS "CMAKE_SYSTEM_PROCESSOR: ${CMAKE_SYSTEM_PROCESSOR}")

--- a/central_unit/CMakeLists.txt
+++ b/central_unit/CMakeLists.txt
@@ -130,8 +130,10 @@ if (ENABLE_TSAN)
 endif ()
 
 # Additional warnings
-add_library(project_warnings INTERFACE)
-target_compile_options(project_warnings INTERFACE
+add_library(smarthome_warnings INTERFACE)
+add_library(smarthome::warnings ALIAS smarthome_warnings)
+
+target_compile_options(smarthome_warnings INTERFACE
         -Wall
         -Wextra
         -Wnon-virtual-dtor
@@ -150,9 +152,9 @@ target_compile_options(project_warnings INTERFACE
         -Wnull-dereference
 )
 
-# warnings GCC only 
+# Additional warnings GCC only
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    target_compile_options(project_warnings INTERFACE
+    target_compile_options(smarthome_warnings INTERFACE
             -Wshadow=local
             -Warith-conversion
             -Wuseless-cast

--- a/central_unit/CMakeLists.txt
+++ b/central_unit/CMakeLists.txt
@@ -104,6 +104,8 @@ if (coverage_enabled AND CMAKE_CROSSCOMPILING)
     set(coverage_enabled OFF)
 endif ()
 
+# TODO Change to library interface (similar to warnings) and add directly to targets in smarthome_targets helpers
+#      Consider same thing for sanitizers
 if (coverage_enabled)
     add_compile_options(--coverage)
     add_link_options(--coverage)

--- a/central_unit/CMakeLists.txt
+++ b/central_unit/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required(VERSION 3.28...4.3)
 project(SmartHome)
 
-set(CMAKE_CXX_STANDARD 23)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+if (MSVC)
+    message(FATAL_ERROR "MSVC not supported")
+endif ()
+
 set(CMAKE_CXX_STANDARD 23) # TODO delete after refactoring targets definitions using helpers
 set(CMAKE_CXX_STANDARD_REQUIRED ON) # TODO delete after refactoring targets definitions using helpers
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/central_unit/CMakeLists.txt
+++ b/central_unit/CMakeLists.txt
@@ -83,53 +83,52 @@ if (TARGET_DEVICE STREQUAL "RPI_ZERO_2W")
     add_compile_options(-mtune=cortex-a53)
 endif ()
 
+# Set release flags
+set(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG")
+set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     # Additional options for debuging
-    add_compile_options(
-            -O0
-            -g3
-            -DDEBUG
-    )
+    add_compile_options(-g3)
+    add_compile_definitions(DEBUG)
 else ()
     # Additional options for release optimization
-    add_compile_options(
-            -O2
-            -DNDEBUG
-            -ffunction-sections
-            -fdata-sections
-    )
-    add_link_options(-Wl,--gc-sections,-s)
+    add_compile_options(-ffunction-sections -fdata-sections)
+    add_link_options(-Wl,--gc-sections -s)
 endif ()
 
 # Enable coverage
-if (ENABLE_COVERAGE AND CMAKE_CROSSCOMPILING)
-    message(WARNING "Coverage is not enabled when cross-compiling, forcing ENABLE_COVERAGE=OFF")
-    set(ENABLE_COVERAGE OFF)
+set(coverage_enabled ${ENABLE_COVERAGE})
+if (coverage_enabled AND CMAKE_CROSSCOMPILING)
+    message(WARNING "Coverage is not enabled when cross-compiling")
+    set(coverage_enabled OFF)
 endif ()
 
-if (ENABLE_COVERAGE)
+if (coverage_enabled)
     add_compile_options(--coverage)
     add_link_options(--coverage)
 endif ()
 
+
 # Enable sanitizers
-if (ENABLE_ASAN AND ENABLE_TSAN)
+set(asan_enabled ${ENABLE_ASAN})
+set(tsan_enabled ${ENABLE_TSAN})
+if (asan_enabled AND tsan_enabled)
     message(FATAL_ERROR "ASan and TSan cannot be enabled simultaneously")
 endif ()
 
-if ((ENABLE_ASAN OR ENABLE_TSAN) AND CMAKE_CROSSCOMPILING)
-    message(WARNING "Sanitizers are not supported with cross-compilation, forcing ENABLE_ASAN=OFF and ENABLE_TSAN=OFF")
-    set(ENABLE_ASAN OFF)
-    set(ENABLE_TSAN OFF)
+if ((asan_enabled OR tsan_enabled) AND CMAKE_CROSSCOMPILING)
+    message(WARNING "Sanitizers are not supported with cross-compilation")
+    set(asan_enabled OFF)
+    set(tsan_enabled OFF)
 endif ()
 
-if (ENABLE_ASAN)
+if (asan_enabled)
     add_compile_options(-fsanitize=address,undefined -fno-omit-frame-pointer)
     add_link_options(-fsanitize=address,undefined)
 endif ()
 
-if (ENABLE_TSAN)
+if (tsan_enabled)
     add_compile_options(-fsanitize=thread -fno-omit-frame-pointer)
     add_link_options(-fsanitize=thread)
 endif ()
@@ -197,12 +196,13 @@ if (BUILD_GUI)
 endif ()
 
 # Add tests
-if (BUILD_TESTS AND CMAKE_CROSSCOMPILING)
-    message(WARNING "Tests are not built when cross-compiling, forcing BUILD_TESTS=OFF")
-    set(BUILD_TESTS OFF)
+set(build_test_enabled ${BUILD_TESTS})
+if (build_test_enabled AND CMAKE_CROSSCOMPILING)
+    message(WARNING "Tests are not built when cross-compiling")
+    set(build_test_enabled OFF)
 endif ()
 
-if (BUILD_TESTS)
+if (build_test_enabled)
     enable_testing()
     add_subdirectory(tests)
 endif ()

--- a/central_unit/CMakePresets.json
+++ b/central_unit/CMakePresets.json
@@ -17,6 +17,13 @@
       }
     },
     {
+      "name": "native_debug_verify",
+      "inherits": "native_debug",
+      "cacheVariables": {
+        "CMAKE_VERIFY_INTERFACE_HEADER_SETS": "ON"
+      }
+    },
+    {
       "name": "native_debug_coverage",
       "inherits": "native_debug",
       "cacheVariables": {

--- a/central_unit/cmake/smarthome_targets.cmake
+++ b/central_unit/cmake/smarthome_targets.cmake
@@ -1,0 +1,111 @@
+include_guard(GLOBAL)
+
+# Finalize a target by setting its compile features and linking to the warnings library.
+function(_smarthome_finalize target scope folder)
+    target_compile_features(${target} ${scope} cxx_std_23)
+    if (scope STREQUAL "PUBLIC")
+        target_link_libraries(${target} PRIVATE smarthome::warnings)
+    endif ()
+    if (NOT folder STREQUAL "")
+        set_target_properties(${target} PROPERTIES FOLDER "${folder}")
+    endif ()
+endfunction()
+
+
+# Create libaray target.
+# Header paths seen by consumers are relative to the include root (src directory),
+# e.g. #include "common/logger/logger.h"
+function(smarthome_add_library name)
+    if (NOT DEFINED SMARTHOME_INCLUDE_ROOT)
+        message(FATAL_ERROR "smarthome_add_library(${name}): SMARTHOME_INCLUDE_ROOT is not set "
+                "for ${CMAKE_CURRENT_SOURCE_DIR}")
+    endif ()
+
+    cmake_parse_arguments(PARSE_ARGV 1 ARG "" "FOLDER"
+            "SOURCES;HEADERS;PRIVATE_HEADERS;PUBLIC_DEPS;PRIVATE_DEPS")
+
+    if (ARG_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "smarthome_add_library(${name}): unexpected arguments: "
+                "${ARG_UNPARSED_ARGUMENTS}")
+    endif ()
+    if (ARG_KEYWORDS_MISSING_VALUES)
+        message(FATAL_ERROR "smarthome_add_library(${name}): keywords without values: "
+                "${ARG_KEYWORDS_MISSING_VALUES}")
+    endif ()
+    if (NOT ARG_HEADERS)
+        message(FATAL_ERROR "smarthome_add_library(${name}): missing HEADERS")
+    endif ()
+
+    set(target smarthome_${name})
+
+    # Add library with sources or header only library as interface
+    if (ARG_SOURCES)
+        add_library(${target} ${ARG_SOURCES})
+        set(scope PUBLIC)
+    else ()
+        foreach (bad_argument IN ITEMS PRIVATE_DEPS PRIVATE_HEADERS)
+            if (ARG_${bad_argument})
+                message(FATAL_ERROR "smarthome_add_library(${name}): ${bad_argument} is not allowed "
+                        "for a header-only library (no SOURCES given)")
+            endif ()
+        endforeach ()
+        add_library(${target} INTERFACE)
+        set(scope INTERFACE)
+    endif ()
+
+    add_library(smarthome::${name} ALIAS ${target})
+
+    # Create library targets with public and private headers
+    target_sources(${target} ${scope}
+            FILE_SET HEADERS
+            BASE_DIRS ${SMARTHOME_INCLUDE_ROOT}
+            FILES ${ARG_HEADERS}
+    )
+    if (ARG_PRIVATE_HEADERS)
+        target_sources(${target} PRIVATE
+                FILE_SET private_headers TYPE HEADERS
+                BASE_DIRS ${SMARTHOME_INCLUDE_ROOT}
+                FILES ${ARG_PRIVATE_HEADERS}
+        )
+    endif ()
+
+    # Link dependencies
+    if (ARG_PUBLIC_DEPS)
+        target_link_libraries(${target} ${scope} ${ARG_PUBLIC_DEPS})
+    endif ()
+    if (ARG_PRIVATE_DEPS)
+        target_link_libraries(${target} PRIVATE ${ARG_PRIVATE_DEPS})
+    endif ()
+
+    # Add target to defined or default folder
+    if (NOT DEFINED ARG_FOLDER)
+        set(ARG_FOLDER "${LIBRARIES_TARGETS_FOLDER}")
+    endif ()
+    _smarthome_finalize(${target} ${scope} "${ARG_FOLDER}")
+endfunction()
+
+
+# Create executable target.
+function(smarthome_add_executable name)
+    cmake_parse_arguments(PARSE_ARGV 1 ARG "" "FOLDER" "SOURCES;DEPS")
+
+    if (ARG_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "smarthome_add_executable(${name}): unexpected arguments: "
+                "${ARG_UNPARSED_ARGUMENTS}")
+    endif ()
+    if (ARG_KEYWORDS_MISSING_VALUES)
+        message(FATAL_ERROR "smarthome_add_executable(${name}): keywords without values: "
+                "${ARG_KEYWORDS_MISSING_VALUES}")
+    endif ()
+    if (NOT ARG_SOURCES)
+        message(FATAL_ERROR "smarthome_add_executable(${name}): missing SOURCES")
+    endif ()
+
+    # Create executable target and link dependencies
+    add_executable(${name} ${ARG_SOURCES})
+    if (ARG_DEPS)
+        target_link_libraries(${name} PRIVATE ${ARG_DEPS})
+    endif ()
+
+    _smarthome_finalize(${name} PUBLIC "${ARG_FOLDER}")
+endfunction()

--- a/central_unit/src/cli/CMakeLists.txt
+++ b/central_unit/src/cli/CMakeLists.txt
@@ -10,6 +10,6 @@ add_executable(smarthomectl
 target_link_libraries(smarthomectl PRIVATE
         smarthome::ipc
         smarthome::logger
+        smarthome::warnings
         Boost::program_options
-        project_warnings
 )

--- a/central_unit/src/common/CMakeLists.txt
+++ b/central_unit/src/common/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package(ZLIB REQUIRED)
 FetchContent_Declare(
         yaml-cpp
         GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
-        GIT_TAG c9371de
+        GIT_TAG yaml-cpp-0.9.0
         GIT_SHALLOW ON
         SYSTEM
         EXCLUDE_FROM_ALL

--- a/central_unit/src/common/CMakeLists.txt
+++ b/central_unit/src/common/CMakeLists.txt
@@ -89,10 +89,11 @@ target_link_libraries(smarthome_ipc PRIVATE
         Boost::system
         Boost::regex
         Boost::iostreams
+        ZLIB::ZLIB
         smarthome::warnings
+        PUBLIC
         smarthome::logger
         smarthome::api
-        ZLIB::ZLIB
 )
 
 # SMARTHOME UTILITY

--- a/central_unit/src/common/CMakeLists.txt
+++ b/central_unit/src/common/CMakeLists.txt
@@ -51,7 +51,7 @@ target_include_directories(smarthome_logger PUBLIC
 
 target_link_libraries(smarthome_logger PRIVATE
         Boost::system
-        project_warnings
+        smarthome::warnings
 )
 
 # SMARTHOME API
@@ -67,7 +67,7 @@ target_include_directories(smarthome_api PUBLIC
 )
 
 target_link_libraries(smarthome_api PRIVATE
-        project_warnings
+        smarthome::warnings
 )
 
 # SMARTHOME IPC
@@ -89,10 +89,10 @@ target_link_libraries(smarthome_ipc PRIVATE
         Boost::system
         Boost::regex
         Boost::iostreams
+        smarthome::warnings
         smarthome::logger
         smarthome::api
         ZLIB::ZLIB
-        project_warnings
 )
 
 # SMARTHOME UTILITY
@@ -124,7 +124,7 @@ endif ()
 target_link_libraries(smarthome_utility
         PRIVATE
         yaml-cpp
-        project_warnings
+        smarthome::warnings
         PUBLIC
         smarthome::logger
 )

--- a/central_unit/src/common/CMakeLists.txt
+++ b/central_unit/src/common/CMakeLists.txt
@@ -1,4 +1,5 @@
 # TODO cleanup common dir (add per lib/sub-dir CMakeLists)
+# TODO consider extracting finding/fetching dependencies to separate .cmake file in cmake dir
 # Fetching yaml-cpp from github for static build
 include(FetchContent)
 
@@ -33,7 +34,6 @@ if (ENABLE_SYSTEMD)
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(SYSTEMD REQUIRED IMPORTED_TARGET libsystemd)
 endif ()
-
 
 # SMARTHOME LOGGER
 add_library(smarthome_logger STATIC
@@ -137,3 +137,6 @@ add_library(smarthome::constants ALIAS smarthome_constants)
 target_include_directories(smarthome_constants INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/constants>
 )
+
+# Add subdirectories
+add_subdirectory(time)

--- a/central_unit/src/common/CMakeLists.txt
+++ b/central_unit/src/common/CMakeLists.txt
@@ -1,3 +1,4 @@
+# TODO cleanup common dir (add per lib/sub-dir CMakeLists)
 # Fetching yaml-cpp from github for static build
 include(FetchContent)
 
@@ -18,6 +19,7 @@ set(YAML_BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
 set(YAML_CPP_INSTALL OFF CACHE BOOL "" FORCE)
 
 FetchContent_MakeAvailable(yaml-cpp)
+set_target_properties(yaml-cpp PROPERTIES FOLDER "${THIRD_PARTY_TARGETS_FOLDER}")
 
 # Boost required
 find_package(Boost 1.74 REQUIRED COMPONENTS
@@ -38,7 +40,7 @@ add_library(smarthome_logger STATIC
         logger/logger.cpp
         logger/async_logger.cpp
 )
-set_target_properties(smarthome_logger PROPERTIES FOLDER "lib")
+set_target_properties(smarthome_logger PROPERTIES FOLDER "${LIBRARIES_TARGETS_FOLDER}")
 
 
 add_library(smarthome::logger ALIAS smarthome_logger)
@@ -56,7 +58,7 @@ target_link_libraries(smarthome_logger PRIVATE
 add_library(smarthome_api STATIC
         api/api.cpp
 )
-set_target_properties(smarthome_api PROPERTIES FOLDER "lib")
+set_target_properties(smarthome_api PROPERTIES FOLDER "${LIBRARIES_TARGETS_FOLDER}")
 
 add_library(smarthome::api ALIAS smarthome_api)
 
@@ -75,7 +77,7 @@ add_library(smarthome_ipc STATIC
         ipc/socket_server_connection.cpp
         ipc/socket_server.cpp
 )
-set_target_properties(smarthome_ipc PROPERTIES FOLDER "lib")
+set_target_properties(smarthome_ipc PROPERTIES FOLDER "${LIBRARIES_TARGETS_FOLDER}")
 
 add_library(smarthome::ipc ALIAS smarthome_ipc)
 
@@ -101,7 +103,7 @@ add_library(smarthome_utility STATIC
         utils/service_manager/standalone_service.cpp
         utils/service_manager/systemd_service.cpp
 )
-set_target_properties(smarthome_utility PROPERTIES FOLDER "lib")
+set_target_properties(smarthome_utility PROPERTIES FOLDER "${LIBRARIES_TARGETS_FOLDER}")
 
 
 add_library(smarthome::utility ALIAS smarthome_utility)

--- a/central_unit/src/common/constants/constants.h
+++ b/central_unit/src/common/constants/constants.h
@@ -293,6 +293,7 @@ namespace SmartHome::Constants {
     namespace AutomatedActionNames {
         inline constexpr std::string_view MODULE_NOTIFICATION = "Module notification";
         inline constexpr std::string_view CONDITIONAL_EVENT  = "Conditional event";
+        inline constexpr std::string_view SCHEDULED_ACTION  = "Scheduled action";
     }
 
     // Utility functions

--- a/central_unit/src/common/time/CMakeLists.txt
+++ b/central_unit/src/common/time/CMakeLists.txt
@@ -1,0 +1,13 @@
+smarthome_add_library(time
+        HEADERS time_provider.h
+)
+
+smarthome_add_library(time_asio
+        HEADERS asio_time_provider.h
+        PUBLIC_DEPS smarthome::time Boost::headers Boost::system
+)
+
+smarthome_add_library(time_testing
+        HEADERS testing/fake_time_provider.h
+        PUBLIC_DEPS smarthome::time
+)

--- a/central_unit/src/common/time/asio_time_provider.h
+++ b/central_unit/src/common/time/asio_time_provider.h
@@ -1,0 +1,159 @@
+#pragma once
+#include "common/time/time_provider.h"
+
+#include <boost/asio/any_io_executor.hpp>
+#include <boost/asio/system_timer.hpp>
+#include <boost/asio/steady_timer.hpp>
+#include <utility>
+
+namespace SmartHome::Time {
+    /**
+     * @brief ITimeProvider implementation backed by real clocks and Boost.Asio timers.
+     */
+    class AsioTimeProvider final : public ITimeProvider {
+    public:
+        /**
+         * @brief Construct provider bound to an \c any_io_executor used by all created timers.
+         *
+         * @note The \c any_io_executor must outlive the provider and every timer it creates.
+         */
+        explicit AsioTimeProvider(boost::asio::any_io_executor executor)
+            : mExecutor(std::move(executor)) {
+        }
+
+        /**
+         * @brief Current wall-clock time.
+         *
+         * @return Current time according to the system clock.
+         */
+        [[nodiscard]] std::chrono::system_clock::time_point now() const override {
+            return std::chrono::system_clock::now();
+        }
+
+        /**
+         * @brief Current monotonic time (for elapsed-time measurements).
+         *
+         * @return Current time according to the steady clock.
+         */
+        [[nodiscard]] std::chrono::steady_clock::time_point steadyNow() const override {
+            return std::chrono::steady_clock::now();
+        }
+
+        /**
+         * @brief Create an absolute (wall-clock) timer.
+         *
+         * @return A new absolute timer instance bound to the provider's \c any_io_executor.
+         */
+        [[nodiscard]] std::unique_ptr<ITimer> createTimer() override {
+            return std::make_unique<AsioTimer>(mExecutor);
+        }
+
+        /**
+         * @brief Create a relative (monotonic) timer.
+         *
+         * @return A new relative timer instance bound to the provider's \c any_io_executor.
+         */
+        [[nodiscard]] std::unique_ptr<ISteadyTimer> createSteadyTimer() override {
+            return std::make_unique<AsioSteadyTimer>(mExecutor);
+        }
+
+    private:
+        /**
+         * @brief Thin adapter over \c ba::system_timer.
+         */
+        class AsioTimer final : public ITimer {
+        public:
+            /**
+             * @brief Construct a new \c AsioTimer object.
+             *
+             * @param executor The \c any_io_executor to which the timer is bound.
+             */
+            explicit AsioTimer(const boost::asio::any_io_executor &executor)
+                : mTimer(executor) {
+            }
+
+            /**
+             * @brief Set expiry time.
+             *
+             * @param timePoint The time point at which the timer should expire.
+             *
+             * @note Re-arming a timer with a pending wait cancels it: the pending handler
+             *       is invoked with \c std::errc::operation_canceled (matching Asio semantics).
+             */
+            void expiresAt(const std::chrono::system_clock::time_point timePoint) override {
+                mTimer.expires_at(timePoint);
+            }
+
+            /**
+             * @brief Register a one-shot handler invoked on expiry or cancellation.
+             *
+             * @param handler The handler to invoke when the timer expires.
+             */
+            void asyncWait(TimerHandler handler) override {
+                mTimer.async_wait([handler = std::move(handler)](const ::boost::system::error_code &ec) {
+                    handler(ec);
+                });
+            }
+
+            /**
+             * @brief Cancel pending wait, its handler is invoked with \c std::errc::operation_canceled.
+             */
+            void cancel() override {
+                mTimer.cancel();
+            }
+
+        private:
+            boost::asio::system_timer mTimer;
+        };
+
+        /**
+         * @brief Thin adapter over \c ba::steady_timer.
+         */
+        class AsioSteadyTimer final : public ISteadyTimer {
+        public:
+            /**
+             * @brief Construct a new \c AsioSteadyTimer object.
+             *
+             * @param executor The \c any_io_executor to which the timer is bound.
+             */
+            explicit AsioSteadyTimer(const boost::asio::any_io_executor &executor)
+                : mTimer(executor) {
+            }
+
+            /**
+             * @brief Set expiry relative to now.
+             *
+             * @param delta The duration after which the timer should expire.
+             *
+             * @note Re-arming a timer with a pending wait cancels it: the pending handler
+             *       is invoked with \c std::errc::operation_canceled (matching Asio semantics).
+             */
+            void expiresAfter(const std::chrono::steady_clock::duration delta) override {
+                mTimer.expires_after(delta);
+            }
+
+            /**
+             * @brief Register a one-shot handler invoked on expiry or cancellation.
+             *
+             * @param handler The handler to invoke when the timer expires.
+             */
+            void asyncWait(TimerHandler handler) override {
+                mTimer.async_wait([handler = std::move(handler)](const ::boost::system::error_code &ec) {
+                    handler(ec);
+                });
+            }
+
+            /**
+             * @brief Cancel pending wait, its handler is invoked with \c std::errc::operation_canceled.
+             */
+            void cancel() override {
+                mTimer.cancel();
+            }
+
+        private:
+            boost::asio::steady_timer mTimer;
+        };
+
+        boost::asio::any_io_executor mExecutor;
+    };
+}

--- a/central_unit/src/common/time/testing/fake_time_provider.h
+++ b/central_unit/src/common/time/testing/fake_time_provider.h
@@ -20,18 +20,38 @@ namespace SmartHome::Time::Testing {
      */
     class FakeTimeProvider final : public ITimeProvider {
     public:
+        /**
+         * @brief Construct a new \c FakeTimeProvider object.
+         *
+         * @param start The initial clock time point.
+         */
         explicit FakeTimeProvider(const std::chrono::system_clock::time_point start)
             : mNow(start) {
         }
 
+        /**
+         * @brief Current fake wall-clock time.
+         *
+         * @return The time last set via construction or \c advanceBy() / \c advanceTo() / \c advanceSystemOnly().
+         */
         [[nodiscard]] std::chrono::system_clock::time_point now() const override {
             return mNow;
         }
 
+        /**
+         * @brief Current fake monotonic time.
+         *
+         * @return The time last set via \c advanceBy().
+         */
         [[nodiscard]] std::chrono::steady_clock::time_point steadyNow() const override {
             return mSteadyNow;
         }
 
+        /**
+         * @brief Create an absolute (wall-clock) fake timer.
+         *
+         * @return A new fake absolute timer instance tracked by this provider.
+         */
         [[nodiscard]] std::unique_ptr<ITimer> createTimer() override {
             auto state = std::make_shared<State<std::chrono::system_clock> >();
             state->pReady = mpReady;
@@ -39,6 +59,11 @@ namespace SmartHome::Time::Testing {
             return std::make_unique<FakeTimer>(std::move(state));
         }
 
+        /**
+         * @brief Create a relative (monotonic) fake timer.
+         *
+         * @return A new fake relative timer instance tracked by this provider.
+         */
         [[nodiscard]] std::unique_ptr<ISteadyTimer> createSteadyTimer() override {
             auto state = std::make_shared<State<std::chrono::steady_clock> >();
             state->pReady = mpReady;
@@ -46,19 +71,31 @@ namespace SmartHome::Time::Testing {
             return std::make_unique<FakeSteadyTimer>(*this, std::move(state));
         }
 
-        /// Advance both clocks by a delta and fire all due timers.
+        /**
+         * @brief Advance both clocks by a delta and fire all due timers.
+         *
+         * @param delta The duration to add to both the wall clock and the steady clock.
+         */
         void advanceBy(const std::chrono::nanoseconds delta) {
             mNow += delta;
             mSteadyNow += delta;
             fireDue();
         }
 
-        /// Advance both clocks so that now() == timePoint, then fire all due timers.
+        /**
+         * @brief Advance both clocks so that \c now() == timePoint, then fire all due timers.
+         *
+         * @param timePoint The wall-clock time point to advance to.
+         */
         void advanceTo(const std::chrono::system_clock::time_point timePoint) {
             advanceBy(timePoint - mNow);
         }
 
-        /// Move only the wall clock (simulates an NTP step / manual clock change).
+        /**
+         * @brief Move only the wall clock (simulates an NTP step / manual clock change).
+         *
+         * @param delta The duration to add to the wall clock.
+         */
         void advanceSystemOnly(const std::chrono::nanoseconds delta) {
             mNow += delta;
             fireDue();
@@ -89,16 +126,24 @@ namespace SmartHome::Time::Testing {
             ReadyQueuePtr pReady;
             bool alive = true; ///< false once the owning timer has been destroyed
 
+            /**
+             * @brief Register the handler to be invoked on the next expiry or cancellation.
+             */
             void arm(TimerHandler newHandler) {
                 handler = std::move(newHandler);
             }
 
-            /// Queue pending handler with operation_canceled (cancel / re-arm / destroy path).
+            /**
+             * @brief Queue pending handler with operation_canceled (cancel / re-arm / destroy path).
+             */
             void abort() {
                 if (auto pending = std::exchange(handler, nullptr))
                     pReady->emplace_back(std::move(pending), std::make_error_code(std::errc::operation_canceled));
             }
 
+            /**
+             * @brief Queue the pending handler with a success error code if expiry has passed.
+             */
             void fireIfDue(const Clock::time_point now) {
                 if (handler && expiry <= now)
                     if (auto pending = std::exchange(handler, nullptr))
@@ -106,26 +151,52 @@ namespace SmartHome::Time::Testing {
             }
         };
 
+        /**
+         * @brief Fake counterpart of \c AsioTimeProvider::AsioTimer, backed by \c State.
+         */
         class FakeTimer final : public ITimer {
         public:
+            /**
+             * @brief Construct a new \c FakeTimer object.
+             *
+             * @param state The shared state tracked by the owning provider.
+             */
             explicit FakeTimer(std::shared_ptr<State<std::chrono::system_clock> > state)
                 : mState(std::move(state)) {
             }
 
-            /// Deregisters from the provider, pending handler is queued for the next fireDue().
+            /**
+             * @brief Deregisters from the provider, pending handler is queued for the next fireDue().
+             */
             ~FakeTimer() override {
                 mState->alive = false;
             }
 
+            /**
+             * @brief Set expiry time.
+             *
+             * @param timePoint The time point at which the timer should expire.
+             *
+             * @note Re-arming a timer with a pending wait cancels it: the pending handler
+             *       is invoked with \c std::errc::operation_canceled (matching Asio semantics).
+             */
             void expiresAt(const std::chrono::system_clock::time_point timePoint) override {
                 mState->abort(); // Re-arm cancels a pending wait, as in Asio
                 mState->expiry = timePoint;
             }
 
+            /**
+             * @brief Register a one-shot handler invoked on expiry or cancellation.
+             *
+             * @param handler The handler to invoke when the timer expires.
+             */
             void asyncWait(TimerHandler handler) override {
                 mState->arm(std::move(handler));
             }
 
+            /**
+             * @brief Cancel pending wait, its handler is invoked with \c std::errc::operation_canceled.
+             */
             void cancel() override {
                 mState->abort();
             }
@@ -134,27 +205,54 @@ namespace SmartHome::Time::Testing {
             std::shared_ptr<State<std::chrono::system_clock> > mState;
         };
 
+        /**
+         * @brief Fake counterpart of \c AsioTimeProvider::AsioSteadyTimer, backed by \c State.
+         */
         class FakeSteadyTimer final : public ISteadyTimer {
         public:
+            /**
+             * @brief Construct a new \c FakeSteadyTimer object.
+             *
+             * @param parent The owning provider, whose current steady time anchors \c expiresAfter().
+             * @param state The shared state tracked by the owning provider.
+             */
             FakeSteadyTimer(FakeTimeProvider &parent,
                             std::shared_ptr<State<std::chrono::steady_clock> > state)
                 : mParent(parent), mState(std::move(state)) {
             }
 
-            /// Deregisters from the provider; pending handler is queued for the next fireDue().
+            /**
+             * @brief Deregisters from the provider; pending handler is queued for the next fireDue().
+             */
             ~FakeSteadyTimer() override {
                 mState->alive = false;
             }
 
+            /**
+             * @brief Set expiry relative to now.
+             *
+             * @param delta The duration after which the timer should expire.
+             *
+             * @note Re-arming a timer with a pending wait cancels it: the pending handler
+             *       is invoked with \c std::errc::operation_canceled (matching Asio semantics).
+             */
             void expiresAfter(const std::chrono::steady_clock::duration delta) override {
                 mState->abort(); // Re-arm cancels a pending wait, as in Asio
                 mState->expiry = mParent.mSteadyNow + delta;
             }
 
+            /**
+             * @brief Register a one-shot handler invoked on expiry or cancellation.
+             *
+             * @param handler The handler to invoke when the timer expires.
+             */
             void asyncWait(TimerHandler handler) override {
                 mState->arm(std::move(handler));
             }
 
+            /**
+             * @brief Cancel pending wait, its handler is invoked with \c std::errc::operation_canceled.
+             */
             void cancel() override {
                 mState->abort();
             }
@@ -195,7 +293,9 @@ namespace SmartHome::Time::Testing {
             drainReady();
         }
 
-        /// Invoke queued handlers until none remain, re-entrant calls find the queue empty.
+        /**
+         * @brief Invoke queued handlers until none remain, re-entrant calls find the queue empty.
+         */
         void drainReady() {
             while (!mpReady->empty()) {
                 std::vector<PendingHandler> batch;

--- a/central_unit/src/common/time/testing/fake_time_provider.h
+++ b/central_unit/src/common/time/testing/fake_time_provider.h
@@ -162,14 +162,14 @@ namespace SmartHome::Time::Testing {
              * @param state The shared state tracked by the owning provider.
              */
             explicit FakeTimer(std::shared_ptr<State<std::chrono::system_clock> > state)
-                : mState(std::move(state)) {
+                : mpState(std::move(state)) {
             }
 
             /**
              * @brief Deregisters from the provider, pending handler is queued for the next fireDue().
              */
             ~FakeTimer() override {
-                mState->alive = false;
+                mpState->alive = false;
             }
 
             FakeTimer(const FakeTimer &) = delete;
@@ -185,8 +185,8 @@ namespace SmartHome::Time::Testing {
              *       is invoked with \c std::errc::operation_canceled (matching Asio semantics).
              */
             void expiresAt(const std::chrono::system_clock::time_point timePoint) override {
-                mState->abort(); // Re-arm cancels a pending wait, as in Asio
-                mState->expiry = timePoint;
+                mpState->abort(); // Re-arm cancels a pending wait, as in Asio
+                mpState->expiry = timePoint;
             }
 
             /**
@@ -195,18 +195,18 @@ namespace SmartHome::Time::Testing {
              * @param handler The handler to invoke when the timer expires.
              */
             void asyncWait(TimerHandler handler) override {
-                mState->arm(std::move(handler));
+                mpState->arm(std::move(handler));
             }
 
             /**
              * @brief Cancel pending wait, its handler is invoked with \c std::errc::operation_canceled.
              */
             void cancel() override {
-                mState->abort();
+                mpState->abort();
             }
 
         private:
-            std::shared_ptr<State<std::chrono::system_clock> > mState;
+            std::shared_ptr<State<std::chrono::system_clock> > mpState;
         };
 
         /**
@@ -222,14 +222,14 @@ namespace SmartHome::Time::Testing {
              */
             FakeSteadyTimer(FakeTimeProvider &parent,
                             std::shared_ptr<State<std::chrono::steady_clock> > state)
-                : mParent(parent), mState(std::move(state)) {
+                : mParent(parent), mpState(std::move(state)) {
             }
 
             /**
              * @brief Deregisters from the provider; pending handler is queued for the next fireDue().
              */
             ~FakeSteadyTimer() override {
-                mState->alive = false;
+                mpState->alive = false;
             }
 
             FakeSteadyTimer(const FakeSteadyTimer &) = delete;
@@ -245,8 +245,8 @@ namespace SmartHome::Time::Testing {
              *       is invoked with \c std::errc::operation_canceled (matching Asio semantics).
              */
             void expiresAfter(const std::chrono::steady_clock::duration delta) override {
-                mState->abort(); // Re-arm cancels a pending wait, as in Asio
-                mState->expiry = mParent.mSteadyNow + delta;
+                mpState->abort(); // Re-arm cancels a pending wait, as in Asio
+                mpState->expiry = mParent.mSteadyNow + delta;
             }
 
             /**
@@ -255,19 +255,19 @@ namespace SmartHome::Time::Testing {
              * @param handler The handler to invoke when the timer expires.
              */
             void asyncWait(TimerHandler handler) override {
-                mState->arm(std::move(handler));
+                mpState->arm(std::move(handler));
             }
 
             /**
              * @brief Cancel pending wait, its handler is invoked with \c std::errc::operation_canceled.
              */
             void cancel() override {
-                mState->abort();
+                mpState->abort();
             }
 
         private:
             FakeTimeProvider &mParent;
-            std::shared_ptr<State<std::chrono::steady_clock> > mState;
+            std::shared_ptr<State<std::chrono::steady_clock> > mpState;
         };
 
         /**

--- a/central_unit/src/common/time/testing/fake_time_provider.h
+++ b/central_unit/src/common/time/testing/fake_time_provider.h
@@ -1,0 +1,215 @@
+#pragma once
+#include "common/time/time_provider.h"
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace SmartHome::Time::Testing {
+    /**
+     * @brief ITimeProvider implementation for tests: manually advanced clocks
+     *        driving both \c now() readings and timer expiry.
+     *
+     * @note Handlers never run on their own: they are queued and invoked inside
+     *       \c advance...() / \c poll(), as Asio runs them only inside \c io_context::run()/poll().
+     *       A handler queued by \c cancel() or re-arm fires on the next call, or is dropped if none follows.
+     *
+     * @note The provider must outlive every timer it creates (as \c io_context does in Asio).
+     *
+     * @note Not thread-safe.
+     */
+    class FakeTimeProvider final : public ITimeProvider {
+    public:
+        explicit FakeTimeProvider(const std::chrono::system_clock::time_point start)
+            : mNow(start) {
+        }
+
+        [[nodiscard]] std::chrono::system_clock::time_point now() const override {
+            return mNow;
+        }
+
+        [[nodiscard]] std::chrono::steady_clock::time_point steadyNow() const override {
+            return mSteadyNow;
+        }
+
+        [[nodiscard]] std::unique_ptr<ITimer> createTimer() override {
+            auto state = std::make_shared<State<std::chrono::system_clock> >();
+            state->pReady = mpReady;
+            mTimers.push_back(state);
+            return std::make_unique<FakeTimer>(std::move(state));
+        }
+
+        [[nodiscard]] std::unique_ptr<ISteadyTimer> createSteadyTimer() override {
+            auto state = std::make_shared<State<std::chrono::steady_clock> >();
+            state->pReady = mpReady;
+            mSteadyTimers.push_back(state);
+            return std::make_unique<FakeSteadyTimer>(*this, std::move(state));
+        }
+
+        /// Advance both clocks by a delta and fire all due timers.
+        void advanceBy(const std::chrono::nanoseconds delta) {
+            mNow += delta;
+            mSteadyNow += delta;
+            fireDue();
+        }
+
+        /// Advance both clocks so that now() == timePoint, then fire all due timers.
+        void advanceTo(const std::chrono::system_clock::time_point timePoint) {
+            advanceBy(timePoint - mNow);
+        }
+
+        /// Move only the wall clock (simulates an NTP step / manual clock change).
+        void advanceSystemOnly(const std::chrono::nanoseconds delta) {
+            mNow += delta;
+            fireDue();
+        }
+
+        /**
+         * @brief Fire timers already due without moving the clocks.
+         *
+         * @details Fake counterpart of \c io_context::poll(). Needed when a timer was armed
+         *          with an expiry already in the past: like Asio, the fake never invokes a
+         *          handler from inside \c asyncWait().
+         */
+        void poll() {
+            fireDue();
+        }
+
+    private:
+        using PendingHandler = std::pair<TimerHandler, std::error_code>;
+        using ReadyQueuePtr = std::shared_ptr<std::vector<PendingHandler> >;
+
+        /**
+         * @brief Shared timer state, outliving the timer object so a snapshot stays valid.
+         */
+        template<class Clock>
+        struct State {
+            Clock::time_point expiry{};
+            TimerHandler handler;
+            ReadyQueuePtr pReady;
+            bool alive = true; ///< false once the owning timer has been destroyed
+
+            void arm(TimerHandler newHandler) {
+                handler = std::move(newHandler);
+            }
+
+            /// Queue pending handler with operation_canceled (cancel / re-arm / destroy path).
+            void abort() {
+                if (auto pending = std::exchange(handler, nullptr))
+                    pReady->emplace_back(std::move(pending), std::make_error_code(std::errc::operation_canceled));
+            }
+
+            void fireIfDue(const Clock::time_point now) {
+                if (handler && expiry <= now)
+                    if (auto pending = std::exchange(handler, nullptr))
+                        pReady->emplace_back(std::move(pending), std::error_code{});
+            }
+        };
+
+        class FakeTimer final : public ITimer {
+        public:
+            explicit FakeTimer(std::shared_ptr<State<std::chrono::system_clock> > state)
+                : mState(std::move(state)) {
+            }
+
+            /// Deregisters from the provider, pending handler is queued for the next fireDue().
+            ~FakeTimer() override {
+                mState->alive = false;
+            }
+
+            void expiresAt(const std::chrono::system_clock::time_point timePoint) override {
+                mState->abort(); // Re-arm cancels a pending wait, as in Asio
+                mState->expiry = timePoint;
+            }
+
+            void asyncWait(TimerHandler handler) override {
+                mState->arm(std::move(handler));
+            }
+
+            void cancel() override {
+                mState->abort();
+            }
+
+        private:
+            std::shared_ptr<State<std::chrono::system_clock> > mState;
+        };
+
+        class FakeSteadyTimer final : public ISteadyTimer {
+        public:
+            FakeSteadyTimer(FakeTimeProvider &parent,
+                            std::shared_ptr<State<std::chrono::steady_clock> > state)
+                : mParent(parent), mState(std::move(state)) {
+            }
+
+            /// Deregisters from the provider; pending handler is queued for the next fireDue().
+            ~FakeSteadyTimer() override {
+                mState->alive = false;
+            }
+
+            void expiresAfter(const std::chrono::steady_clock::duration delta) override {
+                mState->abort(); // Re-arm cancels a pending wait, as in Asio
+                mState->expiry = mParent.mSteadyNow + delta;
+            }
+
+            void asyncWait(TimerHandler handler) override {
+                mState->arm(std::move(handler));
+            }
+
+            void cancel() override {
+                mState->abort();
+            }
+
+        private:
+            FakeTimeProvider &mParent;
+            std::shared_ptr<State<std::chrono::steady_clock> > mState;
+        };
+
+        /**
+         * @brief Queue every timer whose expiry has passed then run handlers.
+         *
+         * @details Handlers are collected first and invoked only afterwards, so none runs while
+         *          the caller of \c cancel() / \c expiresAt() may still hold a lock.
+         */
+        void fireDue() {
+            const auto timers = mTimers;
+            const auto steadyTimers = mSteadyTimers;
+
+            for (const auto &state: timers) {
+                if (state->alive) {
+                    state->fireIfDue(mNow);
+                } else {
+                    state->abort();
+                }
+            }
+            for (const auto &state: steadyTimers) {
+                if (state->alive) {
+                    state->fireIfDue(mSteadyNow);
+                } else {
+                    state->abort();
+                }
+            }
+
+            std::erase_if(mTimers, [](const auto &state) { return !state->alive; });
+            std::erase_if(mSteadyTimers, [](const auto &state) { return !state->alive; });
+
+            drainReady();
+        }
+
+        /// Invoke queued handlers until none remain, re-entrant calls find the queue empty.
+        void drainReady() {
+            while (!mpReady->empty()) {
+                std::vector<PendingHandler> batch;
+                batch.swap(*mpReady);
+                for (auto &[handler, ec]: batch) handler(ec);
+            }
+        }
+
+
+        std::chrono::system_clock::time_point mNow;
+        std::chrono::steady_clock::time_point mSteadyNow{};
+
+        std::vector<std::shared_ptr<State<std::chrono::system_clock> > > mTimers;
+        std::vector<std::shared_ptr<State<std::chrono::steady_clock> > > mSteadyTimers;
+        ReadyQueuePtr mpReady = std::make_shared<std::vector<PendingHandler> >();
+    };
+}

--- a/central_unit/src/common/time/testing/fake_time_provider.h
+++ b/central_unit/src/common/time/testing/fake_time_provider.h
@@ -172,6 +172,10 @@ namespace SmartHome::Time::Testing {
                 mState->alive = false;
             }
 
+            FakeTimer(const FakeTimer &) = delete;
+
+            FakeTimer &operator=(const FakeTimer &) = delete;
+
             /**
              * @brief Set expiry time.
              *
@@ -227,6 +231,10 @@ namespace SmartHome::Time::Testing {
             ~FakeSteadyTimer() override {
                 mState->alive = false;
             }
+
+            FakeSteadyTimer(const FakeSteadyTimer &) = delete;
+
+            FakeSteadyTimer &operator=(const FakeSteadyTimer &) = delete;
 
             /**
              * @brief Set expiry relative to now.

--- a/central_unit/src/common/time/time_provider.h
+++ b/central_unit/src/common/time/time_provider.h
@@ -1,0 +1,99 @@
+#pragma once
+#include <chrono>
+#include <functional>
+#include <memory>
+
+#include <system_error>
+
+// TODO add time zone change check and handling
+
+namespace SmartHome::Time {
+    /**
+     * @brief Handler invoked on timer expiry or cancellation.
+     *
+     * @details Receives a default-constructed error code on normal expiry, or an error code
+     *          comparing equal to \c std::errc::operation_canceled on cancellation or re-arm.
+     */
+    using TimerHandler = std::function<void(const std::error_code &)>;
+
+    /**
+     * @brief Absolute timer bound to \c std::chrono::system_clock.
+     *
+     * @details Intended for calendar-driven scheduling (RRULE, absolute deadlines).
+     */
+    struct ITimer {
+        virtual ~ITimer() = default;
+
+        /**
+         * @brief Set expiry time.
+         *
+         * @note Re-arming a timer with a pending wait cancels it: the pending handler
+         *       is invoked with \c std::errc::operation_canceled (matching Asio semantics).
+         */
+        virtual void expiresAt(std::chrono::system_clock::time_point timePoint) = 0;
+
+        /**
+         * @brief Register a one-shot handler invoked on expiry or cancellation.
+         */
+        virtual void asyncWait(TimerHandler handler) = 0;
+
+        /**
+         * @brief Cancel pending wait, its handler is invoked with \c std::errc::operation_canceled.
+         */
+        virtual void cancel() = 0;
+    };
+
+    /**
+     * @brief Relative timer bound to \c std::chrono::steady_clock.
+     *
+     * @details Intended for timeouts and retries. Immune to wall-clock jumps.
+     */
+    struct ISteadyTimer {
+        virtual ~ISteadyTimer() = default;
+
+        /**
+         * @brief Set expiry relative to now.
+         *
+         * @note Re-arming a timer with a pending wait cancels it: the pending handler
+         *       is invoked with \c std::errc::operation_canceled (matching Asio semantics).
+         */
+        virtual void expiresAfter(std::chrono::steady_clock::duration delta) = 0;
+
+        /**
+         * @brief Register a one-shot handler invoked on expiry or cancellation.
+         */
+        virtual void asyncWait(TimerHandler handler) = 0;
+
+        /**
+         * @brief Cancel pending wait, its handler is invoked with \c std::errc::operation_canceled.
+         */
+        virtual void cancel() = 0;
+    };
+
+    /**
+     * @brief Single source of truth for time: clock readings and timer factory.
+     */
+    struct ITimeProvider {
+        virtual ~ITimeProvider() = default;
+
+        /**
+         * @brief Current wall-clock time.
+         */
+        [[nodiscard]] virtual std::chrono::system_clock::time_point now() const = 0;
+
+        /**
+         * @brief Current monotonic time (for elapsed-time measurements).
+         */
+        [[nodiscard]] virtual std::chrono::steady_clock::time_point steadyNow() const = 0;
+
+        /**
+         * @brief Create an absolute (wall-clock) timer.
+         */
+        [[nodiscard]] virtual std::unique_ptr<ITimer> createTimer() = 0;
+
+        /**
+         * @brief Create a relative (monotonic) timer.
+         */
+        [[nodiscard]] virtual std::unique_ptr<ISteadyTimer> createSteadyTimer() = 0;
+    };
+}

--- a/central_unit/src/core/CMakeLists.txt
+++ b/central_unit/src/core/CMakeLists.txt
@@ -68,7 +68,7 @@ target_link_libraries(smarthome_core_lib PUBLIC
         ical
         ical_cxx
         PRIVATE
-        project_warnings
+        smarthome::warnings
 )
 
 if (ENABLE_SYSTEMD)
@@ -82,6 +82,6 @@ endif ()
 add_executable(smarthomed main.cpp)
 target_link_libraries(smarthomed PRIVATE
         smarthome::core_lib
-        Boost::program_options
-        project_warnings)
+        smarthome::warnings
+        Boost::program_options)
 

--- a/central_unit/src/core/CMakeLists.txt
+++ b/central_unit/src/core/CMakeLists.txt
@@ -30,7 +30,7 @@ set(CMAKE_DISABLE_FIND_PACKAGE_ICU ON CACHE BOOL "" FORCE)
 
 FetchContent_MakeAvailable(libical)
 set_target_properties(ical ical-header ical_cxx icalss icalss-header icalss_cxx icalvcal
-        PROPERTIES FOLDER "third_party")
+        PROPERTIES FOLDER "${THIRD_PARTY_TARGETS_FOLDER}")
 
 
 # Core library
@@ -46,7 +46,7 @@ add_library(smarthome_core_lib STATIC
         actions/mediator_actions.cpp
         actions/database_actions.cpp
 )
-set_target_properties(smarthome_core_lib PROPERTIES FOLDER "lib")
+set_target_properties(smarthome_core_lib PROPERTIES FOLDER "${LIBRARIES_TARGETS_FOLDER}")
 
 add_library(smarthome::core_lib ALIAS smarthome_core_lib)
 

--- a/central_unit/src/core/CMakeLists.txt
+++ b/central_unit/src/core/CMakeLists.txt
@@ -64,6 +64,7 @@ target_link_libraries(smarthome_core_lib PUBLIC
         smarthome::ipc
         smarthome::utility
         smarthome::constants
+        smarthome::time
         nlohmann_json::nlohmann_json
         ical
         ical_cxx
@@ -83,5 +84,6 @@ add_executable(smarthomed main.cpp)
 target_link_libraries(smarthomed PRIVATE
         smarthome::core_lib
         smarthome::warnings
+        smarthome::time_asio
         Boost::program_options)
 

--- a/central_unit/src/core/actions/action_helpers.h
+++ b/central_unit/src/core/actions/action_helpers.h
@@ -28,6 +28,9 @@ namespace SmartHome {
     template<typename T>
     using ValidationResult = std::expected<T, API::ApiError>;
 
+    using ActionDispatcher =
+    std::function<void(std::string_view actionName, uint id, const nlohmann::json &action)>;
+
     /**
      * @brief Shared utilities and command metadata for action handlers.
      *

--- a/central_unit/src/core/cache.cpp
+++ b/central_unit/src/core/cache.cpp
@@ -445,8 +445,8 @@ namespace SmartHome {
         return device;
     }
 
-    ReadingsCache::ReadingsCache(const ConfigCache &configCache, Clock clock)
-        : mConfigCache(configCache), mClock(std::move(clock)) {
+    ReadingsCache::ReadingsCache(const ConfigCache &configCache, Time::ITimeProvider &timeProvider)
+        : mConfigCache(configCache), mTimeProvider(timeProvider) {
     }
 
     std::optional<CachedReading> ReadingsCache::get(const uint deviceId) const {
@@ -497,7 +497,7 @@ namespace SmartHome {
     }
 
     void ReadingsCache::set(const uint deviceId, const nlohmann::json &value, const nlohmann::json &metadata) {
-        auto reading = CachedReading(deviceId, value, mClock(), metadata);
+        auto reading = CachedReading(deviceId, value, mTimeProvider.now(), metadata);
         std::unique_lock lock(mMutex);
         mReadings.insert_or_assign(deviceId, std::move(reading));
     }
@@ -526,7 +526,7 @@ namespace SmartHome {
     }
 
     bool ReadingsCache::isFresh(const CachedReading &reading, const std::chrono::seconds ttl) const {
-        const auto age = mClock() - reading.timestamp;
+        const auto age = mTimeProvider.now() - reading.timestamp;
         return age < ttl;
     }
 }

--- a/central_unit/src/core/cache.h
+++ b/central_unit/src/core/cache.h
@@ -444,11 +444,13 @@ namespace SmartHome {
          */
         explicit ReadingsCache(const ConfigCache &configCache,
                                Clock clock = [] { return std::chrono::system_clock::now(); });
-~ReadingsCache() = default;
 
-ReadingsCache(const ReadingsCache &) = delete;
+        ~ReadingsCache() = default;
 
-ReadingsCache &operator=(const ReadingsCache &) = delete;
+        ReadingsCache(const ReadingsCache &) = delete;
+
+        ReadingsCache &operator=(const ReadingsCache &) = delete;
+
         /**
          * @brief Fetch cached reading by device id.
          *

--- a/central_unit/src/core/cache.h
+++ b/central_unit/src/core/cache.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "common/time/time_provider.h"
 
 #include <chrono>
 #include <map>
@@ -434,16 +435,13 @@ namespace SmartHome {
      */
     class ReadingsCache {
     public:
-        using Clock = std::function<std::chrono::system_clock::time_point()>;
-
         /**
          * @brief Construct readings cache with config cache reference.
          *
          * @param configCache Configuration cache used for TTL lookup.
-         * @param clock Time source used for freshness checks, defaults to system_clock::now().
+         * @param timeProvider Time source abstraction for freshness check (injectable for testing).
          */
-        explicit ReadingsCache(const ConfigCache &configCache,
-                               Clock clock = [] { return std::chrono::system_clock::now(); });
+        explicit ReadingsCache(const ConfigCache &configCache, Time::ITimeProvider &timeProvider);
 
         ~ReadingsCache() = default;
 
@@ -508,7 +506,7 @@ namespace SmartHome {
         mutable std::shared_mutex mMutex;
 
         const ConfigCache &mConfigCache;
-        Clock mClock; ///< Clock used for freshness checks. Can be mocked in tests.
+        Time::ITimeProvider &mTimeProvider;
 
         std::unordered_map<uint, CachedReading> mReadings;
 

--- a/central_unit/src/core/core.cpp
+++ b/central_unit/src/core/core.cpp
@@ -177,7 +177,13 @@ namespace SmartHome {
             if (!mIsRunning) co_return;
 
             // Start scheduler and event handler after populating cache
-            mpScheduler = Scheduler::create(mCoreIoContext, mConfigCache, mpLogger, mTimeProvider);
+            Scheduler::Config schedulerConfig{
+                .timeProvider = mTimeProvider,
+                .configCache = mConfigCache,
+                .executor = mCoreIoContext.get_executor(),
+                .logger = mpLogger
+            };
+            mpScheduler = Scheduler::create(std::move(schedulerConfig));
             mpScheduler->loadFromCache();
             mpScheduler->start();
 

--- a/central_unit/src/core/core.cpp
+++ b/central_unit/src/core/core.cpp
@@ -177,7 +177,7 @@ namespace SmartHome {
             if (!mIsRunning) co_return;
 
             // Start scheduler and event handler after populating cache
-            mpScheduler = std::make_unique<Scheduler>(mCoreIoContext, mConfigCache, mpLogger);
+            mpScheduler = std::make_unique<Scheduler>(mCoreIoContext, mConfigCache, mpLogger, mTimeProvider);
             mpScheduler->loadFromCache();
             mpScheduler->start();
 

--- a/central_unit/src/core/core.cpp
+++ b/central_unit/src/core/core.cpp
@@ -177,7 +177,7 @@ namespace SmartHome {
             if (!mIsRunning) co_return;
 
             // Start scheduler and event handler after populating cache
-            mpScheduler = std::make_unique<Scheduler>(mCoreIoContext, mConfigCache, mpLogger, mTimeProvider);
+            mpScheduler = Scheduler::create(mCoreIoContext, mConfigCache, mpLogger, mTimeProvider);
             mpScheduler->loadFromCache();
             mpScheduler->start();
 

--- a/central_unit/src/core/core.h
+++ b/central_unit/src/core/core.h
@@ -222,14 +222,11 @@ namespace SmartHome {
         std::unique_ptr<Utils::ServiceManager> mpService;
         std::shared_ptr<API::InternalApi> mpApi;
 
-        // Cache
-        ConfigCache mConfigCache;
-        ReadingsCache mReadingsCache{mConfigCache, mTimeProvider};
-
         // Scheduler
-        std::unique_ptr<Scheduler> mpScheduler;
+        std::shared_ptr<Scheduler> mpScheduler;
 
         // TODO check other members shutdown sequence (fix hanging this by shared_from_this like in EventHandler)
+        //      Implement static create (like in Scheduler) to avoid problems with shared_from_this
         // Event handler
         std::shared_ptr<EventHandler> mpEventHandler;
 
@@ -251,6 +248,10 @@ namespace SmartHome {
         static constexpr std::array ms_SIGNALS_TO_HANDLE = {SIGINT, SIGTERM, SIGHUP};
         /// Shutdown timeout timer value in ms
         static constexpr auto ms_SHUTDOWN_TIMEOUT = 5000ms;
+
+        // Cache
+        ConfigCache mConfigCache;
+        ReadingsCache mReadingsCache{mConfigCache, mTimeProvider};
 
         //Core workers
         ba::io_context mCoreWorkerIoContext;

--- a/central_unit/src/core/core.h
+++ b/central_unit/src/core/core.h
@@ -224,7 +224,7 @@ namespace SmartHome {
 
         // Cache
         ConfigCache mConfigCache;
-        ReadingsCache mReadingsCache{mConfigCache};
+        ReadingsCache mReadingsCache{mConfigCache, mTimeProvider};
 
         // Scheduler
         std::unique_ptr<Scheduler> mpScheduler;

--- a/central_unit/src/core/core.h
+++ b/central_unit/src/core/core.h
@@ -6,6 +6,7 @@
 #include "api/internal_api.h"
 #include "cache.h"
 #include "scheduler.h"
+#include "common/time/asio_time_provider.h"
 
 #include <atomic>
 #include <memory>
@@ -244,6 +245,7 @@ namespace SmartHome {
         /// Thread running utility IO_context
         std::optional<std::thread> mCoreUtilityThread;
         std::optional<ba::executor_work_guard<ba::io_context::executor_type> > mCoreUtilityGuard;
+        Time::AsioTimeProvider mTimeProvider{mCoreUtilityIoContext.get_executor()};
         std::optional<ba::signal_set> mSignals;
         /// Signals defined to handle in signalHandler
         static constexpr std::array ms_SIGNALS_TO_HANDLE = {SIGINT, SIGTERM, SIGHUP};

--- a/central_unit/src/core/event_handler.h
+++ b/central_unit/src/core/event_handler.h
@@ -24,8 +24,6 @@ namespace SmartHome {
      */
     class EventHandler : public std::enable_shared_from_this<EventHandler> {
         friend class Tests::EventHandlerTest;
-        using ActionDispatcher =
-        std::function<void(std::string_view actionName, uint id, const nlohmann::json &action)>;
 
     public:
         /**

--- a/central_unit/src/core/scheduler.cpp
+++ b/central_unit/src/core/scheduler.cpp
@@ -304,7 +304,7 @@ namespace SmartHome {
     void Scheduler::dispatchAction(const TaskPtr &pTask) const {
         if (!mIsRunning) return;
         mpLogger->debugf("[SCHEDULER] Dispatching %s for device [%u]",
-                         c::AutomatedActionNames::SCHEDULED_ACTION, pTask->deviceId);
+                         c::AutomatedActionNames::SCHEDULED_ACTION.data(), pTask->deviceId);
 
         boost::asio::post(mIoContext, [self = shared_from_this(), pTask] {
             if (!self->mIsRunning || pTask->removed) return;

--- a/central_unit/src/core/scheduler.cpp
+++ b/central_unit/src/core/scheduler.cpp
@@ -1,12 +1,12 @@
 #include "scheduler.h"
 #include "constants.h"
-#include "api/internal_api.h"
-#include "actions/actions.h"
-#include "actions/database_actions.h"
+
+#include <ranges>
 
 namespace SmartHome {
-    namespace jrs = JsonRpcStrings;
     namespace c = Constants;
+
+    using namespace std::string_literals;
 
     Scheduler::Scheduler(ba::io_context &ioContext,
                          const ConfigCache &configCache,
@@ -22,16 +22,16 @@ namespace SmartHome {
     }
 
     Scheduler::~Scheduler() {
-        if (mIsStopping.exchange(true, std::memory_order_acq_rel)) return;
         stop();
     }
 
     void Scheduler::loadFromCache() {
-        std::scoped_lock lock(mMutex);
+        std::unique_lock lock(mMutex);
 
-        // Clear existing tasks queue by swapping with an empty queue
+        // Drop all tasks: queue by swap, index by clear
         TaskQueue empty;
         std::swap(mTaskQueue, empty);
+        mTasksByDevice.clear();
 
         for (const auto &device: mConfigCache.getAllDevices()) {
             parseDeviceSchedule(device.id, device.config);
@@ -41,43 +41,14 @@ namespace SmartHome {
         if (mIsRunning) scheduleNextTimer();
     }
 
-    void Scheduler::reloadDevice(const uint deviceId) {
-        removeDevice(deviceId);
-
-        std::scoped_lock lock(mMutex);
-
-        // Reparse device schedule from current cache state
-        const auto deviceOpt = mConfigCache.getDevice(deviceId);
-        if (deviceOpt.has_value()) {
-            parseDeviceSchedule(deviceId, deviceOpt->config);
-        }
-
-        mpLogger->debugf("[SCHEDULER] Reloaded schedule for device [%u], queue size: %zu",
-                         deviceId, mTaskQueue.size());
-
-        if (mIsRunning) scheduleNextTimer();
-    }
-
     void Scheduler::removeDevice(const uint deviceId) {
-        std::scoped_lock lock(mMutex);
+        std::unique_lock lock(mMutex);
 
-        // Clear existing tasks queue by swapping with an empty queue
-        TaskQueue tempQueue;
-        std::swap(mTaskQueue, tempQueue);
-
-        // Filter out tasks for the device and keep the rest, flag removed tasks to avoid dispatching them
-        while (!tempQueue.empty()) {
-            auto task = tempQueue.top();
-            tempQueue.pop();
-            if (task->deviceId == deviceId) {
-                task->removed = true;
-            } else {
-                mTaskQueue.push(std::move(task));
-            }
+        if (const auto iter = mTasksByDevice.find(deviceId); iter != mTasksByDevice.end()) {
+            for (const auto &pTask: iter->second)
+                pTask->removed = true;
+            mTasksByDevice.erase(iter);
         }
-
-        mpLogger->debugf("[SCHEDULER] Removed tasks for device [%u], queue size: %zu",
-                         deviceId, mTaskQueue.size());
 
         if (mIsRunning) scheduleNextTimer();
     }
@@ -85,7 +56,7 @@ namespace SmartHome {
     void Scheduler::start() {
         if (mIsRunning.exchange(true, std::memory_order_acq_rel)) return;
 
-        std::scoped_lock lock(mMutex);
+        std::unique_lock lock(mMutex);
         mpLogger->info("[SCHEDULER] Starting scheduler");
         scheduleNextTimer();
     }
@@ -93,9 +64,9 @@ namespace SmartHome {
     void Scheduler::stop() {
         if (!mIsRunning.exchange(false, std::memory_order_acq_rel)) return;
 
-        std::scoped_lock lock(mMutex);
+        std::unique_lock lock(mMutex);
         mpLogger->info("[SCHEDULER] Stopping scheduler");
-        mTimer.cancel();
+        mpTimer->cancel();
     }
 
     bool Scheduler::isRunning() const {
@@ -103,23 +74,27 @@ namespace SmartHome {
     }
 
     size_t Scheduler::taskCount() const {
-        std::scoped_lock lock(mMutex);
-        return mTaskQueue.size();
+        std::shared_lock lock(mMutex);
+
+        size_t count = 0;
+        for (const auto &deviceTasks: mTasksByDevice | std::views::values) {
+            count += deviceTasks.size();
+        }
+
+        return count;
     }
 
     std::optional<std::chrono::system_clock::time_point> Scheduler::getNextRunForModule(const uint moduleId) const {
-        std::scoped_lock lock(mMutex);
+        std::shared_lock lock(mMutex);
 
         auto queueCopy = mTaskQueue;
         std::optional<std::chrono::system_clock::time_point> earliest;
 
         while (!queueCopy.empty()) {
-            const auto &task = queueCopy.top();
-
-            if (!task->removed) {
-                const auto device = mConfigCache.getDevice(task->deviceId);
-                if (device.has_value() && device->moduleId == moduleId) {
-                    earliest = task->nextRun;
+            if (const auto &pTask = queueCopy.top(); !pTask->removed) {
+                if (const auto &device = mConfigCache.getDevice(pTask->deviceId);
+                    device.has_value() && device->moduleId == moduleId) {
+                    earliest = pTask->nextRun;
                     break;
                 }
             }
@@ -141,11 +116,7 @@ namespace SmartHome {
     }
 
     Scheduler::IcalIterPtr Scheduler::createRRuleIterator(const std::string &rruleStr, const icaltimetype &dtstart) {
-        // Parse RRULE string
-        icalrecurrencetype recurrence;
-        icalrecurrencetype_clear(&recurrence); // Zero-initialize
-        recurrence = icalrecurrencetype_from_string(rruleStr.c_str());
-
+        const auto recurrence = icalrecurrencetype_from_string(rruleStr.c_str());
         if (recurrence.freq == ICAL_NO_RECURRENCE) {
             return nullptr;
         }
@@ -161,26 +132,51 @@ namespace SmartHome {
         return std::chrono::system_clock::from_time_t(timestamp);
     }
 
+    icaltimetype Scheduler::timePointToIcal(const std::chrono::system_clock::time_point timePoint) {
+        const auto seconds = std::chrono::floor<std::chrono::seconds>(timePoint);
+        constexpr bool isDate = false;
+        return icaltime_from_timet_with_zone(std::chrono::system_clock::to_time_t(seconds),
+                                             isDate,
+                                             icaltimezone_get_utc_timezone());
+    }
+
     void Scheduler::parseDeviceSchedule(const uint deviceId, const nlohmann::json &config) {
-        if (!config.contains(c::DeviceConfigKeys::SCHEDULE) || !config[c::DeviceConfigKeys::SCHEDULE].is_array()) {
+        if (!config.contains(c::DeviceConfigKeys::SCHEDULE)) {
+            return; // Skip devices without schedule field
+        }
+        if (!config[c::DeviceConfigKeys::SCHEDULE].is_array()) {
+            mpLogger->errorf(
+                ("[SCHEDULER] Skipped parsing scheduled events for device [%u]: "
+                    "'%s' device config field must be an array"),
+                deviceId,
+                c::DeviceConfigKeys::SCHEDULE.data());
             return;
         }
+
+        const std::string errorLogStr = "[SCHEDULER] Failed to parse scheduled event for device ["s +
+                                        std::to_string(deviceId) + "]: ";
+
         const auto now = mTimeProvider.now();
         const auto icalNow = timePointToIcal(now);
 
         for (const auto &entry: config[c::DeviceConfigKeys::SCHEDULE]) {
             if (!entry.is_object()) {
+                mpLogger->error(errorLogStr + "scheduled event entry must be an object");
                 continue;
             }
-            if (entry.contains(c::DeviceConfigKeys::ENABLED) &&
-                entry[c::DeviceConfigKeys::ENABLED].is_boolean() &&
-                !entry[c::DeviceConfigKeys::ENABLED].get<bool>()) {
+            if (!entry.contains(c::DeviceConfigKeys::ENABLED) || !entry[c::DeviceConfigKeys::ENABLED].is_boolean()) {
+                mpLogger->error(errorLogStr + "scheduled event entry must contain boolean '"
+                                + c::DeviceConfigKeys::ENABLED.data() + "' field");
                 continue;
             }
             if (!entry.contains(c::DeviceConfigKeys::RRULE) || !entry[c::DeviceConfigKeys::RRULE].is_string()) {
+                mpLogger->error(errorLogStr + "scheduled event entry must contain string '"
+                                + c::DeviceConfigKeys::RRULE.data() + "' field");
                 continue;
             }
             if (!entry.contains(c::DeviceConfigKeys::ACTION) || !entry[c::DeviceConfigKeys::ACTION].is_object()) {
+                mpLogger->error(errorLogStr + "scheduled event entry must contain an '"
+                                + c::DeviceConfigKeys::ACTION.data() + "' object");
                 continue;
             }
 
@@ -213,23 +209,42 @@ namespace SmartHome {
                 continue;
             }
 
-            auto task = std::make_shared<ScheduledTask>();
-            task->deviceId = deviceId;
-            task->action = entry[c::DeviceConfigKeys::ACTION];
-            task->rruleIterator = std::move(rruleIter);
+            auto pTask = std::make_shared<ScheduledTask>();
+            pTask->deviceId = deviceId;
+            pTask->action = entry[c::DeviceConfigKeys::ACTION];
+            pTask->rruleIterator = std::move(rruleIter);
+
+            // Fast forward if possible
+            if (icaltime_compare(dtstart, icalNow) < 0) {
+                if (!icalrecur_iterator_set_start(pTask->rruleIterator.get(), icalNow)) {
+                    mpLogger->debugf("[SCHEDULER] Fast-forward unavailable for device [%u], RRULE: %s\n"
+                                     "RRULE with COUNT is not supported by fast-forward\n "
+                                     "Check RRULE if errors occur",
+                                     deviceId, rruleStr.c_str());
+                }
+            }
 
             // Advance to first future occurrence
-            if (task->advanceToNext()) {
+            if (pTask->advanceToNext()) {
                 // If nextRun is in the past, advance until it's in the future or recurrence ends
-                while (task->nextRun <= now) {
-                    if (!task->advanceToNext()) break;
+                uint iterations = 0;
+                while (pTask->nextRun <= now) {
+                    if (!pTask->advanceToNext()) {
+                        break; // No next recurrence
+                    }
+                    if (constexpr uint iterationLimit = 20'000; ++iterations > iterationLimit) {
+                        mpLogger->errorf("[SCHEDULER] Failed to advance to next task for device [%u]: "
+                                         "reached iteration limit, dtstart may be too far in the past",
+                                         deviceId);
+                        break; // Reached iteration limit
+                    }
                 }
 
-                if (task->nextRun > now) {
+                if (pTask->nextRun > now) {
                     mpLogger->debugf("[SCHEDULER] Enqueued task for device [%u], next run in %lld s",
                                      deviceId,
-                                     std::chrono::duration_cast<std::chrono::seconds>(task->nextRun - now).count());
-                    mTaskQueue.push(std::move(task));
+                                     std::chrono::duration_cast<std::chrono::seconds>(pTask->nextRun - now).count());
+                    enqueueTask(pTask);
                 }
             }
         }
@@ -242,7 +257,7 @@ namespace SmartHome {
         }
 
         if (mTaskQueue.empty()) {
-            mpLogger->debugf("[SCHEDULER] No task in queue");
+            mpLogger->debug("[SCHEDULER] No tasks in queue");
             return;
         }
 
@@ -256,7 +271,7 @@ namespace SmartHome {
     void Scheduler::onTimerExpired(const std::error_code &ec) {
         if (ec || !mIsRunning) return;
 
-        std::scoped_lock lock(mMutex);
+        std::unique_lock lock(mMutex);
         const auto now = mTimeProvider.now();
 
         while (!mTaskQueue.empty()) {
@@ -269,15 +284,17 @@ namespace SmartHome {
             // Break if the earliest task is not ready yet
             if (mTaskQueue.top()->nextRun > now) break;
 
-            auto task = mTaskQueue.top();
+            auto pTask = mTaskQueue.top();
             mTaskQueue.pop();
 
-            // Advance to next occurrence before dispatching current one
-            if (task->advanceToNext()) {
-                mTaskQueue.push(task);
+            // Advance to next occurrence before dispatching current one, retire task if it has no more occurrences
+            if (pTask->advanceToNext()) {
+                requeueTask(pTask);
+            } else {
+                retireTask(pTask);
             }
 
-            dispatchAction(task);
+            dispatchAction(pTask);
         }
 
         // Set timer for next occurrence
@@ -293,5 +310,22 @@ namespace SmartHome {
             if (!self->mIsRunning || pTask->removed) return;
             self->mDispatchAction(c::AutomatedActionNames::SCHEDULED_ACTION, pTask->deviceId, pTask->action);
         });
+    }
+
+    void Scheduler::enqueueTask(const TaskPtr &pTask) {
+        mTaskQueue.push(pTask);
+        mTasksByDevice[pTask->deviceId].push_back(pTask);
+    }
+
+    void Scheduler::requeueTask(const TaskPtr &pTask) {
+        mTaskQueue.push(pTask);
+    }
+
+    void Scheduler::retireTask(const TaskPtr &pTask) {
+        const auto iter = mTasksByDevice.find(pTask->deviceId);
+        if (iter == mTasksByDevice.end()) return;
+
+        std::erase(iter->second, pTask);
+        if (iter->second.empty()) mTasksByDevice.erase(iter);
     }
 }

--- a/central_unit/src/core/scheduler.cpp
+++ b/central_unit/src/core/scheduler.cpp
@@ -2,19 +2,15 @@
 #include "constants.h"
 
 #include <ranges>
+#include <utility>
 
 namespace SmartHome {
     namespace c = Constants;
 
     using namespace std::string_literals;
 
-    std::shared_ptr<Scheduler> Scheduler::create(ba::io_context &ioContext,
-                                                 const ConfigCache &configCache,
-                                                 const std::shared_ptr<Utils::AsyncLogger> &logger,
-                                                 Time::ITimeProvider &timeProvider,
-                                                 ActionDispatcher dispatchAction) {
-        return std::shared_ptr<Scheduler>(
-            new Scheduler(ioContext, configCache, logger, timeProvider, std::move(dispatchAction)));
+    std::shared_ptr<Scheduler> Scheduler::create(Config config) {
+        return std::shared_ptr<Scheduler>(new Scheduler(std::move(config)));
     }
 
     Scheduler::~Scheduler() {
@@ -101,16 +97,12 @@ namespace SmartHome {
         return earliest;
     }
 
-    Scheduler::Scheduler(ba::io_context &ioContext,
-                         const ConfigCache &configCache,
-                         const std::shared_ptr<Utils::AsyncLogger> &logger,
-                         Time::ITimeProvider &timeProvider,
-                         ActionDispatcher dispatchAction)
-        : mIoContext(ioContext),
-          mConfigCache(configCache),
-          mpLogger(logger),
-          mTimeProvider(timeProvider),
-          mDispatchAction(std::move(dispatchAction)) {
+    Scheduler::Scheduler(Config config)
+        : mTimeProvider(config.timeProvider),
+          mConfigCache(config.configCache),
+          mExecutor(std::move(config.executor)),
+          mpLogger(std::move(config.logger)),
+          mDispatchAction(std::move(config.dispatchAction)) {
         mpTimer = mTimeProvider.createTimer();
     }
 
@@ -149,11 +141,11 @@ namespace SmartHome {
                                              icaltimezone_get_utc_timezone());
     }
 
-    void Scheduler::parseDeviceSchedule(const uint deviceId, const nlohmann::json &config) {
-        if (!config.contains(c::DeviceConfigKeys::SCHEDULE)) {
+    void Scheduler::parseDeviceSchedule(const uint deviceId, const nlohmann::json &deviceConfig) {
+        if (!deviceConfig.contains(c::DeviceConfigKeys::SCHEDULE)) {
             return; // Skip devices without schedule field
         }
-        if (!config[c::DeviceConfigKeys::SCHEDULE].is_array()) {
+        if (!deviceConfig[c::DeviceConfigKeys::SCHEDULE].is_array()) {
             mpLogger->errorf(
                 ("[SCHEDULER] Skipped parsing scheduled events for device [%u]: "
                     "'%s' device config field must be an array"),
@@ -168,7 +160,7 @@ namespace SmartHome {
         const auto now = mTimeProvider.now();
         const auto icalNow = timePointToIcal(now);
 
-        for (const auto &entry: config[c::DeviceConfigKeys::SCHEDULE]) {
+        for (const auto &entry: deviceConfig[c::DeviceConfigKeys::SCHEDULE]) {
             if (!entry.is_object()) {
                 mpLogger->error(errorLogStr + "scheduled event entry must be an object");
                 continue;
@@ -315,7 +307,7 @@ namespace SmartHome {
         mpLogger->debugf("[SCHEDULER] Dispatching %s for device [%u]",
                          c::AutomatedActionNames::SCHEDULED_ACTION.data(), pTask->deviceId);
 
-        boost::asio::post(mIoContext, [self = shared_from_this(), pTask] {
+        boost::asio::post(mExecutor, [self = shared_from_this(), pTask] {
             if (!self->mIsRunning || pTask->removed) return;
             self->mDispatchAction(c::AutomatedActionNames::SCHEDULED_ACTION, pTask->deviceId, pTask->action);
         });

--- a/central_unit/src/core/scheduler.cpp
+++ b/central_unit/src/core/scheduler.cpp
@@ -8,17 +8,13 @@ namespace SmartHome {
 
     using namespace std::string_literals;
 
-    Scheduler::Scheduler(ba::io_context &ioContext,
-                         const ConfigCache &configCache,
-                         const std::shared_ptr<Utils::AsyncLogger> &logger,
-                         Time::ITimeProvider &timeProvider,
-                         ActionDispatcher dispatchAction)
-        : mIoContext(ioContext),
-          mConfigCache(configCache),
-          mpLogger(logger),
-          mTimeProvider(timeProvider),
-          mDispatchAction(std::move(dispatchAction)) {
-        mpTimer = mTimeProvider.createTimer();
+    std::shared_ptr<Scheduler> Scheduler::create(ba::io_context &ioContext,
+                                                 const ConfigCache &configCache,
+                                                 const std::shared_ptr<Utils::AsyncLogger> &logger,
+                                                 Time::ITimeProvider &timeProvider,
+                                                 ActionDispatcher dispatchAction) {
+        return std::shared_ptr<Scheduler>(
+            new Scheduler(ioContext, configCache, logger, timeProvider, std::move(dispatchAction)));
     }
 
     Scheduler::~Scheduler() {
@@ -103,6 +99,19 @@ namespace SmartHome {
         }
 
         return earliest;
+    }
+
+    Scheduler::Scheduler(ba::io_context &ioContext,
+                         const ConfigCache &configCache,
+                         const std::shared_ptr<Utils::AsyncLogger> &logger,
+                         Time::ITimeProvider &timeProvider,
+                         ActionDispatcher dispatchAction)
+        : mIoContext(ioContext),
+          mConfigCache(configCache),
+          mpLogger(logger),
+          mTimeProvider(timeProvider),
+          mDispatchAction(std::move(dispatchAction)) {
+        mpTimer = mTimeProvider.createTimer();
     }
 
     bool Scheduler::ScheduledTask::advanceToNext() {

--- a/central_unit/src/core/scheduler.cpp
+++ b/central_unit/src/core/scheduler.cpp
@@ -10,11 +10,15 @@ namespace SmartHome {
 
     Scheduler::Scheduler(ba::io_context &ioContext,
                          const ConfigCache &configCache,
-                         const std::shared_ptr<Utils::AsyncLogger> &logger)
+                         const std::shared_ptr<Utils::AsyncLogger> &logger,
+                         Time::ITimeProvider &timeProvider,
+                         ActionDispatcher dispatchAction)
         : mIoContext(ioContext),
-          mTimer(ioContext),
           mConfigCache(configCache),
-          mpLogger(logger) {
+          mpLogger(logger),
+          mTimeProvider(timeProvider),
+          mDispatchAction(std::move(dispatchAction)) {
+        mpTimer = mTimeProvider.createTimer();
     }
 
     Scheduler::~Scheduler() {
@@ -161,6 +165,8 @@ namespace SmartHome {
         if (!config.contains(c::DeviceConfigKeys::SCHEDULE) || !config[c::DeviceConfigKeys::SCHEDULE].is_array()) {
             return;
         }
+        const auto now = mTimeProvider.now();
+        const auto icalNow = timePointToIcal(now);
 
         for (const auto &entry: config[c::DeviceConfigKeys::SCHEDULE]) {
             if (!entry.is_object()) {
@@ -178,15 +184,27 @@ namespace SmartHome {
                 continue;
             }
 
-            icaltimetype dtstart;
-            if (entry.contains(c::DeviceConfigKeys::DTSTART) && entry[c::DeviceConfigKeys::DTSTART].is_string()) {
-                dtstart = icaltime_from_string(entry[c::DeviceConfigKeys::DTSTART].get<std::string>().c_str());
+            if (!entry[c::DeviceConfigKeys::ENABLED].get<bool>()) continue; // skip disabled events
+
+            icaltimetype dtstart = icaltime_null_time();
+            if (entry.contains(c::DeviceConfigKeys::DTSTART)) {
+                if (entry[c::DeviceConfigKeys::DTSTART].is_string()) {
+                    dtstart = icaltime_from_string(entry[c::DeviceConfigKeys::DTSTART].get<std::string>().c_str());
+                }
                 if (icaltime_is_null_time(dtstart)) {
-                    dtstart = icaltime_current_time_with_zone(icaltimezone_get_utc_timezone());
+                    mpLogger->errorf("[SCHEDULER] Failed to parse '%s' (%s) for device [%u], "
+                                     "defaulting to now and skipping first occurrence",
+                                     c::DeviceConfigKeys::DTSTART.data(),
+                                     entry[c::DeviceConfigKeys::DTSTART].dump().c_str(),
+                                     deviceId);
                 }
             } else {
-                dtstart = icaltime_current_time_with_zone(icaltimezone_get_utc_timezone());
+                mpLogger->debugf(
+                    "[SCHEDULER] No 'dtstart' for device [%u], defaulting to now and skipping first occurrence",
+                    deviceId);
             }
+
+            if (icaltime_is_null_time(dtstart)) dtstart = icalNow;
 
             const auto &rruleStr = entry[c::DeviceConfigKeys::RRULE].get<std::string>();
             auto rruleIter = createRRuleIterator(rruleStr, dtstart);
@@ -202,7 +220,6 @@ namespace SmartHome {
 
             // Advance to first future occurrence
             if (task->advanceToNext()) {
-                const auto now = std::chrono::system_clock::now();
                 // If nextRun is in the past, advance until it's in the future or recurrence ends
                 while (task->nextRun <= now) {
                     if (!task->advanceToNext()) break;
@@ -230,17 +247,17 @@ namespace SmartHome {
         }
 
         const auto &nextTask = mTaskQueue.top();
-        mTimer.expires_at(nextTask->nextRun);
-        mTimer.async_wait([this](const boost::system::error_code &ec) {
-            onTimerExpired(ec);
+        mpTimer->expiresAt(nextTask->nextRun);
+        mpTimer->asyncWait([self = weak_from_this()](const std::error_code &ec) {
+            if (const auto p = self.lock()) p->onTimerExpired(ec);
         });
     }
 
-    void Scheduler::onTimerExpired(const boost::system::error_code &ec) {
+    void Scheduler::onTimerExpired(const std::error_code &ec) {
         if (ec || !mIsRunning) return;
 
         std::scoped_lock lock(mMutex);
-        const auto now = std::chrono::system_clock::now();
+        const auto now = mTimeProvider.now();
 
         while (!mTaskQueue.empty()) {
             // Skip and remove tasks that were flagged as removed
@@ -267,14 +284,14 @@ namespace SmartHome {
         scheduleNextTimer();
     }
 
-    void Scheduler::dispatchAction(const TaskPtr &task) const {
-        mpLogger->debugf("[SCHEDULER] Dispatching action");
-        auto action = task->action;
-        auto deviceId = task->deviceId;
+    void Scheduler::dispatchAction(const TaskPtr &pTask) const {
+        if (!mIsRunning) return;
+        mpLogger->debugf("[SCHEDULER] Dispatching %s for device [%u]",
+                         c::AutomatedActionNames::SCHEDULED_ACTION, pTask->deviceId);
 
-        boost::asio::post(Core::Instance().coreIoContext(), [action, deviceId]  {
-            constexpr std::string_view actionName = "Scheduled action";
-            ActionHelpers::dispatchAutomatedDeviceAction(actionName, deviceId, action);
+        boost::asio::post(mIoContext, [self = shared_from_this(), pTask] {
+            if (!self->mIsRunning || pTask->removed) return;
+            self->mDispatchAction(c::AutomatedActionNames::SCHEDULED_ACTION, pTask->deviceId, pTask->action);
         });
     }
 }

--- a/central_unit/src/core/scheduler.h
+++ b/central_unit/src/core/scheduler.h
@@ -28,9 +28,6 @@ namespace SmartHome {
      */
     class Scheduler : public std::enable_shared_from_this<Scheduler> {
     public:
-        using ActionDispatcher =
-        std::function<void(std::string_view actionName, uint id, const nlohmann::json &action)>;
-
         /**
          * @brief Construct scheduler bound to an io_context and config cache.
          *

--- a/central_unit/src/core/scheduler.h
+++ b/central_unit/src/core/scheduler.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "cache.h"
 #include "async_logger.h"
+#include "actions/action_helpers.h"
+#include "common/time/time_provider.h"
 
 #include <queue>
 
@@ -19,18 +21,26 @@ namespace SmartHome {
      *
      * @note All public methods are thread-safe.
      */
-    class Scheduler {
+    class Scheduler : public std::enable_shared_from_this<Scheduler> {
     public:
+        using ActionDispatcher =
+        std::function<void(std::string_view actionName, uint id, const nlohmann::json &action)>;
+
         /**
          * @brief Construct scheduler bound to an io_context and config cache.
          *
          * @param ioContext Boost.Asio context for timer operations.
          * @param configCache Configuration cache for device schedule lookup.
          * @param logger Logger instance.
+         * @param timeProvider Time source abstraction used for scheduling calculations (injectable for testing).
+         * @param dispatchAction Callable used to dispatch device actions (injectable for testing).
          */
         Scheduler(ba::io_context &ioContext,
                   const ConfigCache &configCache,
-                  const std::shared_ptr<Utils::AsyncLogger> &logger);
+                  const std::shared_ptr<Utils::AsyncLogger> &logger,
+                  Time::ITimeProvider &timeProvider,
+                  ActionDispatcher dispatchAction = &ActionHelpers::dispatchAutomatedDeviceAction);
+
 
         ~Scheduler();
 
@@ -174,22 +184,24 @@ namespace SmartHome {
          *
          * @param ec Error code from async_wait.
          */
-        void onTimerExpired(const boost::system::error_code &ec);
+        void onTimerExpired(const std::error_code &ec);
 
         /**
          * @brief Dispatch a scheduled action through \c Actions pipeline.
          *
-         * @param task Task whose action to execute.
+         * @param pTask Task whose action to execute.
          */
-        void dispatchAction(const TaskPtr &task) const;
+        void dispatchAction(const TaskPtr &pTask) const;
 
         ba::io_context &mIoContext;
-        ba::system_timer mTimer;
         const ConfigCache &mConfigCache;
         std::shared_ptr<Utils::AsyncLogger> mpLogger;
+        Time::ITimeProvider &mTimeProvider;
 
-        TaskQueue mTaskQueue;
+        ActionDispatcher mDispatchAction; ///< Device action dispatcher (injectable for testing)
         mutable std::mutex mMutex;
+        std::unique_ptr<Time::ITimer> mpTimer;
+        TaskQueue mTaskQueue; /// All tasks including retired ones pending removal.
         std::atomic_bool mIsRunning{false};
         std::atomic_bool mIsStopping{false};
     };

--- a/central_unit/src/core/scheduler.h
+++ b/central_unit/src/core/scheduler.h
@@ -29,23 +29,29 @@ namespace SmartHome {
     class Scheduler : public std::enable_shared_from_this<Scheduler> {
     public:
         /**
+         * @brief Construction parameters for \c Scheduler.
+         */
+        struct Config {
+            /// Time source abstraction used for scheduling calculations (injectable for testing).
+            Time::ITimeProvider &timeProvider;
+            /// Configuration cache for device schedule lookup.
+            const ConfigCache &configCache;
+            /// Boost.Asio executor for timer operations.
+            ba::any_io_executor executor;
+            /// Logger instance.
+            std::shared_ptr<Utils::AsyncLogger> logger;
+            /// Device action dispatcher (injectable for testing)
+            ActionDispatcher dispatchAction = &ActionHelpers::dispatchAutomatedDeviceAction;
+        };
+
+        /**
          * @brief Creates an new instance of \c Scheduler.
          *
-         * @param ioContext Boost.Asio context for timer operations.
-         * @param configCache Configuration cache for device schedule lookup.
-         * @param logger Logger instance.
-         * @param timeProvider Time source abstraction used for scheduling calculations (injectable for testing).
-         * @param dispatchAction Callable used to dispatch device actions (injectable for testing).
+         * @param config Construction parameters.
          *
          * @return A new instance of \c Scheduler. Ownership is transferred to the caller.
          */
-        [[nodiscard]] static std::shared_ptr<Scheduler> create(
-            ba::io_context &ioContext,
-            const ConfigCache &configCache,
-            const std::shared_ptr<Utils::AsyncLogger> &logger,
-            Time::ITimeProvider &timeProvider,
-            ActionDispatcher dispatchAction = &ActionHelpers::dispatchAutomatedDeviceAction
-        );
+        [[nodiscard]] static std::shared_ptr<Scheduler> create(Config config);
 
         /**
          * @brief Destructor. Calls \c stop().
@@ -101,22 +107,14 @@ namespace SmartHome {
 
     private:
         /**
-         * @brief Construct scheduler bound to an io_context and config cache.
+         * @brief Construct scheduler bound to an executor and config cache.
          *
          * @note This constructor is private and only used internally.
          *       Use the static create() method to instantiate a scheduler.
          *
-         * @param ioContext Boost.Asio context for timer operations.
-         * @param configCache Configuration cache for device schedule lookup.
-         * @param logger Logger instance.
-         * @param timeProvider Time source abstraction used for scheduling calculations (injectable for testing).
-         * @param dispatchAction Callable used to dispatch device actions (injectable for testing).
+         * @param config Construction parameters.
          */
-        Scheduler(ba::io_context &ioContext,
-                  const ConfigCache &configCache,
-                  const std::shared_ptr<Utils::AsyncLogger> &logger,
-                  Time::ITimeProvider &timeProvider,
-                  ActionDispatcher dispatchAction);
+        explicit Scheduler(Config config);
 
         /**
          * @brief RAII wrapper for icalrecur_iterator lifecycle.
@@ -185,9 +183,9 @@ namespace SmartHome {
          * @brief Parse device config \b schedule array and enqueue tasks.
          *
          * @param deviceId Device identifier.
-         * @param config Device configuration JSON containing \b schedule key.
+         * @param deviceConfig Device configuration JSON containing \b schedule key.
          */
-        void parseDeviceSchedule(uint deviceId, const nlohmann::json &config);
+        void parseDeviceSchedule(uint deviceId, const nlohmann::json &deviceConfig);
 
         /**
          * @brief Set timer to fire at the earliest task's nextRun.
@@ -240,10 +238,10 @@ namespace SmartHome {
 
         mutable std::shared_mutex mMutex;
 
-        ba::io_context &mIoContext;
-        const ConfigCache &mConfigCache;
-        std::shared_ptr<Utils::AsyncLogger> mpLogger;
         Time::ITimeProvider &mTimeProvider;
+        const ConfigCache &mConfigCache;
+        ba::any_io_executor mExecutor;
+        std::shared_ptr<Utils::AsyncLogger> mpLogger;
 
         ActionDispatcher mDispatchAction; ///< Device action dispatcher (injectable for testing)
 

--- a/central_unit/src/core/scheduler.h
+++ b/central_unit/src/core/scheduler.h
@@ -5,17 +5,22 @@
 #include "common/time/time_provider.h"
 
 #include <queue>
+#include <unordered_map>
+#include <shared_mutex>
+#include <memory>
 
 #include <boost/asio.hpp>
+#include <nlohmann/json.hpp>
 #include <ical.h>
 
-
 namespace SmartHome {
+    namespace ba = boost::asio;
+
     /**
      * @brief Scheduled task execution engine using iCalendar RRULE recurrence.
      *
-     * @details Maintains a priority queue of scheduled tasks parsed from device configurations.
-     *          A single system_timer fires for the nearest task,
+     * @details Maintains a priority queue of tasks parsed from device configurations, plus a
+     *          per-device index used for removal. A single ITimer fires for the nearest task,
      *          dispatches the action through the existing Actions command pipeline,
      *          advances the RRULE iterator, and re-enqueues the task.
      *
@@ -42,6 +47,9 @@ namespace SmartHome {
                   ActionDispatcher dispatchAction = &ActionHelpers::dispatchAutomatedDeviceAction);
 
 
+        /**
+         * @brief Destructor. Calls \c stop().
+         */
         ~Scheduler();
 
         Scheduler(const Scheduler &) = delete;
@@ -57,20 +65,8 @@ namespace SmartHome {
          */
         void loadFromCache();
 
-        // TODO Unused for now, use after db trigger rework (adding payload with changed ids)
         /**
-         * @brief Reload schedule entries for a specific device.
-         *
-         * @details Removes existing tasks for the device and reparses its schedule config.
-         *
-         * @note Used after LISTEN/NOTIFY config changes.
-         *
-         * @param deviceId Device identifier to reload.
-         */
-        void reloadDevice(uint deviceId);
-
-        /**
-         * @brief Remove all scheduled tasks for a device.
+         * @brief Marks tasks as removed in \c mTaskQueue for lazy deletion and deletes them from \c mTasksByDevice.
          *
          * @param deviceId Device identifier.
          */
@@ -92,7 +88,7 @@ namespace SmartHome {
         [[nodiscard]] bool isRunning() const;
 
         /**
-         * @brief Number of tasks currently in the queue.
+         * @brief Number of live tasks (excludes removed and exhausted ones).
          */
         [[nodiscard]] size_t taskCount() const;
 
@@ -123,7 +119,7 @@ namespace SmartHome {
             nlohmann::json action; ///< Action definition from config
             std::chrono::system_clock::time_point nextRun; ///< Next scheduled execution time
             IcalIterPtr rruleIterator; ///< libical recurrence iterator
-            bool removed = false; ///< delete flag for preventing dispatch of removed tasks
+            bool removed = false; ///< Lazy-delete flag: skipped in the queue and suppresses dispatch
 
             /**
              * @brief Advance iterator to next occurrence.
@@ -147,10 +143,10 @@ namespace SmartHome {
         using TaskQueue = std::priority_queue<TaskPtr, std::vector<TaskPtr>, TaskComparator>;
 
         /**
-         * @brief Parse RRULE string and create iterator starting from now.
+         * @brief Parse RRULE string and create an iterator anchored at dtstart.
          *
          * @param rruleStr RRULE string (e.g. "FREQ=MINUTELY;INTERVAL=5").
-         * @param dtstart Output parameter receiving the start time used.
+         * @param dtstart Start time for the recurrence iterator.
          *
          * @return Iterator pointer or nullptr on parse failure.
          */
@@ -158,9 +154,14 @@ namespace SmartHome {
                                                const icaltimetype &dtstart);
 
         /**
-         * @brief Convert icaltimetype to system_clock time_point.
+         * @brief Convert \c icaltimetype to \c system_clock::time_point.
          */
         static std::chrono::system_clock::time_point icalToTimePoint(const icaltimetype &time);
+
+        /**
+         * @brief Convert \c system_clock::time_point to \c icaltimetype.
+         */
+        static icaltimetype timePointToIcal(std::chrono::system_clock::time_point timePoint);
 
         /**
          * @brief Parse device config \b schedule array and enqueue tasks.
@@ -193,16 +194,44 @@ namespace SmartHome {
          */
         void dispatchAction(const TaskPtr &pTask) const;
 
+        /**
+         * @brief Register a newly parsed task in both the queue and the device index.
+         *
+         * @param pTask Task to register.
+         */
+        void enqueueTask(const TaskPtr &pTask);
+
+        /**
+         * @brief Return an already-indexed task to the queue after advancing its iterator.
+         *
+         * @param pTask Task to requeue.
+         *
+         * @pre The task's iterator is advanced before requeue.
+         */
+        void requeueTask(const TaskPtr &pTask);
+
+        /**
+         * @brief Remove a task from the device index.
+         *
+         * @param pTask Task to remove.
+         *
+         * @note A dispatch already posted for this task still runs, \c removeDevice() can no longer suppress it,
+         *       as the task is no longer reachable from the index.
+         */
+        void retireTask(const TaskPtr &pTask);
+
+        mutable std::shared_mutex mMutex;
+
         ba::io_context &mIoContext;
         const ConfigCache &mConfigCache;
         std::shared_ptr<Utils::AsyncLogger> mpLogger;
         Time::ITimeProvider &mTimeProvider;
 
         ActionDispatcher mDispatchAction; ///< Device action dispatcher (injectable for testing)
-        mutable std::mutex mMutex;
+
         std::unique_ptr<Time::ITimer> mpTimer;
         TaskQueue mTaskQueue; /// All tasks including retired ones pending removal.
+        std::unordered_map<uint, std::vector<TaskPtr> > mTasksByDevice; /// Live tasks by device.
         std::atomic_bool mIsRunning{false};
-        std::atomic_bool mIsStopping{false};
     };
 };

--- a/central_unit/src/core/scheduler.h
+++ b/central_unit/src/core/scheduler.h
@@ -29,20 +29,23 @@ namespace SmartHome {
     class Scheduler : public std::enable_shared_from_this<Scheduler> {
     public:
         /**
-         * @brief Construct scheduler bound to an io_context and config cache.
+         * @brief Creates an new instance of \c Scheduler.
          *
          * @param ioContext Boost.Asio context for timer operations.
          * @param configCache Configuration cache for device schedule lookup.
          * @param logger Logger instance.
          * @param timeProvider Time source abstraction used for scheduling calculations (injectable for testing).
          * @param dispatchAction Callable used to dispatch device actions (injectable for testing).
+         *
+         * @return A new instance of \c Scheduler. Ownership is transferred to the caller.
          */
-        Scheduler(ba::io_context &ioContext,
-                  const ConfigCache &configCache,
-                  const std::shared_ptr<Utils::AsyncLogger> &logger,
-                  Time::ITimeProvider &timeProvider,
-                  ActionDispatcher dispatchAction = &ActionHelpers::dispatchAutomatedDeviceAction);
-
+        [[nodiscard]] static std::shared_ptr<Scheduler> create(
+            ba::io_context &ioContext,
+            const ConfigCache &configCache,
+            const std::shared_ptr<Utils::AsyncLogger> &logger,
+            Time::ITimeProvider &timeProvider,
+            ActionDispatcher dispatchAction = &ActionHelpers::dispatchAutomatedDeviceAction
+        );
 
         /**
          * @brief Destructor. Calls \c stop().
@@ -97,6 +100,24 @@ namespace SmartHome {
         std::optional<std::chrono::system_clock::time_point> getNextRunForModule(uint moduleId) const;
 
     private:
+        /**
+         * @brief Construct scheduler bound to an io_context and config cache.
+         *
+         * @note This constructor is private and only used internally.
+         *       Use the static create() method to instantiate a scheduler.
+         *
+         * @param ioContext Boost.Asio context for timer operations.
+         * @param configCache Configuration cache for device schedule lookup.
+         * @param logger Logger instance.
+         * @param timeProvider Time source abstraction used for scheduling calculations (injectable for testing).
+         * @param dispatchAction Callable used to dispatch device actions (injectable for testing).
+         */
+        Scheduler(ba::io_context &ioContext,
+                  const ConfigCache &configCache,
+                  const std::shared_ptr<Utils::AsyncLogger> &logger,
+                  Time::ITimeProvider &timeProvider,
+                  ActionDispatcher dispatchAction);
+
         /**
          * @brief RAII wrapper for icalrecur_iterator lifecycle.
          */

--- a/central_unit/src/db-service/CMakeLists.txt
+++ b/central_unit/src/db-service/CMakeLists.txt
@@ -22,7 +22,7 @@ set(SKIP_BUILD_TEST ON CACHE INTERNAL "")
 set(BUILD_DOC OFF CACHE INTERNAL "")
 
 FetchContent_MakeAvailable(libpqxx)
-set_target_properties(pqxx PROPERTIES FOLDER "third_party")
+set_target_properties(pqxx PROPERTIES FOLDER "${THIRD_PARTY_TARGETS_FOLDER}")
 
 
 # Target

--- a/central_unit/src/db-service/CMakeLists.txt
+++ b/central_unit/src/db-service/CMakeLists.txt
@@ -42,10 +42,10 @@ target_link_libraries(smarthome-database PRIVATE
         smarthome::utility
         smarthome::logger
         smarthome::constants
+        smarthome::warnings
         Boost::program_options
         Boost::system
         pqxx
-        project_warnings
 )
 
 

--- a/central_unit/src/gui/CMakeLists.txt
+++ b/central_unit/src/gui/CMakeLists.txt
@@ -48,5 +48,5 @@ target_link_libraries(smarthomegui PRIVATE
         Qt6::Qml
         smarthome::logger
         smarthome::utility
-        project_warnings
+        smarthome::warnings
 )

--- a/central_unit/src/mediator/CMakeLists.txt
+++ b/central_unit/src/mediator/CMakeLists.txt
@@ -28,10 +28,10 @@ target_link_libraries(smarthome-mediator PRIVATE
         smarthome::utility
         smarthome::logger
         smarthome::constants
+        smarthome::warnings
         Boost::program_options
         Boost::system
         PkgConfig::GPIOD
-        project_warnings
 )
 
 

--- a/central_unit/src/web_server/CMakeLists.txt
+++ b/central_unit/src/web_server/CMakeLists.txt
@@ -40,10 +40,10 @@ target_link_libraries(smarthome-web-server PRIVATE
         smarthome::utility
         smarthome::logger
         smarthome::constants
+        smarthome::warnings
         Boost::program_options
         Boost::system
         Crow::Crow
-        project_warnings
 )
 
 

--- a/central_unit/tests/CMakeLists.txt
+++ b/central_unit/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
 set(BUILD_GMOCK ON CACHE BOOL "" FORCE)
 
 FetchContent_MakeAvailable(googletest)
-set_target_properties(gtest gtest_main gmock gmock_main PROPERTIES FOLDER "third_party")
+set_target_properties(gtest gtest_main gmock gmock_main PROPERTIES FOLDER "${THIRD_PARTY_TARGETS_FOLDER}")
 
 include(GoogleTest)
 
@@ -30,7 +30,7 @@ function(smarthome_add_test_group GROUP)
     endforeach ()
 
     add_executable(${GROUP}_tests ${sources})
-    set_target_properties(${GROUP}_tests PROPERTIES FOLDER "tests")
+    set_target_properties(${GROUP}_tests PROPERTIES FOLDER "${TESTS_TARGETS_FOLDER}")
     target_link_libraries(${GROUP}_tests
             PUBLIC
             GTest::gtest
@@ -59,7 +59,7 @@ get_property(all_sources GLOBAL PROPERTY SMARTHOME_TEST_SOURCES)
 get_property(all_libs GLOBAL PROPERTY SMARTHOME_TEST_LIBS)
 
 add_executable(all_tests ${all_sources})
-set_target_properties(all_tests PROPERTIES FOLDER "tests")
+set_target_properties(all_tests PROPERTIES FOLDER "${TESTS_TARGETS_FOLDER}")
 target_link_libraries(all_tests
         PUBLIC
         GTest::gtest

--- a/central_unit/tests/CMakeLists.txt
+++ b/central_unit/tests/CMakeLists.txt
@@ -38,7 +38,7 @@ function(smarthome_add_test_group GROUP)
             ${ARG_LIBS}
             PRIVATE
             GTest::gtest_main
-            project_warnings
+            smarthome::warnings
     )
 
     gtest_discover_tests(${GROUP}_tests
@@ -67,5 +67,5 @@ target_link_libraries(all_tests
         ${all_libs}
         PRIVATE
         GTest::gtest_main
-        project_warnings
+        smarthome::warnings
 )

--- a/central_unit/tests/core/CMakeLists.txt
+++ b/central_unit/tests/core/CMakeLists.txt
@@ -2,6 +2,7 @@ set(test_names
         event_handler_test
         config_cache_test
         readings_cache_test
+        scheduler_test
 )
 
-smarthome_add_test_group(core TESTS ${test_names} LIBS smarthome::core_lib)
+smarthome_add_test_group(core TESTS ${test_names} LIBS smarthome::core_lib smarthome::time_testing)

--- a/central_unit/tests/core/event_handler_test.h
+++ b/central_unit/tests/core/event_handler_test.h
@@ -1,9 +1,10 @@
 #pragma once
-
-#include <gtest/gtest.h>
 #include "event_handler.h"
 #include "cache.h"
 #include "async_logger.h"
+#include "common/time/testing/fake_time_provider.h"
+
+#include <gtest/gtest.h>
 
 namespace SmartHome::Tests {
     class EventHandlerTest : public ::testing::Test {
@@ -75,12 +76,13 @@ namespace SmartHome::Tests {
 
         // Event handler members
         ConfigCache mConfigCache;
-        ReadingsCache mReadingsCache{mConfigCache};
+        ReadingsCache mReadingsCache{mConfigCache, mTimeProvider};
         ba::io_context mIoContext;
         std::shared_ptr<Utils::AsyncLogger> mpLogger;
 
 
         // Members used for testing
+        Time::Testing::FakeTimeProvider mTimeProvider{std::chrono::system_clock::now()};
         std::shared_ptr<EventHandler> mpHandler;
         std::vector<CapturedDispatch> mDeviceDispatches;
         std::vector<CapturedDispatch> mModuleDispatches;

--- a/central_unit/tests/core/readings_cache_test.cpp
+++ b/central_unit/tests/core/readings_cache_test.cpp
@@ -115,11 +115,11 @@ namespace SmartHome::Tests {
 
         EXPECT_TRUE(mReadingsCache.getFresh(1).has_value());
 
-        mNow += 59s;
+        mTimeProvider.advanceBy(59s);
 
         EXPECT_TRUE(mReadingsCache.getFresh(1).has_value());
 
-        mNow += 2s;
+        mTimeProvider.advanceBy(2s);
 
         EXPECT_FALSE(mReadingsCache.getFresh(1).has_value());
     }
@@ -144,7 +144,7 @@ namespace SmartHome::Tests {
     TEST_F(ReadingsCacheTest, ReadingsCacheOverrideRefreshesTimestamp) {
         populateDevices(1, true);
         populateReadings(1);
-        mNow += 61s;
+        mTimeProvider.advanceBy(61s);
         ASSERT_FALSE(mReadingsCache.getFresh(1).has_value());
 
         populateReadings(1); // Overwrite resets timestamp

--- a/central_unit/tests/core/readings_cache_test.cpp
+++ b/central_unit/tests/core/readings_cache_test.cpp
@@ -57,7 +57,7 @@ namespace SmartHome::Tests {
 
     TEST_F(ReadingsCacheTest, ReadingsCacheEraseReading) {
         populateReadings();
-        EXPECT_TRUE( mReadingsCache.get(1).has_value());
+        EXPECT_TRUE(mReadingsCache.get(1).has_value());
 
         mReadingsCache.erase(1);
         EXPECT_FALSE(mReadingsCache.get(1).has_value());
@@ -96,21 +96,21 @@ namespace SmartHome::Tests {
     }
 
     TEST_F(ReadingsCacheTest, ReadingsCacheGetFreshReadingStaleNoCache) {
-        populateDevices(1,false);
+        populateDevices(1, false);
         populateReadings();
 
         EXPECT_FALSE(mReadingsCache.getFresh(1).has_value());
     }
 
     TEST_F(ReadingsCacheTest, ReadingsCacheGetFreshReadingStaleZeroTime) {
-        populateDevices(1,true, 0);
+        populateDevices(1, true, 0);
         populateReadings();
 
         EXPECT_FALSE(mReadingsCache.getFresh(1).has_value());
     }
 
     TEST_F(ReadingsCacheTest, ReadingsCacheGetFreshReadingTurnedStale) {
-        populateDevices(1,true);
+        populateDevices(1, true);
         populateReadings();
 
         EXPECT_TRUE(mReadingsCache.getFresh(1).has_value());

--- a/central_unit/tests/core/readings_cache_test.h
+++ b/central_unit/tests/core/readings_cache_test.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "cache.h"
+#include "common/time/testing/fake_time_provider.h"
 
 #include <gtest/gtest.h>
 
@@ -14,10 +15,8 @@ namespace SmartHome::Tests {
 
         void populateReadings(uint id = 1, const nlohmann::json &value = 12.34, const nlohmann::json &metadata = {});
 
-        // Controllable time source injected into ReadingsCache via the Clock lambda
-        std::chrono::system_clock::time_point mNow = std::chrono::system_clock::now();
-
+        Time::Testing::FakeTimeProvider mTimeProvider{std::chrono::system_clock::now()};
         ConfigCache mConfigCache;
-        ReadingsCache mReadingsCache{mConfigCache, [this] { return mNow; }};
+        ReadingsCache mReadingsCache{mConfigCache, mTimeProvider};
     };
 }

--- a/central_unit/tests/core/scheduler_test.cpp
+++ b/central_unit/tests/core/scheduler_test.cpp
@@ -21,7 +21,15 @@ namespace SmartHome::Tests {
         };
 
         mpLogger = std::make_shared<Utils::AsyncLogger>(logger, mIoContext);
-        mpScheduler = Scheduler::create(mIoContext, mConfigCache, mpLogger, mTimeProvider, deviceFakeDispatch);
+        Scheduler::Config config{
+            .timeProvider = mTimeProvider,
+            .configCache = mConfigCache,
+            .executor = mIoContext.get_executor(),
+            .logger = mpLogger,
+            .dispatchAction = deviceFakeDispatch
+        };
+
+        mpScheduler = Scheduler::create(std::move(config));
 
         mpScheduler->start();
     }

--- a/central_unit/tests/core/scheduler_test.cpp
+++ b/central_unit/tests/core/scheduler_test.cpp
@@ -21,8 +21,7 @@ namespace SmartHome::Tests {
         };
 
         mpLogger = std::make_shared<Utils::AsyncLogger>(logger, mIoContext);
-        mpScheduler = std::make_shared<Scheduler>(
-            mIoContext, mConfigCache, mpLogger, mTimeProvider, deviceFakeDispatch);
+        mpScheduler = Scheduler::create(mIoContext, mConfigCache, mpLogger, mTimeProvider, deviceFakeDispatch);
 
         mpScheduler->start();
     }

--- a/central_unit/tests/core/scheduler_test.cpp
+++ b/central_unit/tests/core/scheduler_test.cpp
@@ -1,0 +1,441 @@
+#include "scheduler_test.h"
+
+#include <thread>
+
+#include <gmock/gmock.h>
+
+namespace SmartHome::Tests {
+    void SchedulerTest::SetUp() {
+        auto logger = std::make_shared<Utils::Logger>();
+        auto loggerConfig = Utils::Logger::Config{};
+
+        loggerConfig.logLevel = Utils::LogLevels::Level::None;
+        loggerConfig.enableConsoleLogOutput = false;
+        loggerConfig.logFile.enabled = false;
+        loggerConfig.logFile.archiveOld = false;
+
+        logger->applyConfig(loggerConfig);
+
+        auto deviceFakeDispatch = [this](const std::string_view name, const uint id, const nlohmann::json &action) {
+            mDeviceDispatches.push_back({.actionName = std::string(name), .id = id, .action = action});
+        };
+
+        mpLogger = std::make_shared<Utils::AsyncLogger>(logger, mIoContext);
+        mpScheduler = std::make_shared<Scheduler>(
+            mIoContext, mConfigCache, mpLogger, mTimeProvider, deviceFakeDispatch);
+
+        mpScheduler->start();
+    }
+
+
+    //region Helpers
+    nlohmann::json SchedulerTest::validDeviceConfigJson(uint deviceId, uint moduleId, const nlohmann::json &schedule) {
+        return {
+            {"id", deviceId},
+            {"logic_id", 11},
+            {"module_id", moduleId},
+            {"name", "testModule"},
+            {"type", "sensor"},
+            {
+                "config", {
+                    {"use_cache", true},
+                    {"cache_ttl", 300u},
+                    {
+                        "schedule", schedule
+                    }
+                }
+            },
+        };
+    }
+
+    nlohmann::json SchedulerTest::validDeviceConfigJsonAction() {
+        return {
+            "action", {{"method", "core.set"}, {"params", nlohmann::json::object()}}
+        };
+    }
+
+    //endregion
+
+    // TODO add tests simulating time zone change
+
+    //region Load / parse / remove events
+    TEST_F(SchedulerTest, LoadFromCache) {
+        ASSERT_TRUE(mpScheduler->isRunning());
+        EXPECT_EQ(mpScheduler->taskCount(), 0);
+
+        mConfigCache.setDevice(CachedDevice(validDeviceConfigJson(1, 1)));
+        mConfigCache.setDevice(CachedDevice(validDeviceConfigJson(2, 2)));
+        mpScheduler->loadFromCache();
+
+        EXPECT_EQ(mpScheduler->taskCount(), 2);
+    }
+
+    TEST_F(SchedulerTest, RemoveDevice) {
+        mConfigCache.setDevice(CachedDevice(validDeviceConfigJson(1)));
+        mConfigCache.setDevice(CachedDevice(validDeviceConfigJson(2)));
+        mpScheduler->loadFromCache();
+        EXPECT_EQ(mpScheduler->taskCount(), 2);
+
+        mpScheduler->removeDevice(1);
+        EXPECT_EQ(mpScheduler->taskCount(), 1);
+    }
+
+    TEST_F(SchedulerTest, GetNextRunForModule) {
+        // First but disabled (1min)
+        mConfigCache.setDevice(CachedDevice(
+            validDeviceConfigJson(1, 1, {
+                                      {
+                                          {"rrule", "FREQ=MINUTELY;INTERVAL=1"},
+                                          validDeviceConfigJsonAction(),
+                                          {"enabled", false}
+                                      }
+                                  })));
+
+        // // Second (5min) - should be next for module 1
+        mConfigCache.setDevice(CachedDevice(
+            validDeviceConfigJson(2, 1, {
+                                      {
+                                          {"rrule", "FREQ=MINUTELY;INTERVAL=5"},
+                                          validDeviceConfigJsonAction(),
+                                          {"enabled", true}
+                                      }
+                                  })));
+
+        // Third (15min)
+        mConfigCache.setDevice(CachedDevice(
+            validDeviceConfigJson(3, 1, {
+                                      {
+                                          {"rrule", "FREQ=MINUTELY;INTERVAL=15"},
+                                          validDeviceConfigJsonAction(),
+                                          {"enabled", true}
+                                      }
+                                  })));
+
+        // Should be next for module 2
+        mConfigCache.setDevice(CachedDevice(
+            validDeviceConfigJson(4, 2, {
+                                      {
+                                          {"rrule", "FREQ=SECONDLY;INTERVAL=30"},
+                                          validDeviceConfigJsonAction(),
+                                          {"enabled", true}
+                                      }
+                                  })));
+
+        // Half past every hour - should be next for module 3
+        mConfigCache.setDevice(CachedDevice(
+            validDeviceConfigJson(5, 3, {
+                                      {
+                                          {"rrule", "FREQ=HOURLY;INTERVAL=1"},
+                                          validDeviceConfigJsonAction(),
+                                          {"dtstart", "2026-01-01T00:30:00Z"},
+                                          {"enabled", true}
+                                      }
+                                  })));
+
+        mpScheduler->loadFromCache();
+        ASSERT_EQ(mpScheduler->taskCount(), 4);
+
+        EXPECT_THAT(mpScheduler->getNextRunForModule(1),
+                    ::testing::Optional(::testing::Eq(mStartTimePoint + 5min)));
+
+        EXPECT_THAT(mpScheduler->getNextRunForModule(2),
+                    ::testing::Optional(::testing::Eq(mStartTimePoint + 30s)));
+
+        constexpr auto nextHalfPast = std::chrono::floor<std::chrono::hours>(mStartTimePoint - 30min) + 1h + 30min;
+
+        EXPECT_THAT(mpScheduler->getNextRunForModule(3),
+                    ::testing::Optional(::testing::Eq(nextHalfPast)));
+    }
+
+    TEST_F(SchedulerTest, TaskWithoutFreqInRrule) {
+        mConfigCache.setDevice(CachedDevice(
+            validDeviceConfigJson(1, 1, {
+                                      {
+                                          {"rrule", "BYMONTHDAY=15;COUNT=2"},
+                                          validDeviceConfigJsonAction(),
+                                          {"enabled", true}
+                                      }
+                                  })));
+        mpScheduler->loadFromCache();
+        EXPECT_EQ(mpScheduler->taskCount(), 0);
+    }
+
+    TEST_F(SchedulerTest, MissingOrInvalidSchedule) {
+        auto deviceConfig = validDeviceConfigJson();
+        deviceConfig["config"].erase("schedule");
+        mConfigCache.setDevice(CachedDevice(deviceConfig));
+
+        mpScheduler->loadFromCache();
+        EXPECT_EQ(mpScheduler->taskCount(), 0);
+
+        deviceConfig["config"]["schedule"] = "invalid_schedule";
+        mConfigCache.setDevice(CachedDevice(deviceConfig));
+
+        mpScheduler->loadFromCache();
+        EXPECT_EQ(mpScheduler->taskCount(), 0);
+    }
+
+    TEST_F(SchedulerTest, InvalidEntry) {
+        auto deviceConfig = validDeviceConfigJson();
+        deviceConfig["config"]["schedule"][0] = "invalid_entry";
+        mConfigCache.setDevice(CachedDevice(deviceConfig));
+
+        mpScheduler->loadFromCache();
+        EXPECT_EQ(mpScheduler->taskCount(), 0);
+    }
+
+    TEST_F(SchedulerTest, MissingOrInvalidOrFalseEnabled) {
+        auto deviceConfig = validDeviceConfigJson();
+        deviceConfig["config"]["schedule"][0].erase("enabled");
+        mConfigCache.setDevice(CachedDevice(deviceConfig));
+
+        mpScheduler->loadFromCache();
+        EXPECT_EQ(mpScheduler->taskCount(), 0);
+
+        deviceConfig["config"]["schedule"][0]["enabled"] = "true";
+        mConfigCache.setDevice(CachedDevice(deviceConfig));
+
+        mpScheduler->loadFromCache();
+        EXPECT_EQ(mpScheduler->taskCount(), 0);
+
+        deviceConfig["config"]["schedule"][0]["enabled"] = false;
+        mConfigCache.setDevice(CachedDevice(deviceConfig));
+
+        mpScheduler->loadFromCache();
+        EXPECT_EQ(mpScheduler->taskCount(), 0);
+    }
+
+    TEST_F(SchedulerTest, MissingOrInvalidRrule) {
+        auto deviceConfig = validDeviceConfigJson();
+        deviceConfig["config"]["schedule"][0].erase("rrule");
+        mConfigCache.setDevice(CachedDevice(deviceConfig));
+
+        mpScheduler->loadFromCache();
+        EXPECT_EQ(mpScheduler->taskCount(), 0);
+
+        deviceConfig["config"]["schedule"][0]["rrule"] = {{"FREQ=DAILY"}};
+        mConfigCache.setDevice(CachedDevice(deviceConfig));
+
+        mpScheduler->loadFromCache();
+        EXPECT_EQ(mpScheduler->taskCount(), 0);
+    }
+
+    TEST_F(SchedulerTest, MissingOrInvalidOrAction) {
+        auto deviceConfig = validDeviceConfigJson();
+        deviceConfig["config"]["schedule"][0].erase("action");
+        mConfigCache.setDevice(CachedDevice(deviceConfig));
+
+        mpScheduler->loadFromCache();
+        EXPECT_EQ(mpScheduler->taskCount(), 0);
+
+        deviceConfig["config"]["schedule"][0]["action"] = "invalid_action";
+        mConfigCache.setDevice(CachedDevice(deviceConfig));
+
+        mpScheduler->loadFromCache();
+        EXPECT_EQ(mpScheduler->taskCount(), 0);
+    }
+
+    TEST_F(SchedulerTest, MissingOrInvalidDtstart) {
+        auto deviceConfig = validDeviceConfigJson();
+        mConfigCache.setDevice(CachedDevice(deviceConfig));
+
+        mpScheduler->loadFromCache();
+        EXPECT_EQ(mpScheduler->taskCount(), 1);
+
+        deviceConfig["config"]["schedule"][0]["dtstart"] = 12345;
+        mConfigCache.setDevice(CachedDevice(deviceConfig));
+
+        mpScheduler->loadFromCache();
+        EXPECT_EQ(mpScheduler->taskCount(), 1);
+    }
+
+    TEST_F(SchedulerTest, HandlesAncientDtstartWithoutStalling) {
+        mConfigCache.setDevice(CachedDevice(
+            validDeviceConfigJson(1, 1, {
+                                      {
+                                          {"rrule", "FREQ=SECONDLY;INTERVAL=1"},
+                                          validDeviceConfigJsonAction(),
+                                          {"dtstart", "2025-01-01T00:00:00Z"},
+                                          {"enabled", true}
+                                      }
+                                  })));
+        auto promiseFinished = std::make_shared<std::promise<bool> >();
+        auto futureResult = promiseFinished->get_future();
+
+        std::jthread([scheduler = mpScheduler, promiseFinished] {
+            scheduler->loadFromCache();
+            promiseFinished->set_value(true);
+        }).detach();
+
+        EXPECT_TRUE(futureResult.wait_for(150ms)!=std::future_status::timeout);
+    }
+
+    TEST_F(SchedulerTest, DiscardsEventThatWouldStallDueToAncientDtstart) {
+        mConfigCache.setDevice(CachedDevice(
+            validDeviceConfigJson(1, 1, {
+                                      {
+                                          {"rrule", "FREQ=SECONDLY;INTERVAL=1;COUNT=200000"},
+                                          {"dtstart", "2025-01-01T00:00:00Z"},
+                                          validDeviceConfigJsonAction(),
+                                          {"enabled", true}
+                                      }
+                                  })));
+        auto promiseFinished = std::make_shared<std::promise<size_t> >();
+        auto futureResult = promiseFinished->get_future();
+
+        std::jthread([scheduler = mpScheduler, promiseFinished] {
+            scheduler->loadFromCache();
+            promiseFinished->set_value(scheduler->taskCount());
+        }).detach();
+
+        ASSERT_TRUE(futureResult.wait_for(150ms)!=std::future_status::timeout) << "Scheduler stalled";
+        EXPECT_EQ(futureResult.get(), 0);
+    }
+
+    TEST_F(SchedulerTest, DiscardsEventWithNoFutureOccurence) {
+        mConfigCache.setDevice(CachedDevice(
+            validDeviceConfigJson(1, 1, {
+                                      {
+                                          {"rrule", "FREQ=DAILY;UNTIL=20251231"},
+                                          {"dtstart", "2025-01-01T00:00:00Z"},
+                                          validDeviceConfigJsonAction(),
+                                          {"enabled", true}
+                                      }
+                                  })));
+        mpScheduler->loadFromCache();
+        EXPECT_EQ(mpScheduler->taskCount(), 0);
+    }
+
+    TEST_F(SchedulerTest, DiscardsExhaustedRecurrenceDuringManualAdvance) {
+        mConfigCache.setDevice(CachedDevice(
+            validDeviceConfigJson(1, 1, {
+                                      {
+                                          {"rrule", "FREQ=DAILY;INTERVAL=1;COUNT=5"},
+                                          {"dtstart", "2025-01-01T00:00:00Z"},
+                                          validDeviceConfigJsonAction(),
+                                          {"enabled", true}
+                                      }
+                                  })));
+
+        mpScheduler->loadFromCache();
+        EXPECT_EQ(mpScheduler->taskCount(), 0);
+    }
+
+    //endregion
+
+    //region Handle / dispatch tasks
+    TEST_F(SchedulerTest, DispatchTask) {
+        mConfigCache.setDevice(CachedDevice(validDeviceConfigJson()));
+        mpScheduler->loadFromCache();
+
+        ASSERT_EQ(mpScheduler->taskCount(), 1);
+        EXPECT_THAT(mDeviceDispatches, ::testing::IsEmpty());
+        EXPECT_THAT(mpScheduler->getNextRunForModule(1),
+                    ::testing::Optional(::testing::Eq(mStartTimePoint + 5min)));
+
+        mTimeProvider.advanceBy(4min);
+        EXPECT_EQ(mDeviceDispatches.size(), 0);
+        mIoContext.poll();
+        mTimeProvider.advanceBy(1min);
+        EXPECT_EQ(mDeviceDispatches.size(), 0);
+        mIoContext.restart();
+        mIoContext.poll();
+        EXPECT_EQ(mDeviceDispatches.size(), 1);
+    }
+
+    TEST_F(SchedulerTest, TaskWithCountLimit) {
+        mConfigCache.setDevice(CachedDevice(
+            validDeviceConfigJson(1, 1, {
+                                      {
+                                          {
+                                              "rrule",
+                                              "FREQ=MONTHLY;BYMONTHDAY=23;COUNT=2"
+                                          },
+                                          validDeviceConfigJsonAction(),
+                                          {"enabled", true}
+                                      }
+                                  })));
+        mpScheduler->loadFromCache();
+        ASSERT_EQ(mpScheduler->taskCount(), 1);
+
+        mTimeProvider.advanceBy(std::chrono::months(2));
+        mIoContext.restart();
+        mIoContext.poll();
+        EXPECT_EQ(mDeviceDispatches.size(), 2);
+    }
+
+    TEST_F(SchedulerTest, TaskWithUntilLimit) {
+        mConfigCache.setDevice(CachedDevice(
+            validDeviceConfigJson(1, 1, {
+                                      {
+                                          {
+                                              "rrule",
+                                              "FREQ=MONTHLY;BYMONTHDAY=23;UNTIL=20260623"
+                                          },
+                                          validDeviceConfigJsonAction(),
+                                          {"enabled", true}
+                                      }
+                                  })));
+        mpScheduler->loadFromCache();
+        ASSERT_EQ(mpScheduler->taskCount(), 1);
+
+        mTimeProvider.advanceBy(std::chrono::months(6));
+        mIoContext.restart();
+        mIoContext.poll();
+        EXPECT_EQ(mDeviceDispatches.size(), 2);
+    }
+
+    TEST_F(SchedulerTest, TaskWithoutDtstartSkippedFirstOccurrence) {
+        mConfigCache.setDevice(CachedDevice(
+            validDeviceConfigJson(1, 1, {
+                                      {
+                                          {"rrule", "FREQ=MONTHLY;COUNT=2"},
+                                          validDeviceConfigJsonAction(),
+                                          {"enabled", true}
+                                      }
+                                  })));
+        mpScheduler->loadFromCache();
+        ASSERT_EQ(mpScheduler->taskCount(), 1);
+
+        mTimeProvider.advanceBy(std::chrono::months(2));
+        mIoContext.restart();
+        mIoContext.poll();
+        EXPECT_EQ(mDeviceDispatches.size(), 1);
+    }
+
+    TEST_F(SchedulerTest, SkipsRemovedTaskEncounteredDuringTimerFire) {
+        mConfigCache.setDevice(CachedDevice(
+            validDeviceConfigJson(1, 1, {
+                                      {
+                                          {"rrule", "FREQ=MINUTELY;INTERVAL=1;COUNT=2"},
+                                          validDeviceConfigJsonAction(),
+                                          {"enabled", true}
+                                      }
+                                  })));
+
+        mConfigCache.setDevice(CachedDevice(
+            validDeviceConfigJson(2, 2, {
+                                      {
+                                          {"rrule", "FREQ=MINUTELY;INTERVAL=3;COUNT=2"},
+                                          validDeviceConfigJsonAction(),
+                                          {"enabled", true}
+                                      }
+                                  })));
+
+        mpScheduler->loadFromCache();
+        ASSERT_EQ(mpScheduler->taskCount(), 2);
+
+        mpScheduler->removeDevice(2);
+        ASSERT_EQ(mpScheduler->taskCount(), 1);
+
+        mTimeProvider.advanceBy(3min);
+        mIoContext.restart();
+        mIoContext.poll();
+
+        EXPECT_EQ(mDeviceDispatches.size(), 1);
+        EXPECT_EQ(mDeviceDispatches[0].id, 1);
+        EXPECT_EQ(mpScheduler->taskCount(), 0);
+    }
+
+    //endregion
+}

--- a/central_unit/tests/core/scheduler_test.h
+++ b/central_unit/tests/core/scheduler_test.h
@@ -1,0 +1,49 @@
+#pragma once
+#include "scheduler.h"
+#include "common/time/testing/fake_time_provider.h"
+
+#include <gtest/gtest.h>
+
+namespace SmartHome::Tests {
+    class SchedulerTest : public ::testing::Test {
+    protected:
+        struct CapturedDispatch {
+            std::string actionName;
+            uint id;
+            nlohmann::json action;
+        };
+
+        void SetUp() override;
+
+        static nlohmann::json validDeviceConfigJson(uint deviceId = 1,
+                                                    uint moduleId = 1,
+                                                    const nlohmann::json &schedule = {
+                                                        {
+                                                            {"rrule", "FREQ=MINUTELY;INTERVAL=5"},
+                                                            {
+                                                                "action",
+                                                                {
+                                                                    {"method", "core.set"},
+                                                                    {"params", nlohmann::json::object()}
+                                                                }
+                                                            },
+                                                            {"enabled", true}
+                                                        }
+                                                    });
+
+        static nlohmann::json validDeviceConfigJsonAction();
+
+        std::vector<CapturedDispatch> mDeviceDispatches;
+        // Set time with precision to seconds (working with RRULE requires this precision)
+        static constexpr auto mStartTimePoint =
+                std::chrono::system_clock::time_point{
+                    std::chrono::sys_days{std::chrono::April / 22 / 2026} + 12h + 34min
+                };
+
+        Time::Testing::FakeTimeProvider mTimeProvider{mStartTimePoint};
+        ConfigCache mConfigCache;
+        std::shared_ptr<Scheduler> mpScheduler;
+        boost::asio::io_context mIoContext;
+        std::shared_ptr<Utils::AsyncLogger> mpLogger;
+    };
+}


### PR DESCRIPTION
# SH-222 Scheduler unit tests

Adds unit tests for `Scheduler`. Testing required decoupling it from real time, so this PR also introduces the `ITimeProvider` abstraction, and fixes the bugs that testing uncovered.

## Time abstraction
- `ITimeProvider` interface added with an Asio-based implementation for production and a fake one for tests.
- `Scheduler` and `Cache` now take an injected time provider, and `Scheduler` an injected dispatch, so scheduling and dispatch logic can be exercised without real sleeps.

## Scheduler
- Added unit tests for `Scheduler`.
- Fixed bugs found while testing:
  - Lazy deletion of tasks was not working correctly.
  - Mutex changed to `shared_mutex`.
  - Update `parseDeviceSchedule` to add proper JSON data validation.
  - Fixed timer handler never firing, caused by `unique_ptr` usage.
- Removed unused method.

## CMake
- Added helper functions for adding targets, together with constants for target folder names.
- Renamed `project_warnings` to `smarthome_warnings` for consistency.
- Raised `cmake_minimum_required` and added a fatal error when configuring with MSVC, which is not supported.
- Fixed option handling in the main `CMakeLists`.
- Fixed yaml-cpp fetch - `GIT_TAG` now points at a release tag.

## Other
- Fixed private API and logger linking in the `ipc` library.
- Extracted the `ActionDispatcher` alias to `ActionHelpers`.